### PR TITLE
fix: refresh npm before trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Use latest npm for trusted publishing
+        run: npm install -g npm@latest
+
       - run: cargo fmt --check
 
       - run: cargo clippy -- -D warnings
@@ -190,6 +193,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+
+      - name: Use latest npm for trusted publishing
+        run: npm install -g npm@latest
 
       - run: cargo fmt --check
 

--- a/docs/devlogs/2026-07-07-fix-npm-trusted-publishing-cli.md
+++ b/docs/devlogs/2026-07-07-fix-npm-trusted-publishing-cli.md
@@ -1,0 +1,36 @@
+# Fix npm trusted publishing CLI
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Updated the release workflow to install the latest npm CLI before npm publish.
+- Keeps the existing `NPM_TOKEN` fallback while making the tokenless trusted
+  publishing path compatible with current npm requirements.
+
+## What Changed
+
+- Added `npm install -g npm@latest` to both GitHub release publish jobs:
+  manual workflow dispatch and tag push publishing.
+- Left the existing auth logic intact: use `NPM_TOKEN` when present, otherwise
+  publish via npm trusted publishing/OIDC.
+
+## Why It Matters
+
+- The `v0.1.5` workflow built and uploaded GitHub release assets, but npm
+  publish failed with `ENEEDAUTH`.
+- npm trusted publishing requires a recent npm CLI. Upgrading npm inside the
+  publish jobs removes runner image drift as a release blocker.
+
+## Validation
+
+- Run `git diff --check`.
+- Open PR and require CI/DCO checks.
+- Publish the fixed terminal input regression as a new patch version after this
+  workflow update lands.
+
+## Release Notes
+
+- Release automation now refreshes npm before publishing, improving npm trusted
+  publishing reliability.


### PR DESCRIPTION
## Summary
- install latest npm before both release publish paths
- keep NPM_TOKEN fallback behavior unchanged
- document the ENEEDAUTH workflow hardening in a devlog

## Context
npm trusted publishing requires a recent npm CLI. The v0.1.5 workflow reached npm publish but failed with ENEEDAUTH after building GitHub release assets.

## Validation
- git diff --check

Closes #39