### PR TITLE
Fix release publish retry path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          $requested = "${{ inputs.version }}"
+          if ($requested -match "^\d+\.\d+\.\d+(?:-.+)?$") {
+            $existingTag = "v$requested"
+            git fetch origin "refs/tags/${existingTag}:refs/tags/${existingTag}" --force 2>$null
+            $tagExists = $LASTEXITCODE -eq 0
+            if (-not $tagExists) {
+              git rev-parse --verify $existingTag *> $null
+              $tagExists = $LASTEXITCODE -eq 0
+            }
+
+            if ($tagExists) {
+              Write-Output "$existingTag already exists; skipping release preparation and publishing that tag."
+              "tag=$existingTag" >> $env:GITHUB_OUTPUT
+              exit 0
+            }
+          }
+
           $releaseArgs = @("${{ inputs.version }}", "--push", "--yes")
           if ("${{ inputs.notes }}") {
             $releaseArgs += @("--notes", "${{ inputs.notes }}")
@@ -89,8 +106,20 @@ jobs:
         id: pack
         shell: pwsh
         run: |
-          $raw = npm pack --json --ignore-scripts
-          $pack = ($raw | ConvertFrom-Json)[0].filename
+          $raw = npm pack --json --ignore-scripts 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            $raw | Write-Output
+            exit $LASTEXITCODE
+          }
+
+          $text = $raw | Out-String
+          $match = [regex]::Match($text, '(?s)\[\s*\{.*?"filename"\s*:\s*"(?<filename>[^"]+)"')
+          if (-not $match.Success) {
+            $text | Write-Output
+            throw "Could not parse npm pack filename."
+          }
+
+          $pack = $match.Groups["filename"].Value
           "tarball=$pack" >> $env:GITHUB_OUTPUT
 
       - name: Publish npm package
@@ -174,8 +203,20 @@ jobs:
         id: pack
         shell: pwsh
         run: |
-          $raw = npm pack --json --ignore-scripts
-          $pack = ($raw | ConvertFrom-Json)[0].filename
+          $raw = npm pack --json --ignore-scripts 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            $raw | Write-Output
+            exit $LASTEXITCODE
+          }
+
+          $text = $raw | Out-String
+          $match = [regex]::Match($text, '(?s)\[\s*\{.*?"filename"\s*:\s*"(?<filename>[^"]+)"')
+          if (-not $match.Success) {
+            $text | Write-Output
+            throw "Could not parse npm pack filename."
+          }
+
+          $pack = $match.Groups["filename"].Value
           "tarball=$pack" >> $env:GITHUB_OUTPUT
 
       - name: Resolve release notes

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,6 +59,9 @@ or updates the GitHub release.
 If publishing fails after the tag exists, rerun the failed publish job after
 fixing credentials. The publish job skips npm when that exact package version
 is already live and updates an existing GitHub release with `--clobber` assets.
+If the whole workflow needs to be dispatched again for an exact version whose
+tag already exists, the prepare job skips version preparation and publishes the
+existing tag.
 
 Separately, if a `v*` tag is pushed from a local release fallback, the tag push
 path in the same workflow publishes npm and creates the GitHub release.

--- a/docs/devlogs/2026-07-07-fix-release-publish-retry.md
+++ b/docs/devlogs/2026-07-07-fix-release-publish-retry.md
@@ -1,0 +1,31 @@
+# Fix release publish retry
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Fixed the release publish retry path after `v0.1.4` prepared successfully but failed while packing npm assets.
+- Tracked the retry fix through GitHub issue #32.
+
+## What Changed
+
+- The manual release workflow now detects an existing exact-version tag and skips release preparation.
+- The publish jobs now parse the tarball filename from `npm pack --json` even when npm lifecycle output appears before the JSON.
+- The same robust pack parsing is used for manual publish retries and tag-triggered publishing.
+
+## Why It Matters
+
+- A failed publish job can be retried without recreating the release commit or tag.
+- npm pack output differs between local runs and GitHub Actions when lifecycle scripts emit output.
+- The already-created `v0.1.4` tag can now be published from CI/CD.
+
+## Validation
+
+- Reviewed the existing-tag dispatch path for exact versions.
+- Ran workflow/doc whitespace checks.
+- Planned CI validation before merge and release rerun.
+
+## Release Notes
+
+- Release workflow retries now handle existing exact-version tags and noisy npm pack output.


### PR DESCRIPTION
## Summary
- Skip release preparation when an exact-version tag already exists.
- Parse npm pack tarball names even when lifecycle output appears before JSON.
- Document the retry path and add a devlog.

## Validation
- git diff --check
- PowerShell parse test for noisy npm pack output
- PowerShell existing-tag detection test for v0.1.4
- npm pack --dry-run --ignore-scripts

Closes #32