### PR TITLE
Add terminal sleep mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ GridBash is a Windows-native Rust TUI multiplexer built for agent-heavy developm
 - Real PTY-backed panes through Windows ConPTY via `portable-pty`.
 - Up to 100 panes in one terminal process.
 - Configurable default terminal profile: Git Bash, PowerShell, cmd, agents, or custom.
-- Native host-terminal text selection with no mouse-capture mode.
+- Native host-terminal text selection, with temporary mouse capture only while sleeping panes need hover wake.
 - Normal terminal keys pass through to the focused pane, or to selected panes when multiple panes are selected.
 - Modeless Alt shortcuts for pane focus, selection, settings, and quit.
 - Compact dark theme with focus, selection, activity, exit, and output-volume badges.
@@ -142,7 +142,7 @@ Passing grid, count, profile, or cwd arguments bypasses the startup picker and u
 
 ## Controls
 
-GridBash does not capture the mouse, so normal drag selection and copy behavior stays owned by your host terminal. App controls use Alt shortcuts and do not require switching modes.
+GridBash normally leaves mouse selection and copy behavior owned by your host terminal. When one or more panes are asleep, it temporarily captures mouse motion so hovering a sleeping pane can wake it, then releases mouse capture after the last sleeping pane wakes.
 
 | Input | Action |
 | --- | --- |
@@ -151,6 +151,8 @@ GridBash does not capture the mouse, so normal drag selection and copy behavior 
 | Alt+Up / Alt+Down | Focus pane above / below |
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
+| Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |
+| Hover sleeping pane | Wake the pane and make its terminal contents visible again |
 | Alt+o | Open sample settings |
 | Alt+q | Quit |
 

--- a/docs/devlogs/2026-07-07-sleep-terminal-panes.md
+++ b/docs/devlogs/2026-07-07-sleep-terminal-panes.md
@@ -1,0 +1,27 @@
+# Sleep terminal panes
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Add pane sleep mode for hiding visually noisy terminal output until the pane is needed again.
+
+## What Changed
+
+- Added `Alt+z` to sleep the focused pane, or the selected panes when multiple panes are selected.
+- Sleeping panes render as black terminal interiors while their PTY processes and output history keep running.
+- Hovering a sleeping pane wakes it and focuses it.
+- Mouse capture is enabled only while panes are asleep, then released after the final sleeping pane wakes.
+
+## Why It Matters
+
+- Dense agent grids can stay running without every active terminal competing for visual attention.
+
+## Validation
+
+- `cargo test` with `CARGO_TARGET_DIR=C:\Users\Jason\Documents\GitHub\gridbash\target`
+
+## Release Notes
+
+- New terminal pane sleep mode: press `Alt+z` to black out a pane, then hover it to wake it.

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,8 +8,8 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use crossterm::{
     event::{
-        self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEvent, KeyEventKind,
-        KeyModifiers,
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -21,7 +21,7 @@ use crate::{
     cli::{Cli, GridMode},
     composer::Composer,
     config::Config,
-    layout::{GridLayout, GridSize, PaneId},
+    layout::{GridLayout, GridSize, PaneId, pane_at},
     profiles::find_profile,
     pty::{PtyEvent, PtyPane},
     setup::{LaunchPlan, PaneLaunchSpec},
@@ -40,6 +40,7 @@ pub struct App {
     panes: Vec<PtyPane>,
     focus: usize,
     selected: BTreeSet<usize>,
+    sleeping: BTreeSet<usize>,
     rects: Vec<Rect>,
     settings: SettingsState,
     status: String,
@@ -227,9 +228,10 @@ impl App {
             panes: Vec::new(),
             focus: 0,
             selected: BTreeSet::new(),
+            sleeping: BTreeSet::new(),
             rects: Vec::new(),
             settings: SettingsState::default(),
-            status: "Alt+arrows move | Alt+s select | Alt+a all/none | Alt+o settings".into(),
+            status: "Alt+arrows move | Alt+s select | Alt+z sleep | Alt+o settings".into(),
             event_tx,
             event_rx,
             last_activity_decay: Instant::now(),
@@ -270,6 +272,7 @@ impl App {
             .ok_or_else(|| anyhow!("no launch plan selected"))?;
         self.layout = GridLayout::new(plan.grid);
         self.panes.clear();
+        self.sleeping.clear();
 
         for (index, spec) in plan.panes.iter().enumerate() {
             self.spawn_pane_spec(index, spec, 0)?;
@@ -299,6 +302,7 @@ impl App {
 
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
         let mut needs_render = true;
+        let mut mouse_capture_enabled = false;
 
         loop {
             needs_render |= self.drain_pty_events();
@@ -313,6 +317,7 @@ impl App {
                 self.sync_pane_sizes();
                 needs_render = false;
             }
+            self.sync_mouse_capture(terminal, &mut mouse_capture_enabled)?;
 
             if event::poll(INPUT_POLL_INTERVAL)? {
                 match event::read()? {
@@ -324,6 +329,9 @@ impl App {
                         }
                     }
                     Event::Resize(_, _) => needs_render = true,
+                    Event::Mouse(mouse) if !self.settings.open => {
+                        needs_render |= self.handle_mouse(mouse);
+                    }
                     Event::Paste(text) if !self.settings.open => {
                         self.route_input(text.as_bytes())?;
                     }
@@ -332,6 +340,25 @@ impl App {
             }
         }
 
+        if mouse_capture_enabled {
+            execute!(terminal.backend_mut(), DisableMouseCapture)?;
+        }
+
+        Ok(())
+    }
+
+    fn sync_mouse_capture(&self, terminal: &mut Tui, enabled: &mut bool) -> Result<()> {
+        let should_enable = !self.sleeping.is_empty();
+        if should_enable == *enabled {
+            return Ok(());
+        }
+
+        if should_enable {
+            execute!(terminal.backend_mut(), EnableMouseCapture)?;
+        } else {
+            execute!(terminal.backend_mut(), DisableMouseCapture)?;
+        }
+        *enabled = should_enable;
         Ok(())
     }
 
@@ -454,6 +481,10 @@ impl App {
                 self.status = format!("selected {} panes", self.selected.len());
                 Ok(Some(false))
             }
+            'z' => {
+                self.toggle_sleep_for_targets();
+                Ok(Some(false))
+            }
             'o' => {
                 self.settings.open = true;
                 self.status = "settings open".into();
@@ -511,6 +542,59 @@ impl App {
         })
     }
 
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if !matches!(
+            mouse.kind,
+            MouseEventKind::Moved
+                | MouseEventKind::Down(_)
+                | MouseEventKind::Up(_)
+                | MouseEventKind::Drag(_)
+        ) {
+            return false;
+        }
+
+        let Some(index) = pane_at(&self.rects, mouse.column, mouse.row) else {
+            return false;
+        };
+
+        if self.sleeping.remove(&index) {
+            self.focus = index;
+            self.status = format!("woke pane {}", index + 1);
+            return true;
+        }
+
+        false
+    }
+
+    fn toggle_sleep_for_targets(&mut self) {
+        let targets = self.target_panes();
+        if targets.is_empty() {
+            return;
+        }
+
+        let should_sleep = targets.iter().any(|index| !self.sleeping.contains(index));
+        if should_sleep {
+            for index in &targets {
+                self.sleeping.insert(*index);
+                self.selected.remove(index);
+            }
+
+            if self.sleeping.contains(&self.focus)
+                && let Some(index) = self.next_awake_pane(self.focus)
+            {
+                self.focus = index;
+            }
+        } else {
+            for index in &targets {
+                self.sleeping.remove(index);
+            }
+            self.focus = targets[0];
+        }
+
+        let action = if should_sleep { "slept" } else { "woke" };
+        self.status = format!("{} {} {}", action, targets.len(), pane_word(targets.len()));
+    }
+
     fn route_input(&mut self, bytes: &[u8]) -> Result<()> {
         let targets = self.input_targets();
         for index in targets {
@@ -523,6 +607,10 @@ impl App {
     }
 
     fn input_targets(&self) -> Vec<usize> {
+        awake_input_targets_for(self.focus, &self.selected, self.panes.len(), &self.sleeping)
+    }
+
+    fn target_panes(&self) -> Vec<usize> {
         input_targets_for(self.focus, &self.selected, self.panes.len())
     }
 
@@ -530,18 +618,28 @@ impl App {
         if self.panes.is_empty() {
             return;
         }
-        self.focus = (self.focus + 1) % self.panes.len();
+
+        for offset in 1..=self.panes.len() {
+            let candidate = (self.focus + offset) % self.panes.len();
+            if !self.sleeping.contains(&candidate) {
+                self.focus = candidate;
+                return;
+            }
+        }
     }
 
     fn focus_previous(&mut self) {
         if self.panes.is_empty() {
             return;
         }
-        self.focus = if self.focus == 0 {
-            self.panes.len() - 1
-        } else {
-            self.focus - 1
-        };
+
+        for offset in 1..=self.panes.len() {
+            let candidate = (self.focus + self.panes.len() - offset) % self.panes.len();
+            if !self.sleeping.contains(&candidate) {
+                self.focus = candidate;
+                return;
+            }
+        }
     }
 
     fn focus_in_grid(&mut self, row_delta: isize) {
@@ -555,9 +653,19 @@ impl App {
         } else {
             self.focus.saturating_add(columns)
         };
-        if candidate < self.panes.len() {
+        if candidate < self.panes.len() && !self.sleeping.contains(&candidate) {
             self.focus = candidate;
         }
+    }
+
+    fn next_awake_pane(&self, start: usize) -> Option<usize> {
+        if self.panes.is_empty() {
+            return None;
+        }
+
+        (1..=self.panes.len())
+            .map(|offset| (start + offset) % self.panes.len())
+            .find(|index| !self.sleeping.contains(index))
     }
 
     pub fn pane_rects(&self, area: Rect) -> Vec<Rect> {
@@ -574,6 +682,10 @@ impl App {
 
     pub fn selected(&self) -> &BTreeSet<usize> {
         &self.selected
+    }
+
+    pub fn pane_sleeping(&self, index: usize) -> bool {
+        self.sleeping.contains(&index)
     }
 
     pub fn status(&self) -> &str {
@@ -707,6 +819,22 @@ fn input_targets_for(focus: usize, selected: &BTreeSet<usize>, pane_count: usize
     }
 }
 
+fn awake_input_targets_for(
+    focus: usize,
+    selected: &BTreeSet<usize>,
+    pane_count: usize,
+    sleeping: &BTreeSet<usize>,
+) -> Vec<usize> {
+    input_targets_for(focus, selected, pane_count)
+        .into_iter()
+        .filter(|index| !sleeping.contains(index))
+        .collect()
+}
+
+fn pane_word(count: usize) -> &'static str {
+    if count == 1 { "pane" } else { "panes" }
+}
+
 fn control_byte(ch: char) -> Option<u8> {
     let lower = ch.to_ascii_lowercase();
     if lower.is_ascii_lowercase() {
@@ -801,6 +929,18 @@ mod tests {
         assert_eq!(input_targets_for(8, &selected(&[]), 4), vec![3]);
         assert!(input_targets_for(0, &selected(&[]), 0).is_empty());
     }
+
+    #[test]
+    fn sleeping_panes_do_not_receive_input() {
+        assert_eq!(
+            awake_input_targets_for(2, &selected(&[]), 4, &selected(&[2])),
+            Vec::<usize>::new()
+        );
+        assert_eq!(
+            awake_input_targets_for(2, &selected(&[0, 3]), 4, &selected(&[0])),
+            vec![3]
+        );
+    }
 }
 
 fn setup_terminal() -> Result<Tui> {
@@ -816,6 +956,7 @@ fn teardown_terminal(terminal: &mut Tui) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         DisableBracketedPaste,
+        DisableMouseCapture,
         LeaveAlternateScreen
     )?;
     terminal.show_cursor()?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
         let focused = app.focus() == index;
         let selected = app.selected().contains(&index);
-        let chrome = pane_chrome(selected, focused, pane.active, pane.exited);
+        let sleeping = app.pane_sleeping(index);
+        let chrome = pane_chrome(selected, focused, pane.active, pane.exited, sleeping);
 
         let folder = app
             .pane_folder(index)
@@ -58,9 +59,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        render_screen(frame, inner, pane.screen());
+        if sleeping {
+            render_sleeping_screen(frame, inner);
+        } else {
+            render_screen(frame, inner, pane.screen());
+        }
 
-        if focused {
+        if focused && !sleeping {
             set_terminal_cursor(frame, inner, pane.screen());
         }
     }
@@ -98,7 +103,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(format!("{} selected", app.selected().len())),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
-        Span::raw(" | Alt+q quit"),
+        Span::raw(" | Alt+z sleep | hover wakes | Alt+q quit"),
     ]);
     frame.render_widget(
         Paragraph::new(status).style(Style::default().bg(Color::Rgb(11, 15, 20))),
@@ -121,8 +126,16 @@ struct PaneChrome {
     badge: &'static str,
 }
 
-fn pane_chrome(selected: bool, focused: bool, _active: bool, exited: bool) -> PaneChrome {
-    let border_style = if selected {
+fn pane_chrome(
+    selected: bool,
+    focused: bool,
+    _active: bool,
+    exited: bool,
+    sleeping: bool,
+) -> PaneChrome {
+    let border_style = if sleeping {
+        Style::default().fg(Color::Rgb(32, 36, 42))
+    } else if selected {
         Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
@@ -138,6 +151,8 @@ fn pane_chrome(selected: bool, focused: bool, _active: bool, exited: bool) -> Pa
 
     let badge = if exited {
         " exited"
+    } else if sleeping {
+        " asleep"
     } else if selected {
         " selected"
     } else {
@@ -262,6 +277,20 @@ fn label_name(name: &str) -> String {
     }
 
     label
+}
+
+fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let style = Style::default().fg(Color::Black).bg(Color::Black);
+    let blank = " ".repeat(area.width as usize);
+    let lines = (0..area.height)
+        .map(|_| Line::from(Span::styled(blank.clone(), style)))
+        .collect::<Vec<_>>();
+
+    frame.render_widget(Paragraph::new(lines).style(style), area);
 }
 
 fn render_screen(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen) {
@@ -444,14 +473,25 @@ mod tests {
     #[test]
     fn output_activity_does_not_change_idle_pane_chrome() {
         assert_eq!(
-            pane_chrome(false, false, false, false),
-            pane_chrome(false, false, true, false)
+            pane_chrome(false, false, false, false, false),
+            pane_chrome(false, false, true, false, false)
         );
     }
 
     #[test]
     fn selected_and_exited_badges_remain_visible() {
-        assert_eq!(pane_chrome(true, false, true, false).badge, " selected");
-        assert_eq!(pane_chrome(true, false, true, true).badge, " exited");
+        assert_eq!(
+            pane_chrome(true, false, true, false, false).badge,
+            " selected"
+        );
+        assert_eq!(pane_chrome(true, false, true, true, false).badge, " exited");
+    }
+
+    #[test]
+    fn sleeping_panes_show_sleep_badge() {
+        assert_eq!(
+            pane_chrome(false, false, true, false, true).badge,
+            " asleep"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add Alt+z pane sleep mode for focused or multi-selected panes
- render sleeping pane interiors black while PTYs keep running
- temporarily enable mouse capture only while panes are asleep so hover wakes them
- document the control and add a devlog

## Validation
- cargo test with CARGO_TARGET_DIR=C:\Users\Jason\Documents\GitHub\gridbash\target

Closes #54