### PR TITLE
Show auth usage in gridcell headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "serde",
+ "serde_json",
  "shell-words",
  "tokio",
  "toml",
@@ -1394,6 +1395,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,3 +2045,9 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ directories = "6.0"
 portable-pty = "0.9"
 ratatui = "0.30"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 shell-words = "1.1"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"

--- a/docs/devlogs/2026-07-07-show-auth-usage-in-gridcell-headers.md
+++ b/docs/devlogs/2026-07-07-show-auth-usage-in-gridcell-headers.md
@@ -1,0 +1,37 @@
+# Show auth usage in gridcell headers
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Gridcell headers can now show remaining vibe auth usage and optional OpenAI
+  API spend context while panes are running.
+
+## What Changed
+
+- Added a background usage monitor that resolves pane launch profiles to vibe
+  profile auth directories, or the default Claude/Codex auth directories for
+  direct profile launches.
+- Added compact header labels for Claude/Codex usage windows, such as
+  `5h 40% left / 7d 92% left`.
+- Added optional OpenAI API spend labels, such as `API $1.50 24h`, when
+  `OPENAI_ADMIN_KEY` is available.
+- Kept all usage and spend fetches best-effort so missing auth, unsupported
+  profiles, offline network, or endpoint failures leave headers unchanged.
+
+## Why It Matters
+
+- Users running many agent panes can see how much account capacity remains
+  without leaving GridBash.
+- API spend can be visible alongside pane context for users who monitor
+  paid API usage during agent work.
+
+## Validation
+
+- `cargo test`
+
+## Release Notes
+
+- Gridcell headers now surface best-effort Claude/Codex auth usage and optional
+  OpenAI API spend labels.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     env,
     io::{self, Stdout},
+    sync::mpsc as std_mpsc,
     time::{Duration, Instant},
 };
 
@@ -26,6 +27,7 @@ use crate::{
     pty::{PtyEvent, PtyPane},
     setup::{LaunchPlan, PaneLaunchSpec},
     ui,
+    usage::{self, UsageEvent, UsageTarget},
 };
 
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
@@ -45,6 +47,10 @@ pub struct App {
     status: String,
     event_tx: mpsc::UnboundedSender<PtyEvent>,
     event_rx: mpsc::UnboundedReceiver<PtyEvent>,
+    usage_tx: std_mpsc::Sender<UsageEvent>,
+    usage_rx: std_mpsc::Receiver<UsageEvent>,
+    profile_usage: BTreeMap<String, String>,
+    api_spend_label: Option<String>,
     last_activity_decay: Instant,
 }
 
@@ -218,6 +224,7 @@ impl App {
                 columns: 3,
             });
         let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (usage_tx, usage_rx) = std_mpsc::channel();
 
         Ok(Self {
             config,
@@ -232,6 +239,10 @@ impl App {
             status: "Alt+arrows move | Alt+s select | Alt+a all/none | Alt+o settings".into(),
             event_tx,
             event_rx,
+            usage_tx,
+            usage_rx,
+            profile_usage: BTreeMap::new(),
+            api_spend_label: None,
             last_activity_decay: Instant::now(),
         })
     }
@@ -274,8 +285,24 @@ impl App {
         for (index, spec) in plan.panes.iter().enumerate() {
             self.spawn_pane_spec(index, spec, 0)?;
         }
+        self.start_usage_monitor(&plan);
 
         Ok(())
+    }
+
+    fn start_usage_monitor(&mut self, plan: &LaunchPlan) {
+        self.profile_usage.clear();
+        self.api_spend_label = None;
+
+        let targets = plan
+            .panes
+            .iter()
+            .map(|spec| UsageTarget {
+                profile_name: spec.profile_name.clone(),
+                command: spec.command.command.clone(),
+            })
+            .collect::<Vec<_>>();
+        usage::spawn_usage_monitor(targets, self.usage_tx.clone());
     }
 
     fn spawn_pane_spec(
@@ -302,6 +329,7 @@ impl App {
 
         loop {
             needs_render |= self.drain_pty_events();
+            needs_render |= self.drain_usage_events();
             needs_render |= self.decay_activity();
 
             if needs_render {
@@ -370,6 +398,33 @@ impl App {
 
         for pane in &mut self.panes {
             changed |= pane.poll_exit();
+        }
+
+        changed
+    }
+
+    fn drain_usage_events(&mut self) -> bool {
+        let mut changed = false;
+
+        while let Ok(event) = self.usage_rx.try_recv() {
+            match event {
+                UsageEvent::Profile {
+                    profile_name,
+                    label,
+                } => match label {
+                    Some(label) => {
+                        changed |= self.profile_usage.get(&profile_name) != Some(&label);
+                        self.profile_usage.insert(profile_name, label);
+                    }
+                    None => {
+                        changed |= self.profile_usage.remove(&profile_name).is_some();
+                    }
+                },
+                UsageEvent::ApiSpend { label } => {
+                    changed |= self.api_spend_label != label;
+                    self.api_spend_label = label;
+                }
+            }
         }
 
         changed
@@ -600,6 +655,26 @@ impl App {
             .as_ref()
             .and_then(|plan| plan.panes.get(index))
             .and_then(|pane| pane.worktree_name.as_deref())
+    }
+
+    pub fn pane_usage_label(&self, index: usize) -> Option<String> {
+        let mut parts = Vec::new();
+
+        if let Some(profile_name) = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(index))
+            .map(|pane| pane.profile_name.as_str())
+            && let Some(label) = self.profile_usage.get(profile_name)
+        {
+            parts.push(label.clone());
+        }
+
+        if let Some(label) = &self.api_spend_label {
+            parts.push(label.clone());
+        }
+
+        (!parts.is_empty()).then(|| parts.join(" | "))
     }
 
     pub fn sync_pane_sizes(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod profiles;
 mod pty;
 mod setup;
 mod ui;
+mod usage;
 mod vibe;
 
 use anyhow::Result;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -39,16 +39,21 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             .pane_folder(index)
             .map(label_name)
             .unwrap_or_else(|| folder_label(pane.cwd()));
+        let usage = app
+            .pane_usage_label(index)
+            .map(|label| format!(" | {label}"))
+            .unwrap_or_default();
         let title = if let Some(worktree) = app.pane_worktree(index) {
             format!(
-                " {} | {} | {}{} ",
+                " {} | {} | {}{}{} ",
                 index + 1,
                 folder,
                 worktree,
+                usage,
                 chrome.badge
             )
         } else {
-            format!(" {} | {}{} ", index + 1, folder, chrome.badge)
+            format!(" {} | {}{}{} ", index + 1, folder, usage, chrome.badge)
         };
 
         let block = Block::default()

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Reverse,
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
@@ -369,7 +370,7 @@ fn codex_usage_snapshot(dir: &Path) -> Option<UsageWindows> {
     let sessions = dir.join("sessions");
     let mut files = Vec::new();
     collect_codex_rollouts(&sessions, &mut files);
-    files.sort_by(|left, right| right.1.cmp(&left.1));
+    files.sort_by_key(|entry| Reverse(entry.1));
 
     files
         .into_iter()

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,604 @@
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::mpsc::Sender,
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use serde::Deserialize;
+
+const CLAUDE_USAGE_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/usage";
+const CODEX_USAGE_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/usage";
+const OPENAI_COSTS_ENDPOINT: &str = "https://api.openai.com/v1/organization/costs";
+const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageTarget {
+    pub profile_name: String,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UsageEvent {
+    Profile {
+        profile_name: String,
+        label: Option<String>,
+    },
+    ApiSpend {
+        label: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthKind {
+    Claude,
+    Codex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UsageSource {
+    profile_name: String,
+    dir: PathBuf,
+    kind: AuthKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct UsageBlock {
+    used_percent: f64,
+}
+
+pub fn spawn_usage_monitor(targets: Vec<UsageTarget>, tx: Sender<UsageEvent>) {
+    thread::spawn(move || {
+        let targets = resolve_usage_sources(&targets);
+        loop {
+            let mut disconnected = false;
+
+            for source in &targets {
+                let label = profile_usage_label(source);
+                if tx
+                    .send(UsageEvent::Profile {
+                        profile_name: source.profile_name.clone(),
+                        label,
+                    })
+                    .is_err()
+                {
+                    disconnected = true;
+                    break;
+                }
+            }
+
+            if disconnected {
+                break;
+            }
+
+            if tx
+                .send(UsageEvent::ApiSpend {
+                    label: api_spend_label(),
+                })
+                .is_err()
+            {
+                break;
+            }
+
+            thread::sleep(REFRESH_INTERVAL);
+        }
+    });
+}
+
+fn resolve_usage_sources(targets: &[UsageTarget]) -> Vec<UsageSource> {
+    let mut sources = BTreeMap::new();
+    for target in targets {
+        if let Some(source) = resolve_usage_source(target) {
+            sources.entry(source.profile_name.clone()).or_insert(source);
+        }
+    }
+    sources.into_values().collect()
+}
+
+fn resolve_usage_source(target: &UsageTarget) -> Option<UsageSource> {
+    let vibe_dir = profiles_home().join(&target.profile_name);
+    if vibe_dir.is_dir() {
+        let kind = profile_kind(&vibe_dir)
+            .or_else(|| infer_kind(&target.profile_name))
+            .unwrap_or(AuthKind::Claude);
+        return Some(UsageSource {
+            profile_name: target.profile_name.clone(),
+            dir: vibe_dir,
+            kind,
+        });
+    }
+
+    let command_kind = infer_kind(&target.command).or_else(|| infer_kind(&target.profile_name))?;
+    let dir = match command_kind {
+        AuthKind::Claude => home_dir()?.join(".claude"),
+        AuthKind::Codex => home_dir()?.join(".codex"),
+    };
+
+    dir.is_dir().then(|| UsageSource {
+        profile_name: target.profile_name.clone(),
+        dir,
+        kind: command_kind,
+    })
+}
+
+fn profile_kind(dir: &Path) -> Option<AuthKind> {
+    let raw = fs::read_to_string(dir.join(".profile-kind")).ok()?;
+    match raw.trim() {
+        "claude" => Some(AuthKind::Claude),
+        "codex" => Some(AuthKind::Codex),
+        _ => None,
+    }
+}
+
+fn infer_kind(value: &str) -> Option<AuthKind> {
+    let name = Path::new(value)
+        .file_stem()
+        .and_then(|part| part.to_str())
+        .unwrap_or(value)
+        .to_ascii_lowercase();
+
+    if name.starts_with("codex") || name.contains("codex") {
+        Some(AuthKind::Codex)
+    } else if name.starts_with("claude") || name.contains("claude") {
+        Some(AuthKind::Claude)
+    } else {
+        None
+    }
+}
+
+fn profile_usage_label(source: &UsageSource) -> Option<String> {
+    let usage = match source.kind {
+        AuthKind::Claude => fetch_claude_usage(&source.dir),
+        AuthKind::Codex => {
+            fetch_codex_usage(&source.dir).or_else(|| codex_usage_snapshot(&source.dir))
+        }
+    }?;
+    usage_label(usage.five, usage.seven)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct UsageWindows {
+    five: Option<UsageBlock>,
+    seven: Option<UsageBlock>,
+}
+
+fn usage_label(five: Option<UsageBlock>, seven: Option<UsageBlock>) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(block) = five {
+        parts.push(format!(
+            "5h {}% left",
+            available_percent(block.used_percent)
+        ));
+    }
+    if let Some(block) = seven {
+        parts.push(format!(
+            "7d {}% left",
+            available_percent(block.used_percent)
+        ));
+    }
+    (!parts.is_empty()).then(|| parts.join(" / "))
+}
+
+fn available_percent(used_percent: f64) -> u8 {
+    (100.0 - used_percent).round().clamp(0.0, 100.0) as u8
+}
+
+fn fetch_claude_usage(dir: &Path) -> Option<UsageWindows> {
+    let token = read_claude_access_token(dir)?;
+    let output = run_curl(&[
+        "-s",
+        "-m",
+        "3",
+        "-H",
+        &format!("Authorization: Bearer {token}"),
+        "-H",
+        "anthropic-beta: oauth-2025-04-20",
+        CLAUDE_USAGE_ENDPOINT,
+    ])?;
+
+    parse_claude_usage(&output)
+}
+
+fn fetch_codex_usage(dir: &Path) -> Option<UsageWindows> {
+    let auth = read_codex_auth(dir)?;
+    let mut args = vec![
+        "-s".to_string(),
+        "-m".to_string(),
+        "3".to_string(),
+        "-H".to_string(),
+        format!("Authorization: Bearer {}", auth.access_token),
+        "-H".to_string(),
+        "User-Agent: codex-cli".to_string(),
+    ];
+    if let Some(account_id) = auth.account_id {
+        args.push("-H".to_string());
+        args.push(format!("chatgpt-account-id: {account_id}"));
+    }
+    args.push(CODEX_USAGE_ENDPOINT.to_string());
+
+    let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let output = run_curl(&refs)?;
+    parse_codex_usage(&output)
+}
+
+fn api_spend_label() -> Option<String> {
+    let token = env::var("OPENAI_ADMIN_KEY")
+        .ok()
+        .filter(|value| !value.is_empty())?;
+    let now = unix_now()?;
+    let start = now.saturating_sub(24 * 60 * 60);
+    let url = format!("{OPENAI_COSTS_ENDPOINT}?start_time={start}&end_time={now}&limit=2");
+    let output = run_curl(&[
+        "-s",
+        "-m",
+        "3",
+        "-H",
+        &format!("Authorization: Bearer {token}"),
+        "-H",
+        "Content-Type: application/json",
+        &url,
+    ])?;
+    let spend = parse_openai_costs(&output)?;
+    Some(format_api_spend(spend.value, spend.currency.as_deref()))
+}
+
+fn format_api_spend(value: f64, currency: Option<&str>) -> String {
+    match currency.unwrap_or("usd") {
+        "usd" => format!("API ${value:.2} 24h"),
+        other => format!("API {value:.2} {} 24h", other.to_ascii_uppercase()),
+    }
+}
+
+fn run_curl(args: &[&str]) -> Option<String> {
+    let curl = if cfg!(windows) { "curl.exe" } else { "curl" };
+    let output = Command::new(curl).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn read_claude_access_token(dir: &Path) -> Option<String> {
+    let raw = fs::read_to_string(dir.join(".credentials.json")).ok()?;
+    let creds: ClaudeCredentials = serde_json::from_str(&raw).ok()?;
+    creds.claude_ai_oauth?.access_token
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeCredentials {
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: Option<ClaudeOauth>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeOauth {
+    #[serde(rename = "accessToken")]
+    access_token: Option<String>,
+}
+
+fn read_codex_auth(dir: &Path) -> Option<CodexAuth> {
+    let raw = fs::read_to_string(dir.join("auth.json")).ok()?;
+    let auth: CodexAuthFile = serde_json::from_str(&raw).ok()?;
+    let tokens = auth.tokens?;
+    let access_token = tokens.access_token.filter(|value| !value.is_empty())?;
+    Some(CodexAuth {
+        access_token,
+        account_id: tokens.account_id,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexAuth {
+    access_token: String,
+    account_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexAuthFile {
+    tokens: Option<CodexTokens>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexTokens {
+    access_token: Option<String>,
+    account_id: Option<String>,
+}
+
+fn parse_claude_usage(raw: &str) -> Option<UsageWindows> {
+    let data: ClaudeUsageResponse = serde_json::from_str(raw).ok()?;
+    Some(UsageWindows {
+        five: data.five_hour.and_then(|block| block.utilization),
+        seven: data.seven_day.and_then(|block| block.utilization),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeUsageResponse {
+    five_hour: Option<ClaudeUsageBlock>,
+    seven_day: Option<ClaudeUsageBlock>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeUsageBlock {
+    #[serde(default, deserialize_with = "optional_usage_block")]
+    utilization: Option<UsageBlock>,
+}
+
+fn parse_codex_usage(raw: &str) -> Option<UsageWindows> {
+    let data: CodexUsageResponse = serde_json::from_str(raw).ok()?;
+    let rate_limit = data.rate_limit?;
+    Some(UsageWindows {
+        five: rate_limit
+            .primary_window
+            .and_then(|block| block.used_percent),
+        seven: rate_limit
+            .secondary_window
+            .and_then(|block| block.used_percent),
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexUsageResponse {
+    rate_limit: Option<CodexRateLimit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexRateLimit {
+    primary_window: Option<CodexRateLimitWindow>,
+    secondary_window: Option<CodexRateLimitWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexRateLimitWindow {
+    #[serde(default, deserialize_with = "optional_usage_block")]
+    used_percent: Option<UsageBlock>,
+}
+
+fn optional_usage_block<'de, D>(deserializer: D) -> Result<Option<UsageBlock>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(deserializer)?;
+    Ok(value.map(|used_percent| UsageBlock { used_percent }))
+}
+
+fn codex_usage_snapshot(dir: &Path) -> Option<UsageWindows> {
+    let sessions = dir.join("sessions");
+    let mut files = Vec::new();
+    collect_codex_rollouts(&sessions, &mut files);
+    files.sort_by(|left, right| right.1.cmp(&left.1));
+
+    files
+        .into_iter()
+        .take(8)
+        .find_map(|(file, _)| extract_codex_rate_limits(&file))
+}
+
+fn collect_codex_rollouts(dir: &Path, out: &mut Vec<(PathBuf, u128)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+
+        if file_type.is_dir() {
+            collect_codex_rollouts(&path, out);
+        } else if file_type.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"))
+        {
+            out.push((path.clone(), modified_millis(&path)));
+        }
+    }
+}
+
+fn modified_millis(path: &Path) -> u128 {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+fn extract_codex_rate_limits(file: &Path) -> Option<UsageWindows> {
+    let raw = fs::read_to_string(file).ok()?;
+    for line in raw.lines().rev() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let Some(payload) = value.get("payload") else {
+            continue;
+        };
+        if payload.get("type").and_then(|value| value.as_str()) != Some("token_count") {
+            continue;
+        }
+        let Some(rate_limits) = payload.get("rate_limits") else {
+            continue;
+        };
+        let primary = rate_limits.get("primary").and_then(rate_limit_block);
+        let secondary = rate_limits.get("secondary").and_then(rate_limit_block);
+        if primary.is_some() || secondary.is_some() {
+            return Some(UsageWindows {
+                five: primary,
+                seven: secondary,
+            });
+        }
+    }
+    None
+}
+
+fn rate_limit_block(value: &serde_json::Value) -> Option<UsageBlock> {
+    value
+        .get("used_percent")
+        .and_then(|value| value.as_f64())
+        .map(|used_percent| UsageBlock { used_percent })
+}
+
+fn parse_openai_costs(raw: &str) -> Option<ApiSpend> {
+    let data: CostsResponse = serde_json::from_str(raw).ok()?;
+    let mut total = 0.0;
+    let mut currency = None;
+
+    for bucket in data.data {
+        for result in bucket.results {
+            let Some(amount) = result.amount else {
+                continue;
+            };
+            let Some(value) = amount.value else {
+                continue;
+            };
+            total += value;
+            if currency.is_none() {
+                currency = amount.currency;
+            }
+        }
+    }
+
+    Some(ApiSpend {
+        value: total,
+        currency,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct ApiSpend {
+    value: f64,
+    currency: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CostsResponse {
+    #[serde(default)]
+    data: Vec<CostBucket>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CostBucket {
+    #[serde(default)]
+    results: Vec<CostResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CostResult {
+    amount: Option<CostAmount>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CostAmount {
+    value: Option<f64>,
+    currency: Option<String>,
+}
+
+fn profiles_home() -> PathBuf {
+    env::var_os("CLAUDE_PROFILES_HOME")
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join(".claude-profiles")))
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("USERPROFILE")
+        .or_else(|| env::var_os("HOME"))
+        .map(PathBuf::from)
+}
+
+fn unix_now() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_available_usage_windows() {
+        assert_eq!(
+            usage_label(
+                Some(UsageBlock { used_percent: 60.2 }),
+                Some(UsageBlock { used_percent: 8.0 })
+            ),
+            Some("5h 40% left / 7d 92% left".into())
+        );
+    }
+
+    #[test]
+    fn clamps_available_percent() {
+        assert_eq!(available_percent(-12.0), 100);
+        assert_eq!(available_percent(101.0), 0);
+    }
+
+    #[test]
+    fn parses_codex_usage_response() {
+        let usage = parse_codex_usage(
+            r#"{
+                "rate_limit": {
+                    "primary_window": {"used_percent": 61.0},
+                    "secondary_window": {"used_percent": 12.4}
+                }
+            }"#,
+        )
+        .expect("usage");
+
+        assert_eq!(
+            usage_label(usage.five, usage.seven),
+            Some("5h 39% left / 7d 88% left".into())
+        );
+    }
+
+    #[test]
+    fn parses_openai_costs_response() {
+        let spend = parse_openai_costs(
+            r#"{
+                "data": [
+                    {"results": [{"amount": {"value": 0.06, "currency": "usd"}}]},
+                    {"results": [{"amount": {"value": 1.44, "currency": "usd"}}]}
+                ]
+            }"#,
+        )
+        .expect("spend");
+
+        assert_eq!(
+            format_api_spend(spend.value, spend.currency.as_deref()),
+            "API $1.50 24h"
+        );
+    }
+
+    #[test]
+    fn extracts_codex_rate_limits_from_rollout_line() {
+        let temp = env::temp_dir().join(format!(
+            "gridbash-usage-test-{}.jsonl",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        fs::write(
+            &temp,
+            r#"{"type":"session_meta","payload":{"id":"abc"}}"#.to_string()
+                + "\n"
+                + r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":70},"secondary":{"used_percent":20}}}}"#,
+        )
+        .expect("write rollout");
+
+        let usage = extract_codex_rate_limits(&temp).expect("limits");
+        let _ = fs::remove_file(temp);
+
+        assert_eq!(
+            usage_label(usage.five, usage.seven),
+            Some("5h 30% left / 7d 80% left".into())
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #55.
- Adds a background usage monitor for vibe/default Claude and Codex auth profiles.
- Shows compact gridcell header labels like `5h 40% left / 7d 92% left`.
- Shows optional OpenAI API spend labels like `API $1.50 24h` when `OPENAI_ADMIN_KEY` is available.

## Testing

- [x] `cargo fmt --check`
- [ ] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] `cargo build --release`
- [ ] `npm pack`
- [x] Not applicable or not run: clippy, release build, and npm pack were not run; this change is runtime/UI logic covered by unit tests and `cargo test`.

## Contributor Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I signed off my commits with `git commit -s`.
- [x] I updated docs, examples, or tests when behavior changed.
- [x] This is not a public report of a security vulnerability.

## Notes For Reviewers

- Usage/spend fetches are best-effort and run on a background thread; pane startup and rendering do not wait on network calls.
- Codex tries live ChatGPT usage first and falls back to the latest local rollout rate-limit snapshot.
- API spend uses OpenAI organization costs and therefore requires `OPENAI_ADMIN_KEY`.