### PR TITLE
chore: delete closed issue branches

### DIFF
--- a/.github/workflows/delete-issue-branches.yml
+++ b/.github/workflows/delete-issue-branches.yml
@@ -1,0 +1,96 @@
+name: Delete Issue Branches
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  delete-related-branches:
+    name: Delete related branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete matching remote branches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const repository = context.payload.repository;
+            const issueNumber = String(issue.number);
+            const defaultBranch = repository.default_branch;
+            const { owner, repo } = context.repo;
+
+            const escapedIssueNumber = issueNumber.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const explicitIssuePattern = new RegExp(
+              `(^|[\\/_\\.-])(?:issue|issues|gh|ticket)[\\/_\\.-]?${escapedIssueNumber}(?=$|[\\/_\\.-])`,
+              "i",
+            );
+            const leadingSegmentPattern = new RegExp(
+              `^${escapedIssueNumber}(?:$|[\\._-])`,
+            );
+
+            function isRelatedBranch(branchName) {
+              if (explicitIssuePattern.test(branchName)) {
+                return true;
+              }
+
+              return branchName
+                .split("/")
+                .some((segment) => leadingSegmentPattern.test(segment));
+            }
+
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            const deleted = [];
+            const skipped = [];
+
+            for (const branch of branches) {
+              const name = branch.name;
+
+              if (!isRelatedBranch(name)) {
+                continue;
+              }
+
+              if (name === defaultBranch) {
+                skipped.push(`${name} is the default branch`);
+                continue;
+              }
+
+              if (branch.protected) {
+                skipped.push(`${name} is protected`);
+                continue;
+              }
+
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${name}`,
+                });
+                deleted.push(name);
+                core.notice(`Deleted branch ${name} for closed issue #${issueNumber}.`);
+              } catch (error) {
+                skipped.push(`${name}: ${error.message}`);
+                core.warning(`Could not delete branch ${name}: ${error.message}`);
+              }
+            }
+
+            if (deleted.length === 0 && skipped.length === 0) {
+              core.info(`No matching branches found for closed issue #${issueNumber}.`);
+              return;
+            }
+
+            if (deleted.length > 0) {
+              core.info(`Deleted branches: ${deleted.join(", ")}`);
+            }
+
+            if (skipped.length > 0) {
+              core.info(`Skipped branches: ${skipped.join("; ")}`);
+            }

--- a/docs/devlogs/2026-07-07-delete-issue-branches-after-closure.md
+++ b/docs/devlogs/2026-07-07-delete-issue-branches-after-closure.md
@@ -1,0 +1,29 @@
+# Delete Issue Branches After Closure
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Added issue-close automation that removes clearly related remote branches.
+
+## What Changed
+
+- Added a GitHub Actions workflow that runs when an issue is closed.
+- The workflow scans remote branches and matches conservative issue naming patterns such as `issue-53`, `gh/53`, and `fix/53-short-description`.
+- Matching branches are deleted only when they are not the repository default branch and are not protected.
+
+## Why It Matters
+
+- Closed issue branches no longer accumulate after work is finished, while protected and unrelated branches stay untouched.
+
+## Validation
+
+- Ran `git diff --check`.
+- Checked the embedded workflow JavaScript with `node`.
+- Ran a `node` sanity check for matching expected issue branch names and rejecting obvious false positives.
+- Attempted `npx --yes actionlint@latest .github\workflows\delete-issue-branches.yml`, but npm could not determine an executable for that package.
+
+## Release Notes
+
+- Closed issues now trigger cleanup for unprotected remote branches that are clearly named after the issue number.


### PR DESCRIPTION
## Summary
- Add an issue-closed GitHub Actions workflow that deletes clearly related unprotected remote branches.
- Match conservative issue branch naming patterns such as \issue-53\, \gh/53\, and \ix/53-short-description\.
- Add an unreleased devlog entry for the automation.

## Validation
- \git diff --check\
- Embedded workflow JavaScript syntax check with \
ode\
- Branch matcher sanity check with \
ode\
- Attempted \
px --yes actionlint@latest .github\\workflows\\delete-issue-branches.yml\, but npm could not determine an executable for that package.

Closes #53