### PR TITLE
fix: stop terminal R autoinput regression

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -56,6 +56,13 @@ and pushes the release commit and `vX.Y.Z` tag. A separate publish job in the
 same workflow run then builds the Windows package, publishes npm, and creates
 or updates the GitHub release.
 
+Before creating the release commit, the script fetches origin branch refs and
+fails if any unmerged task branches remain under `chore/`, `docs/`, `feat/`,
+`fix/`, `refactor/`, or `test/`. Review, merge, or delete those branches before
+releasing. Use `--allow-unmerged-branches` only when the branch queue was
+explicitly reviewed and the release is intentionally shipping without those
+changes.
+
 If publishing fails after the tag exists, rerun the failed publish job after
 fixing credentials. The publish job skips npm when that exact package version
 is already live and updates an existing GitHub release with `--clobber` assets.
@@ -84,6 +91,7 @@ The script will:
 
 - require a clean working tree
 - require `main` or `master` unless `--allow-branch` is passed
+- require reviewed/merged origin task branches unless `--allow-unmerged-branches` is passed
 - bump `package.json` and `Cargo.toml`
 - update `Cargo.lock`
 - copy the devlog to `docs/releases/vX.Y.Z.md`

--- a/docs/devlogs/2026-07-07-fix-terminal-r-autoinput-regression.md
+++ b/docs/devlogs/2026-07-07-fix-terminal-r-autoinput-regression.md
@@ -1,0 +1,44 @@
+# Fix terminal R autoinput regression
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Fixed a terminal startup regression where cursor-position query responses
+  could be replayed and leak a stray `R` into child terminals.
+- Added a release guard that blocks releases while origin still has unmerged
+  task branches, unless the releaser explicitly confirms a branch review.
+
+## What Changed
+
+- The PTY terminal-query scanner now keeps only enough trailing bytes to detect
+  split escape sequences. It no longer keeps a complete `ESC [ 6 n` query in
+  the scan tail, which prevented duplicate cursor-position responses.
+- Added regression tests for split cursor-position queries and for complete
+  query replay prevention.
+- `npm/scripts/release.js` now refreshes origin branch refs and fails releases
+  when unmerged `chore/`, `docs/`, `feat/`, `fix/`, `refactor/`, or `test/`
+  branches remain.
+- Documented the new release branch queue check in `docs/RELEASING.md`.
+
+## Why It Matters
+
+- The prior fix lived on `origin/fix/prevent-terminal-r-autoinput`, but `v0.1.5`
+  was cut from `main` without that branch merged. That let the regression ship
+  through the GitHub release artifact.
+- Parallel agent work needs an explicit branch queue check before releases, or
+  valid fixes can remain stranded on task branches.
+
+## Validation
+
+- Run `cargo fmt --check`.
+- Run `cargo test`.
+- Run `cargo clippy -- -D warnings`.
+- Run `node npm/scripts/release.js --help`.
+- Confirm the release guard reports unmerged origin task branches.
+
+## Release Notes
+
+- Fixes stray `R` input caused by repeated terminal cursor-position responses.
+- Release tooling now catches unmerged task branches before creating a release.

--- a/npm/scripts/release.js
+++ b/npm/scripts/release.js
@@ -23,6 +23,8 @@ Options:
   --push               Push the release commit and tag to origin
   --yes                Required with --push
   --allow-branch       Allow releasing from a branch other than main or master
+  --allow-unmerged-branches
+                      Allow release even when origin has unmerged task branches
   --skip-checks        Skip cargo fmt, tests, prepare, and npm pack dry run
 `);
 }
@@ -183,6 +185,102 @@ function assertBranchAllowed() {
   }
 }
 
+function hasRemote(name) {
+  const result = spawnSync("git", ["remote", "get-url", name], {
+    cwd: root,
+    stdio: "ignore",
+    shell: false,
+  });
+  return result.status === 0;
+}
+
+function refreshOriginBranches() {
+  if (!hasRemote("origin")) {
+    return;
+  }
+
+  const result = spawnSync(
+    "git",
+    ["fetch", "--prune", "origin", "+refs/heads/*:refs/remotes/origin/*"],
+    {
+      cwd: root,
+      stdio: "pipe",
+      encoding: "utf8",
+      shell: false,
+    },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    fail(
+      `could not refresh origin branches before release\n${result.stderr || result.stdout}\nUse --allow-unmerged-branches only after manually reviewing branch state.`,
+    );
+  }
+}
+
+function taskBranchName(remoteBranch) {
+  return remoteBranch.replace(/^origin\//, "");
+}
+
+function isTaskBranch(remoteBranch) {
+  return /^(chore|docs|feat|fix|refactor|test)\//.test(taskBranchName(remoteBranch));
+}
+
+function isMergedIntoHead(remoteBranch) {
+  const result = spawnSync("git", ["merge-base", "--is-ancestor", remoteBranch, "HEAD"], {
+    cwd: root,
+    stdio: "ignore",
+    shell: false,
+  });
+  return result.status === 0;
+}
+
+function unmergedOriginTaskBranches() {
+  if (!hasRemote("origin")) {
+    return [];
+  }
+
+  const output = run("git", ["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"], {
+    capture: true,
+  });
+
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((branch) => branch !== "origin/HEAD")
+    .filter((branch) => !["origin/main", "origin/master"].includes(branch))
+    .filter(isTaskBranch)
+    .filter((branch) => !isMergedIntoHead(branch));
+}
+
+function summarizeBranch(remoteBranch) {
+  const latest = run("git", ["log", "--oneline", "-1", remoteBranch], { capture: true });
+  return `- ${remoteBranch}: ${latest}`;
+}
+
+function assertNoUnmergedTaskBranches() {
+  if (flags.has("--allow-unmerged-branches")) {
+    return;
+  }
+
+  refreshOriginBranches();
+  const branches = unmergedOriginTaskBranches();
+  if (branches.length === 0) {
+    return;
+  }
+
+  const visible = branches.slice(0, 12).map(summarizeBranch).join("\n");
+  const hiddenCount = branches.length - 12;
+  const hidden = hiddenCount > 0 ? `\n- ...and ${hiddenCount} more` : "";
+  fail(
+    `unmerged origin task branches exist; review, merge, or delete them before release:\n${visible}${hidden}\nUse --allow-unmerged-branches only after an explicit branch review.`,
+  );
+}
+
 function assertTagFree(tag) {
   const result = spawnSync("git", ["rev-parse", "--verify", tag], {
     cwd: root,
@@ -210,6 +308,7 @@ if (flags.has("--push") && !flags.has("--yes")) {
 
 assertClean();
 assertBranchAllowed();
+assertNoUnmergedTaskBranches();
 
 const packageJson = readJson("package.json");
 const cargoToml = fs.readFileSync(path.join(root, "Cargo.toml"), "utf8");

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -12,6 +12,12 @@ use vt100::{Parser, Screen};
 
 use crate::layout::PaneId;
 
+const DEVICE_STATUS_QUERY: &[u8] = b"\x1b[5n";
+const CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
+const PRIMARY_DEVICE_ATTRIBUTES_QUERY: &[u8] = b"\x1b[c";
+const PRIMARY_DEVICE_ATTRIBUTES_ZERO_QUERY: &[u8] = b"\x1b[0c";
+const MAX_TERMINAL_QUERY_LEN: usize = 4;
+
 #[derive(Debug, Clone)]
 pub enum PtyEvent {
     Output {
@@ -166,11 +172,11 @@ impl PtyPane {
         scan.extend_from_slice(&self.response_scan_tail);
         scan.extend_from_slice(bytes);
 
-        if contains_sequence(&scan, b"\x1b[5n") {
+        if contains_sequence(&scan, DEVICE_STATUS_QUERY) {
             let _ = self.write(b"\x1b[0n");
         }
 
-        let cursor_position_requests = count_sequence(&scan, b"\x1b[6n");
+        let cursor_position_requests = count_sequence(&scan, CURSOR_POSITION_QUERY);
         if cursor_position_requests > 0 {
             let (row, column) = self.parser.screen().cursor_position();
             let response = format!(
@@ -183,13 +189,13 @@ impl PtyPane {
             }
         }
 
-        if contains_sequence(&scan, b"\x1b[c") || contains_sequence(&scan, b"\x1b[0c") {
+        if contains_sequence(&scan, PRIMARY_DEVICE_ATTRIBUTES_QUERY)
+            || contains_sequence(&scan, PRIMARY_DEVICE_ATTRIBUTES_ZERO_QUERY)
+        {
             let _ = self.write(b"\x1b[?1;2c");
         }
 
-        const MAX_QUERY_LEN: usize = 5;
-        let tail_start = scan.len().saturating_sub(MAX_QUERY_LEN - 1);
-        self.response_scan_tail = scan[tail_start..].to_vec();
+        self.response_scan_tail = terminal_query_scan_tail(&scan);
     }
 
     pub fn terminate(&mut self) {
@@ -253,6 +259,12 @@ fn count_sequence(buffer: &[u8], sequence: &[u8]) -> usize {
         .count()
 }
 
+fn terminal_query_scan_tail(scan: &[u8]) -> Vec<u8> {
+    let tail_len = MAX_TERMINAL_QUERY_LEN.saturating_sub(1);
+    let tail_start = scan.len().saturating_sub(tail_len);
+    scan[tail_start..].to_vec()
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -268,6 +280,22 @@ mod tests {
     fn counts_split_terminal_query_sequences() {
         assert_eq!(count_sequence(b"\x1b[6n", b"\x1b[6n"), 1);
         assert_eq!(count_sequence(b"abc", b"\x1b[6n"), 0);
+    }
+
+    #[test]
+    fn terminal_query_scan_tail_keeps_split_queries_detectable() {
+        let mut scan = terminal_query_scan_tail(b"prompt\x1b[6");
+        scan.extend_from_slice(b"n");
+
+        assert_eq!(count_sequence(&scan, CURSOR_POSITION_QUERY), 1);
+    }
+
+    #[test]
+    fn terminal_query_scan_tail_does_not_replay_complete_queries() {
+        let mut scan = terminal_query_scan_tail(CURSOR_POSITION_QUERY);
+        scan.extend_from_slice(b"prompt");
+
+        assert_eq!(count_sequence(&scan, CURSOR_POSITION_QUERY), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- port the missing terminal query scan-tail fix onto main
- add regression tests for split cursor-position queries and replay prevention
- block releases when origin still has unmerged task branches unless explicitly overridden

## Investigation
- v0.1.5 points at 56e2bbd on main.
- The prior fix, cdf17c0 on origin/fix/prevent-terminal-r-autoinput, is not an ancestor of v0.1.5.
- The GitHub release has v0.1.5 assets, but npm only lists 0.1.0; the v0.1.5 publish workflow failed at npm auth.

## Validation
- node --check npm/scripts/release.js
- node npm/scripts/release.js --help
- cargo fmt --check
- cargo test
- cargo clippy -- -D warnings
- node npm/scripts/release.js patch --skip-checks --allow-branch stops on unmerged task branches

Closes #37