### PR TITLE
Land default multi-select input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Fast, beautiful terminal grids for running lots of CLI agents at once.
 
-GridBash is a Windows-native Rust TUI multiplexer built for agent-heavy development: launch a grid of Codex, Claude, Gemini, Aider, OpenCode, Goose, Amp, Cursor, Copilot, Git Bash, PowerShell, or any custom command, then select panes and broadcast input only where you want it.
+GridBash is a Windows-native Rust TUI multiplexer built for agent-heavy development: launch a grid of Codex, Claude, Gemini, Aider, OpenCode, Goose, Amp, Cursor, Copilot, Git Bash, PowerShell, or any custom command, then select panes and send input only where you want it.
 
 > V1 is intentionally single-process. Closing GridBash closes its child agents. Daemon detach/reattach is the next major frontier.
 
@@ -23,8 +23,8 @@ GridBash is a Windows-native Rust TUI multiplexer built for agent-heavy developm
 - Up to 100 panes in one terminal process.
 - Configurable default terminal profile: Git Bash, PowerShell, cmd, agents, or custom.
 - Native host-terminal text selection with no mouse-capture mode.
-- Normal terminal keys pass through to focused or broadcast panes.
-- Modeless Alt shortcuts for pane focus, selection, broadcast, settings, and quit.
+- Normal terminal keys pass through to the focused pane, or to selected panes when multiple panes are selected.
+- Modeless Alt shortcuts for pane focus, selection, settings, and quit.
 - Compact dark theme with focus, selection, activity, exit, and output-volume badges.
 - Built-in launch profiles for common CLI coding agents.
 - Startup dimension picker with a live grid preview.
@@ -151,11 +151,10 @@ GridBash does not capture the mouse, so normal drag selection and copy behavior 
 | Alt+Up / Alt+Down | Focus pane above / below |
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
-| Alt+b | Toggle selected broadcast mode |
 | Alt+o | Open sample settings |
 | Alt+q | Quit |
 
-When broadcast is on, typing goes to selected panes only. If nothing is selected, input goes to the focused pane.
+Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane.
 
 The settings screen is currently a sample UI. Its switches, steppers, and choices can be changed, but they do not affect runtime behavior yet.
 
@@ -201,7 +200,7 @@ Default profile resolution order:
 
 ## Design Goals
 
-GridBash is inspired by agent-first multiplexers such as Mato and terminal workspaces such as Zellij, but V1 takes a different path: Windows-native, single binary, visual selection, selected broadcast, and a hard bias toward fast multi-agent grids.
+GridBash is inspired by agent-first multiplexers such as Mato and terminal workspaces such as Zellij, but V1 takes a different path: Windows-native, single binary, visual selection, scoped multi-pane input, and a hard bias toward fast multi-agent grids.
 
 ## Community
 
@@ -213,4 +212,4 @@ GridBash is inspired by agent-first multiplexers such as Mato and terminal works
 
 ## Legacy Launcher
 
-The old Windows Terminal launcher is still useful for quick split-pane grids, but it cannot support true selected broadcast because Windows Terminal does not expose subset pane selection. The Rust app is the path forward.
+The old Windows Terminal launcher is still useful for quick split-pane grids, but it cannot support true subset pane input because Windows Terminal does not expose subset pane selection. The Rust app is the path forward.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - Windows-native single process.
 - Real PTY panes.
-- Mouse selection and selected broadcast.
+- Mouse selection and selected multi-pane input.
 - Built-in CLI agent profiles.
 - Demo-ready dark theme.
 - Release as a single Windows x64 executable.

--- a/docs/devlogs/2026-07-07-default-multi-select-input.md
+++ b/docs/devlogs/2026-07-07-default-multi-select-input.md
@@ -1,0 +1,29 @@
+# Default multi-select input
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Removed the explicit selected-input mode toggle.
+- Input now targets selected panes automatically when more than one pane is selected.
+
+## What Changed
+
+- Removed the Alt+b mode switch from the app controls.
+- Updated the status bar to show whether input is headed to the focused pane or selected panes.
+- Updated docs to describe automatic multi-pane input.
+
+## Why It Matters
+
+- Multi-pane input now follows visible pane selection directly, so there is no extra mode to discover or remember.
+- A single selected pane remains visual selection only; input still follows the focused pane until multiple panes are selected.
+
+## Validation
+
+- Added app-level regression tests for focused-pane and selected-pane input targeting.
+- Ran `cargo test`.
+
+## Release Notes
+
+- Selecting multiple panes now sends input to those panes by default. The old Alt+b toggle has been removed.

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,7 +41,6 @@ pub struct App {
     focus: usize,
     selected: BTreeSet<usize>,
     rects: Vec<Rect>,
-    broadcast: bool,
     settings: SettingsState,
     status: String,
     event_tx: mpsc::UnboundedSender<PtyEvent>,
@@ -229,11 +228,8 @@ impl App {
             focus: 0,
             selected: BTreeSet::new(),
             rects: Vec::new(),
-            broadcast: false,
             settings: SettingsState::default(),
-            status:
-                "Alt+arrows move | Alt+s select | Alt+a all/none | Alt+b broadcast | Alt+o settings"
-                    .into(),
+            status: "Alt+arrows move | Alt+s select | Alt+a all/none | Alt+o settings".into(),
             event_tx,
             event_rx,
             last_activity_decay: Instant::now(),
@@ -444,15 +440,6 @@ impl App {
         let lower = ch.to_ascii_lowercase();
         match lower {
             'q' => Ok(Some(true)),
-            'b' => {
-                self.broadcast = !self.broadcast;
-                self.status = if self.broadcast {
-                    "broadcast selected: on".into()
-                } else {
-                    "broadcast selected: off".into()
-                };
-                Ok(Some(false))
-            }
             's' => {
                 toggle_selection(&mut self.selected, self.focus);
                 self.status = format!("selected {} panes", self.selected.len());
@@ -536,11 +523,7 @@ impl App {
     }
 
     fn input_targets(&self) -> Vec<usize> {
-        if self.broadcast && !self.selected.is_empty() {
-            self.selected.iter().copied().collect()
-        } else {
-            vec![self.focus.min(self.panes.len().saturating_sub(1))]
-        }
+        input_targets_for(self.focus, &self.selected, self.panes.len())
     }
 
     fn focus_next(&mut self) {
@@ -591,10 +574,6 @@ impl App {
 
     pub fn selected(&self) -> &BTreeSet<usize> {
         &self.selected
-    }
-
-    pub fn broadcast(&self) -> bool {
-        self.broadcast
     }
 
     pub fn status(&self) -> &str {
@@ -716,6 +695,18 @@ fn toggle_selection(selected: &mut BTreeSet<usize>, index: usize) {
     }
 }
 
+fn input_targets_for(focus: usize, selected: &BTreeSet<usize>, pane_count: usize) -> Vec<usize> {
+    if pane_count == 0 {
+        return Vec::new();
+    }
+
+    if selected.len() > 1 {
+        selected.iter().copied().collect()
+    } else {
+        vec![focus.min(pane_count - 1)]
+    }
+}
+
 fn control_byte(ch: char) -> Option<u8> {
     let lower = ch.to_ascii_lowercase();
     if lower.is_ascii_lowercase() {
@@ -783,6 +774,32 @@ fn function_key_sequence(number: u8) -> Option<&'static [u8]> {
         11 => Some(b"\x1b[23~"),
         12 => Some(b"\x1b[24~"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selected(indices: &[usize]) -> BTreeSet<usize> {
+        indices.iter().copied().collect()
+    }
+
+    #[test]
+    fn input_targets_focused_pane_without_multiple_selected_panes() {
+        assert_eq!(input_targets_for(2, &selected(&[]), 4), vec![2]);
+        assert_eq!(input_targets_for(2, &selected(&[0]), 4), vec![2]);
+    }
+
+    #[test]
+    fn input_targets_selected_panes_when_multiple_panes_are_selected() {
+        assert_eq!(input_targets_for(2, &selected(&[0, 3]), 4), vec![0, 3]);
+    }
+
+    #[test]
+    fn input_targets_clamps_focus_to_available_panes() {
+        assert_eq!(input_targets_for(8, &selected(&[]), 4), vec![3]);
+        assert!(input_targets_for(0, &selected(&[]), 0).is_empty());
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -65,10 +65,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         }
     }
 
-    let broadcast = if app.broadcast() {
-        "BROADCAST"
+    let input_scope = if app.selected().len() > 1 {
+        "selected panes"
     } else {
-        "focused"
+        "focused pane"
     };
     let status = Line::from(vec![
         Span::styled(
@@ -87,8 +87,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         ),
         Span::raw(" | "),
         Span::styled(
-            broadcast,
-            Style::default().fg(if app.broadcast() {
+            input_scope,
+            Style::default().fg(if app.selected().len() > 1 {
                 Color::Cyan
             } else {
                 Color::Gray


### PR DESCRIPTION
## Summary
- make input target selected panes automatically when multiple panes are selected
- remove the explicit Alt+b broadcast toggle
- update status text, docs, and devlog for scoped multi-pane input

Completes #41

## Validation
- npm test