### PR TITLE
Integrate quiet output badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GridBash is a Windows-native Rust TUI multiplexer built for agent-heavy developm
 - Sleeping panes stay visually hidden until hovered, then wake without crossing input into other panes.
 - Normal terminal keys pass through to the focused pane, or to selected panes when multiple panes are selected.
 - Modeless Alt shortcuts for pane focus, selection, rename, settings, and quit.
-- Compact dark theme with focus, selection, activity, exit, and output-volume badges.
+- Compact dark theme with focus, selection, sleep, exit, usage, and quiet-output cues.
 - Claude, Codex, and other agent panes show a compact conversation summary in the footer line.
 - Built-in launch profiles for common CLI coding agents.
 - Startup dimension picker with a live grid preview.
@@ -175,14 +175,16 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+r | Rename the focused pane |
 | Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |
 | Hover sleeping pane | Wake the pane and make its terminal contents visible again |
-| Alt+o | Open sample settings |
+| Alt+o | Open settings |
 | Alt+q | Quit |
 
 Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
 
-The settings screen is currently a sample UI. Its switches, steppers, and choices can be changed, but they do not affect runtime behavior yet.
+Pane titles add a small quiet-output marker after roughly three seconds without output. The marker means a pane produced output and then went idle; it does not mean the process exited or completed its task.
+
+The settings screen includes sample controls plus live color controls for the accent, focus, selected, quiet, and exited grid roles. Palette changes apply immediately for the current run.
 
 ## Profiles
 

--- a/docs/devlogs/2026-07-07-integrate-quiet-output-badges.md
+++ b/docs/devlogs/2026-07-07-integrate-quiet-output-badges.md
@@ -1,0 +1,26 @@
+# Integrate quiet output badges
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Integrated quiet-output pane markers and live palette settings from the older feature branch onto current main.
+
+## What Changed
+
+- Added PTY output quiet tracking that marks a pane after recent output has stopped.
+- Added a quiet-output title marker and palette-controlled quiet border while preserving focused, selected, sleeping, exited, usage, and worktree title labels.
+- Added live settings rows for accent, focus, selected, quiet, and exited colors without restoring active-state chrome.
+
+## Why It Matters
+
+- Quiet panes are easier to scan in busy grids without confusing idle output for exited processes or reintroducing active-state flicker.
+
+## Validation
+
+- `npm test` passed.
+
+## Release Notes
+
+- Quiet-output markers and runtime palette controls are available in the grid settings screen.

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect};
+use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect, style::Color};
 use tokio::sync::mpsc;
 use vt100::Screen;
 
@@ -38,6 +38,8 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(16);
 const MAX_PANE_NAME_CHARS: usize = 32;
 const CONVERSATION_SUMMARY_MAX_CHARS: usize = 120;
+const ACTIVITY_DECAY_INTERVAL: Duration = Duration::from_millis(250);
+const OUTPUT_QUIET_AFTER: Duration = Duration::from_secs(3);
 
 pub struct App {
     config: Config,
@@ -153,11 +155,181 @@ enum SwapSelection {
     Pair(usize, usize),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaletteRole {
+    Accent,
+    Focus,
+    Selected,
+    Quiet,
+    Exited,
+}
+
+impl PaletteRole {
+    const ALL: [Self; 5] = [
+        Self::Accent,
+        Self::Focus,
+        Self::Selected,
+        Self::Quiet,
+        Self::Exited,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Accent => "Accent color",
+            Self::Focus => "Focus border",
+            Self::Selected => "Selected border",
+            Self::Quiet => "Quiet border",
+            Self::Exited => "Exited border",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaletteColor {
+    Cyan,
+    Sky,
+    Blue,
+    Teal,
+    Green,
+    Yellow,
+    Amber,
+    Orange,
+    Red,
+    Magenta,
+    Gray,
+    White,
+}
+
+impl PaletteColor {
+    const ALL: [Self; 12] = [
+        Self::Cyan,
+        Self::Sky,
+        Self::Blue,
+        Self::Teal,
+        Self::Green,
+        Self::Yellow,
+        Self::Amber,
+        Self::Orange,
+        Self::Red,
+        Self::Magenta,
+        Self::Gray,
+        Self::White,
+    ];
+
+    fn color(self) -> Color {
+        match self {
+            Self::Cyan => Color::Cyan,
+            Self::Sky => Color::Rgb(88, 166, 255),
+            Self::Blue => Color::Blue,
+            Self::Teal => Color::Rgb(54, 211, 153),
+            Self::Green => Color::Green,
+            Self::Yellow => Color::Yellow,
+            Self::Amber => Color::Rgb(245, 158, 11),
+            Self::Orange => Color::Rgb(249, 115, 22),
+            Self::Red => Color::Red,
+            Self::Magenta => Color::Magenta,
+            Self::Gray => Color::Gray,
+            Self::White => Color::White,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Cyan => "cyan",
+            Self::Sky => "sky",
+            Self::Blue => "blue",
+            Self::Teal => "teal",
+            Self::Green => "green",
+            Self::Yellow => "yellow",
+            Self::Amber => "amber",
+            Self::Orange => "orange",
+            Self::Red => "red",
+            Self::Magenta => "magenta",
+            Self::Gray => "gray",
+            Self::White => "white",
+        }
+    }
+
+    fn adjust(self, delta: isize) -> Self {
+        let index = Self::ALL
+            .iter()
+            .position(|color| *color == self)
+            .unwrap_or_default();
+        let next = (index as isize + delta).rem_euclid(Self::ALL.len() as isize) as usize;
+        Self::ALL[next]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GridPalette {
+    accent: PaletteColor,
+    focus: PaletteColor,
+    selected: PaletteColor,
+    quiet: PaletteColor,
+    exited: PaletteColor,
+}
+
+impl Default for GridPalette {
+    fn default() -> Self {
+        Self {
+            accent: PaletteColor::Cyan,
+            focus: PaletteColor::Yellow,
+            selected: PaletteColor::Cyan,
+            quiet: PaletteColor::Magenta,
+            exited: PaletteColor::Red,
+        }
+    }
+}
+
+impl GridPalette {
+    pub fn accent(&self) -> Color {
+        self.accent.color()
+    }
+
+    pub fn focus(&self) -> Color {
+        self.focus.color()
+    }
+
+    pub fn selected(&self) -> Color {
+        self.selected.color()
+    }
+
+    pub fn quiet(&self) -> Color {
+        self.quiet.color()
+    }
+
+    pub fn exited(&self) -> Color {
+        self.exited.color()
+    }
+
+    fn color_for(self, role: PaletteRole) -> PaletteColor {
+        match role {
+            PaletteRole::Accent => self.accent,
+            PaletteRole::Focus => self.focus,
+            PaletteRole::Selected => self.selected,
+            PaletteRole::Quiet => self.quiet,
+            PaletteRole::Exited => self.exited,
+        }
+    }
+
+    fn adjust(&mut self, role: PaletteRole, delta: isize) {
+        let target = match role {
+            PaletteRole::Accent => &mut self.accent,
+            PaletteRole::Focus => &mut self.focus,
+            PaletteRole::Selected => &mut self.selected,
+            PaletteRole::Quiet => &mut self.quiet,
+            PaletteRole::Exited => &mut self.exited,
+        };
+        *target = (*target).adjust(delta);
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SettingsRow {
     pub selected: bool,
     pub label: &'static str,
     pub value: String,
+    pub value_color: Option<Color>,
     pub hint: &'static str,
 }
 
@@ -258,7 +430,7 @@ struct SettingsState {
     pane_density: i32,
     scrollback: i32,
     refresh_ms: i32,
-    accent_index: usize,
+    palette: GridPalette,
 }
 
 impl Default for SettingsState {
@@ -272,14 +444,14 @@ impl Default for SettingsState {
             pane_density: 2,
             scrollback: 10_000,
             refresh_ms: 16,
-            accent_index: 0,
+            palette: GridPalette::default(),
         }
     }
 }
 
 impl SettingsState {
-    const ROW_COUNT: usize = 7;
-    const ACCENTS: [&'static str; 4] = ["cyan", "yellow", "green", "magenta"];
+    const BASE_ROW_COUNT: usize = 6;
+    const ROW_COUNT: usize = Self::BASE_ROW_COUNT + PaletteRole::ALL.len();
 
     fn move_cursor(&mut self, delta: isize) {
         let current = self.cursor as isize;
@@ -287,16 +459,25 @@ impl SettingsState {
     }
 
     fn activate(&mut self) {
+        if self.palette_role().is_some() {
+            self.adjust(1);
+            return;
+        }
+
         match self.cursor {
             0 => self.compact_titles = !self.compact_titles,
             1 => self.activity_badges = !self.activity_badges,
             2 => self.confirm_quit = !self.confirm_quit,
-            6 => self.adjust(1),
             _ => self.adjust(1),
         }
     }
 
     fn adjust(&mut self, delta: i32) {
+        if let Some(role) = self.palette_role() {
+            self.palette.adjust(role, delta as isize);
+            return;
+        }
+
         match self.cursor {
             0 => {
                 if delta != 0 {
@@ -316,60 +497,80 @@ impl SettingsState {
             3 => self.pane_density = (self.pane_density + delta).clamp(1, 5),
             4 => self.scrollback = (self.scrollback + delta * 1000).clamp(1_000, 50_000),
             5 => self.refresh_ms = (self.refresh_ms + delta * 4).clamp(8, 100),
-            6 => {
-                let count = Self::ACCENTS.len() as isize;
-                self.accent_index =
-                    (self.accent_index as isize + delta as isize).rem_euclid(count) as usize;
-            }
             _ => {}
         }
     }
 
     fn rows(&self) -> Vec<SettingsRow> {
-        vec![
+        let mut rows = vec![
             self.row(
                 0,
                 "Compact pane titles",
                 switch_value(self.compact_titles),
+                None,
                 "shorter labels in pane chrome",
             ),
             self.row(
                 1,
                 "Activity badges",
                 switch_value(self.activity_badges),
-                "show live and selected state",
+                None,
+                "quiet markers",
             ),
             self.row(
                 2,
                 "Confirm before quit",
                 switch_value(self.confirm_quit),
+                None,
                 "extra guard for Alt+q",
             ),
             self.row(
                 3,
                 "Pane density",
                 self.pane_density.to_string(),
+                None,
                 "spacing scale from 1 to 5",
             ),
             self.row(
                 4,
                 "Scrollback rows",
                 self.scrollback.to_string(),
+                None,
                 "history budget per pane",
             ),
             self.row(
                 5,
                 "Refresh delay",
                 format!("{} ms", self.refresh_ms),
+                None,
                 "render loop throttle",
             ),
-            self.row(
-                6,
-                "Accent color",
-                Self::ACCENTS[self.accent_index].to_string(),
-                "cycle the UI highlight",
-            ),
-        ]
+        ];
+
+        rows.extend(
+            PaletteRole::ALL
+                .iter()
+                .enumerate()
+                .map(|(offset, role)| self.palette_row(Self::BASE_ROW_COUNT + offset, *role)),
+        );
+        rows
+    }
+
+    fn palette_role(&self) -> Option<PaletteRole> {
+        self.cursor
+            .checked_sub(Self::BASE_ROW_COUNT)
+            .and_then(|index| PaletteRole::ALL.get(index).copied())
+    }
+
+    fn palette_row(&self, index: usize, role: PaletteRole) -> SettingsRow {
+        let color = self.palette.color_for(role);
+        self.row(
+            index,
+            role.label(),
+            color.name().to_string(),
+            Some(color.color()),
+            "-/+ color",
+        )
     }
 
     fn row(
@@ -377,12 +578,14 @@ impl SettingsState {
         index: usize,
         label: &'static str,
         value: String,
+        value_color: Option<Color>,
         hint: &'static str,
     ) -> SettingsRow {
         SettingsRow {
             selected: self.cursor == index,
             label,
             value,
+            value_color,
             hint,
         }
     }
@@ -660,15 +863,20 @@ impl App {
     }
 
     fn decay_activity(&mut self) -> bool {
-        if self.last_activity_decay.elapsed() < Duration::from_millis(250) {
+        if self.last_activity_decay.elapsed() < ACTIVITY_DECAY_INTERVAL {
             return false;
         }
 
-        let changed = self.panes.iter().any(|pane| pane.active);
+        let now = Instant::now();
+        let mut changed = false;
         for pane in &mut self.panes {
-            pane.active = false;
+            if pane.active {
+                pane.active = false;
+                changed = true;
+            }
+            changed |= pane.refresh_output_activity(now, OUTPUT_QUIET_AFTER);
         }
-        self.last_activity_decay = Instant::now();
+        self.last_activity_decay = now;
         changed
     }
 
@@ -1414,6 +1622,14 @@ impl App {
         self.settings.rows()
     }
 
+    pub fn activity_badges_enabled(&self) -> bool {
+        self.settings.activity_badges
+    }
+
+    pub fn palette(&self) -> &GridPalette {
+        &self.settings.palette
+    }
+
     pub fn pane_label(&self, index: usize) -> String {
         self.pane_names
             .get(index)
@@ -1948,6 +2164,28 @@ mod tests {
             awake_input_targets_for(2, &selected(&[0, 3]), 4, &selected(&[0])),
             vec![3]
         );
+    }
+
+    #[test]
+    fn palette_color_cycles_in_both_directions() {
+        assert_eq!(PaletteColor::Cyan.adjust(1), PaletteColor::Sky);
+        assert_eq!(PaletteColor::Cyan.adjust(-1), PaletteColor::White);
+    }
+
+    #[test]
+    fn settings_rows_include_live_grid_palette_roles() {
+        let settings = SettingsState::default();
+        let rows = settings.rows();
+
+        assert_eq!(rows.len(), SettingsState::ROW_COUNT);
+        assert_eq!(rows[1].label, "Activity badges");
+        assert_eq!(rows[1].value, "on");
+        assert_eq!(rows[SettingsState::BASE_ROW_COUNT].label, "Accent color");
+        assert_eq!(
+            rows[SettingsState::BASE_ROW_COUNT + 3].label,
+            "Quiet border"
+        );
+        assert_eq!(rows[SettingsState::BASE_ROW_COUNT + 3].value, "magenta");
     }
 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
     thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
@@ -31,6 +32,40 @@ pub enum PtyEvent {
     },
 }
 
+#[derive(Debug, Clone, Default)]
+struct OutputActivity {
+    last_output_at: Option<Instant>,
+    quiet: bool,
+}
+
+impl OutputActivity {
+    fn record_output(&mut self, now: Instant) {
+        self.last_output_at = Some(now);
+        self.quiet = false;
+    }
+
+    fn refresh(&mut self, now: Instant, quiet_after: Duration) -> bool {
+        if self.quiet {
+            return false;
+        }
+
+        let Some(last_output_at) = self.last_output_at else {
+            return false;
+        };
+
+        if now.duration_since(last_output_at) < quiet_after {
+            return false;
+        }
+
+        self.quiet = true;
+        true
+    }
+
+    fn is_quiet(&self) -> bool {
+        self.quiet
+    }
+}
+
 pub struct PtyPane {
     id: PaneId,
     generation: u64,
@@ -42,6 +77,7 @@ pub struct PtyPane {
     rows: u16,
     cols: u16,
     response_scan_tail: Vec<u8>,
+    output_activity: OutputActivity,
     pub active: bool,
     pub exited: bool,
 }
@@ -102,6 +138,7 @@ impl PtyPane {
             rows: 24,
             cols: 80,
             response_scan_tail: Vec::new(),
+            output_activity: OutputActivity::default(),
             active: false,
             exited: false,
         })
@@ -126,7 +163,20 @@ impl PtyPane {
     pub fn process_output(&mut self, bytes: &[u8]) {
         self.parser.process(bytes);
         self.active = true;
+        self.output_activity.record_output(Instant::now());
         self.answer_terminal_queries(bytes);
+    }
+
+    pub fn output_quiet(&self) -> bool {
+        !self.exited && self.output_activity.is_quiet()
+    }
+
+    pub fn refresh_output_activity(&mut self, now: Instant, quiet_after: Duration) -> bool {
+        if self.exited {
+            return false;
+        }
+
+        self.output_activity.refresh(now, quiet_after)
     }
 
     pub fn write(&self, bytes: &[u8]) -> Result<()> {
@@ -296,6 +346,27 @@ mod tests {
         scan.extend_from_slice(b"prompt");
 
         assert_eq!(count_sequence(&scan, CURSOR_POSITION_QUERY), 0);
+    }
+
+    #[test]
+    fn output_activity_marks_quiet_after_output_stops() {
+        let start = Instant::now();
+        let quiet_after = Duration::from_secs(3);
+        let mut activity = OutputActivity::default();
+
+        assert!(!activity.refresh(start + quiet_after, quiet_after));
+        assert!(!activity.is_quiet());
+
+        activity.record_output(start);
+        assert!(!activity.refresh(start + Duration::from_secs(2), quiet_after));
+        assert!(!activity.is_quiet());
+
+        assert!(activity.refresh(start + quiet_after, quiet_after));
+        assert!(activity.is_quiet());
+        assert!(!activity.refresh(start + quiet_after + Duration::from_secs(1), quiet_after));
+
+        activity.record_output(start + quiet_after + Duration::from_secs(2));
+        assert!(!activity.is_quiet());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use std::path::Path;
 use vt100::Cell;
 
-use crate::app::{App, PaneSelection, RenamePaneView, SettingsRow};
+use crate::app::{App, GridPalette, PaneSelection, RenamePaneView, SettingsRow};
 
 const APP_BG: Color = Color::Rgb(11, 15, 20);
 const SETTINGS_BG: Color = Color::Rgb(9, 14, 19);
@@ -24,6 +24,8 @@ pub struct DrawState {
     pub pane_rects: Vec<Rect>,
 }
 
+const QUIET_MARKER: &str = " *";
+
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
     let chunks = Layout::default()
@@ -34,6 +36,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let grid_area = chunks[0];
     let status_area = chunks[1];
     let rects = app.pane_rects(grid_area);
+    let palette = app.palette();
     let rename_view = app.rename_pane_view();
     let modal_open = app.settings_open() || rename_view.is_some();
 
@@ -45,7 +48,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let focused = app.focus() == index;
         let selected = app.selected().contains(&index);
         let sleeping = app.pane_sleeping(index);
-        let chrome = pane_chrome(selected, focused, pane.active, pane.exited, sleeping);
+        let quiet = app.activity_badges_enabled() && pane.output_quiet();
+        let chrome = pane_chrome(
+            selected,
+            focused,
+            pane.active,
+            pane.exited,
+            sleeping,
+            quiet,
+            palette,
+        );
 
         let folder = app
             .pane_folder(index)
@@ -54,6 +66,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let usage = app.pane_usage_label(index);
         let title = pane_title(
             &app.pane_label(index),
+            chrome.quiet_marker,
             &folder,
             app.pane_worktree(index),
             usage.as_deref(),
@@ -93,21 +106,21 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             " GridBash ",
             Style::default()
                 .fg(Color::Black)
-                .bg(Color::Cyan)
+                .bg(palette.accent())
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" "),
         Span::styled(
             "LIVE",
             Style::default()
-                .fg(Color::Yellow)
+                .fg(palette.focus())
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" | "),
         Span::styled(
             input_scope,
             Style::default().fg(if app.selected().len() > 1 {
-                Color::Cyan
+                palette.selected()
             } else {
                 Color::Gray
             }),
@@ -124,7 +137,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     );
 
     if app.settings_open() {
-        render_settings(frame, area, &app.settings_rows());
+        render_settings(frame, area, &app.settings_rows(), palette);
     }
     if let Some(rename) = rename_view.as_ref() {
         render_rename_pane(frame, area, rename);
@@ -138,11 +151,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
 fn pane_title(
     label: &str,
+    quiet_marker: &str,
     folder: &str,
     worktree: Option<&str>,
     usage: Option<&str>,
     badge: &str,
 ) -> String {
+    let label = format!("{label}{quiet_marker}");
     let usage = usage.map(|label| format!(" | {label}")).unwrap_or_default();
     if let Some(worktree) = worktree {
         format!(" {label} | {folder} | {worktree}{usage}{badge} ")
@@ -155,6 +170,7 @@ fn pane_title(
 struct PaneChrome {
     border_style: Style,
     badge: &'static str,
+    quiet_marker: &'static str,
 }
 
 fn pane_chrome(
@@ -163,19 +179,25 @@ fn pane_chrome(
     _active: bool,
     exited: bool,
     sleeping: bool,
+    quiet: bool,
+    palette: &GridPalette,
 ) -> PaneChrome {
     let border_style = if sleeping {
         Style::default().fg(Color::Rgb(32, 36, 42))
     } else if selected {
         Style::default()
-            .fg(Color::Cyan)
+            .fg(palette.selected())
             .add_modifier(Modifier::BOLD)
     } else if focused {
         Style::default()
-            .fg(Color::Yellow)
+            .fg(palette.focus())
             .add_modifier(Modifier::BOLD)
     } else if exited {
-        Style::default().fg(Color::Red)
+        Style::default().fg(palette.exited())
+    } else if quiet {
+        Style::default()
+            .fg(palette.quiet())
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
@@ -189,14 +211,20 @@ fn pane_chrome(
     } else {
         ""
     };
+    let quiet_marker = if quiet && !exited && !sleeping {
+        QUIET_MARKER
+    } else {
+        ""
+    };
 
     PaneChrome {
         border_style,
         badge,
+        quiet_marker,
     }
 }
 
-fn render_settings(frame: &mut Frame<'_>, area: Rect, rows: &[SettingsRow]) {
+fn render_settings(frame: &mut Frame<'_>, area: Rect, rows: &[SettingsRow], palette: &GridPalette) {
     let modal = settings_modal_rect(area, rows.len());
     let shadow = settings_shadow_rect(area, modal);
 
@@ -214,7 +242,7 @@ fn render_settings(frame: &mut Frame<'_>, area: Rect, rows: &[SettingsRow]) {
         .borders(Borders::ALL)
         .border_style(
             Style::default()
-                .fg(SETTINGS_BORDER)
+                .fg(palette.accent())
                 .add_modifier(Modifier::BOLD),
         )
         .style(settings_panel_style())
@@ -364,10 +392,10 @@ fn settings_lines(rows: &[SettingsRow], width: u16) -> Vec<Line<'static>> {
     lines.push(Line::from(""));
     lines.push(settings_section(
         "THEME",
-        "one accent across the grid",
+        "runtime palette for grid chrome",
         width,
     ));
-    if let Some(row) = rows.get(6) {
+    for row in rows.iter().skip(6) {
         lines.push(settings_row(row, width));
     }
 
@@ -515,34 +543,25 @@ fn command_key(label: &'static str) -> Span<'static> {
 fn settings_value_label(row: &SettingsRow) -> String {
     match row.value.as_str() {
         "on" | "off" => format!("[ {} ]", row.value),
-        "cyan" | "yellow" | "green" | "magenta" => format!("< {} >", row.value),
+        _ if row.value_color.is_some() => format!("< {} >", row.value),
         _ => format!("- {} +", row.value),
     }
 }
 
 fn settings_value_style(row: &SettingsRow) -> Style {
+    if let Some(color) = row.value_color {
+        return Style::default()
+            .fg(Color::Black)
+            .bg(color)
+            .add_modifier(Modifier::BOLD);
+    }
+
     let mut style = match row.value.as_str() {
         "on" => Style::default()
             .fg(Color::Black)
             .bg(SETTINGS_BORDER)
             .add_modifier(Modifier::BOLD),
         "off" => Style::default().fg(SETTINGS_MUTED).bg(SETTINGS_SURFACE),
-        "cyan" => Style::default()
-            .fg(Color::Black)
-            .bg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-        "yellow" => Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-        "green" => Style::default()
-            .fg(Color::Black)
-            .bg(Color::Green)
-            .add_modifier(Modifier::BOLD),
-        "magenta" => Style::default()
-            .fg(Color::Black)
-            .bg(Color::Magenta)
-            .add_modifier(Modifier::BOLD),
         _ if row.selected => Style::default()
             .fg(Color::Black)
             .bg(Color::Yellow)
@@ -887,25 +906,34 @@ mod tests {
 
     #[test]
     fn output_activity_does_not_change_idle_pane_chrome() {
+        let palette = GridPalette::default();
+
         assert_eq!(
-            pane_chrome(false, false, false, false, false),
-            pane_chrome(false, false, true, false, false)
+            pane_chrome(false, false, false, false, false, false, &palette),
+            pane_chrome(false, false, true, false, false, false, &palette)
         );
     }
 
     #[test]
     fn selected_and_exited_badges_remain_visible() {
+        let palette = GridPalette::default();
+
         assert_eq!(
-            pane_chrome(true, false, true, false, false).badge,
+            pane_chrome(true, false, true, false, false, true, &palette).badge,
             " selected"
         );
-        assert_eq!(pane_chrome(true, false, true, true, false).badge, " exited");
+        assert_eq!(
+            pane_chrome(true, false, true, true, false, true, &palette).badge,
+            " exited"
+        );
     }
 
     #[test]
     fn sleeping_panes_show_sleep_badge() {
+        let palette = GridPalette::default();
+
         assert_eq!(
-            pane_chrome(false, false, true, false, true).badge,
+            pane_chrome(false, false, true, false, true, true, &palette).badge,
             " asleep"
         );
     }
@@ -913,16 +941,34 @@ mod tests {
     #[test]
     fn pane_title_uses_custom_label_in_number_slot() {
         assert_eq!(
-            pane_title("api", "gridbash/", Some("feat/rename-panes"), None, ""),
+            pane_title("api", "", "gridbash/", Some("feat/rename-panes"), None, ""),
             " api | gridbash/ | feat/rename-panes "
         );
         assert_eq!(
-            pane_title("1", "gridbash/", None, None, " selected"),
+            pane_title("1", "", "gridbash/", None, None, " selected"),
             " 1 | gridbash/ selected "
         );
         assert_eq!(
-            pane_title("2", "gridbash/", None, Some("5h 80% left"), " selected"),
+            pane_title("2", "", "gridbash/", None, Some("5h 80% left"), " selected"),
             " 2 | gridbash/ | 5h 80% left selected "
         );
+    }
+
+    #[test]
+    fn pane_title_keeps_quiet_marker_with_custom_label() {
+        assert_eq!(
+            pane_title("api", QUIET_MARKER, "gridbash/", None, None, ""),
+            " api * | gridbash/ "
+        );
+    }
+
+    #[test]
+    fn quiet_output_marks_idle_pane_without_active_chrome() {
+        let palette = GridPalette::default();
+        let quiet = pane_chrome(false, false, false, false, false, true, &palette);
+        let active_quiet = pane_chrome(false, false, true, false, false, true, &palette);
+
+        assert_eq!(quiet.quiet_marker, QUIET_MARKER);
+        assert_eq!(quiet.border_style, active_quiet.border_style);
     }
 }


### PR DESCRIPTION
## Summary
- Integrates quiet-output idle markers onto current main without restoring active-state chrome flicker.
- Adds live runtime palette rows for accent, focus, selected, quiet, and exited grid roles.
- Preserves current main behavior for rename, sleep, usage labels, pane-contained selection, runtime resize, worktrees, and conversation footers.

## Validation
- npm test

Refs #64