### PR TITLE
refactor: remove stale saved setup schema

### DIFF
--- a/docs/COMMUNITY_SETUP.md
+++ b/docs/COMMUNITY_SETUP.md
@@ -90,8 +90,8 @@ Milestones intentionally have no due dates.
 - `#3 docs: add release checklist for Windows binary and npm tarball`
 - `#4 test: verify first-run onboarding on clean Windows profile`
 - `#5 feat: improve profile detection diagnostics`
-- `#6 feat: polish saved setup management`
-- `#7 test: add composer preview and folder assignment coverage`
+- `#6 feat: polish startup picker controls`
+- `#7 test: add startup picker preview coverage`
 - `#8 feat: persist settings screen controls`
 - `#9 feat: add in-app help and legend overlay`
 - `#10 docs: define v1.0 acceptance checklist`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,6 @@
 ## V2
 
 - Background daemon for detach/reattach.
-- Saved workspaces and templates.
 - Multi-client attach.
 - Agent status classifiers.
 - Plugin API.

--- a/docs/devlogs/2026-07-07-remove-stale-saved-setup-schema.md
+++ b/docs/devlogs/2026-07-07-remove-stale-saved-setup-schema.md
@@ -1,0 +1,29 @@
+# Remove stale saved setup schema
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Removed the stale saved-setup config schema left behind after the startup picker replaced the old composer flow.
+- Kept the current startup picker, direct launch, and managed worktree launch behavior intact.
+
+## What Changed
+
+- Removed `Config::setups` and the unused `save_setup` helper.
+- Removed obsolete saved setup types and helper tests from `src/setup.rs`.
+- Added config parsing coverage so legacy `[setups]` tables are ignored without breaking config load.
+- Dropped saved workspace/templates from the roadmap until there is a fresh product design for it.
+
+## Why It Matters
+
+- The code now matches the current product surface: GridBash launches from the startup grid picker or explicit CLI options, not named saved setups.
+- Users with old config files can keep starting GridBash while the unused setup table is ignored.
+
+## Validation
+
+- `npm test` (43 passed, 1 ignored)
+
+## Release Notes
+
+- Removed stale saved-setup internals from config parsing and setup planning.

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
-use crate::{profiles::Profile, setup::SavedSetup};
+use crate::profiles::Profile;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
@@ -16,8 +16,6 @@ pub struct Config {
     pub defaults: Defaults,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profiles: BTreeMap<String, Profile>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub setups: BTreeMap<String, SavedSetup>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -60,11 +58,6 @@ impl Config {
         self.defaults.profile = Some(profile.into());
     }
 
-    #[allow(dead_code)]
-    pub fn save_setup(&mut self, name: impl Into<String>, setup: SavedSetup) {
-        self.setups.insert(name.into(), setup);
-    }
-
     pub fn default_path() -> Option<PathBuf> {
         ProjectDirs::from("", "", "GridBash").map(|dirs| dirs.config_dir().join("config.toml"))
     }
@@ -100,9 +93,12 @@ mod tests {
     }
 
     #[test]
-    fn parses_named_setups() {
+    fn ignores_legacy_setups_table() {
         let config: Config = toml::from_str(
             r#"
+            [defaults]
+            profile = "powershell"
+
             [setups.sample]
             agents = ["claude-1", "codex-2"]
 
@@ -113,8 +109,7 @@ mod tests {
         )
         .expect("parse config");
 
-        let setup = config.setups.get("sample").expect("sample setup");
-        assert_eq!(setup.agents, vec!["claude-1", "codex-2"]);
-        assert_eq!(setup.folders[0].name, "gridbash");
+        assert_eq!(config.defaults.profile.as_deref(), Some("powershell"));
+        assert!(config.profiles.is_empty());
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,28 +3,13 @@ use std::{
     process::Command,
 };
 
-use anyhow::{Context, Result, anyhow};
-use serde::{Deserialize, Serialize};
+use anyhow::Result;
 
 use crate::{
     layout::GridSize,
     profiles::{AGENT_PROFILE_NAMES, LaunchCommand, Profile},
     worktrees::{ManagedWorktreeOptions, ensure_pane_worktrees},
 };
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SavedSetup {
-    #[serde(default)]
-    pub folders: Vec<SetupFolder>,
-    #[serde(default)]
-    pub agents: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SetupFolder {
-    pub name: String,
-    pub path: PathBuf,
-}
 
 #[derive(Debug, Clone)]
 pub struct LaunchPlan {
@@ -40,51 +25,6 @@ pub struct PaneLaunchSpec {
     pub cwd: PathBuf,
     pub folder_name: String,
     pub worktree_name: Option<String>,
-}
-
-impl SavedSetup {
-    pub fn new(folders: Vec<SetupFolder>, agents: Vec<String>) -> Self {
-        Self { folders, agents }
-    }
-
-    pub fn validate(&self) -> Result<()> {
-        if self.folders.is_empty() {
-            return Err(anyhow!("setup needs at least one folder"));
-        }
-        if self.agents.is_empty() {
-            return Err(anyhow!("setup needs at least one agent"));
-        }
-        for folder in &self.folders {
-            if !folder.path.is_dir() {
-                return Err(anyhow!("folder does not exist: {}", folder.path.display()));
-            }
-        }
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn launch_plan(&self) -> Result<LaunchPlan> {
-        self.validate()?;
-        let panes = self
-            .agents
-            .iter()
-            .enumerate()
-            .map(|(index, agent)| {
-                let folder = &self.folders[index % self.folders.len()];
-                vibe_pane_spec(agent, folder)
-            })
-            .collect::<Vec<_>>();
-        let grid = GridSize::from_count(panes.len());
-        Ok(LaunchPlan { panes, grid })
-    }
-}
-
-impl SetupFolder {
-    #[allow(dead_code)]
-    pub fn from_path(path: PathBuf) -> Self {
-        let name = folder_display_name(&path);
-        Self { name, path }
-    }
 }
 
 impl LaunchPlan {
@@ -252,98 +192,11 @@ fn clean_agent_label(value: String) -> String {
     }
 }
 
-#[allow(dead_code)]
-pub fn sanitize_setup_name(value: &str) -> Option<String> {
-    let normalized = value
-        .trim()
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>()
-        .split('-')
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join("-");
-
-    (!normalized.is_empty()).then_some(normalized)
-}
-
-#[allow(dead_code)]
-fn vibe_pane_spec(agent: &str, folder: &SetupFolder) -> PaneLaunchSpec {
-    PaneLaunchSpec {
-        profile_name: agent.to_string(),
-        command: Profile {
-            command: "vibe".into(),
-            args: vec!["run".into(), agent.into(), "--".into()],
-            title: Some(agent.into()),
-        },
-        cwd: folder.path.clone(),
-        folder_name: folder.name.clone(),
-        worktree_name: git_worktree_name(&folder.path),
-    }
-}
-
-#[allow(dead_code)]
-pub fn setup_from_selection(folders: Vec<PathBuf>, agents: Vec<String>) -> Result<SavedSetup> {
-    let setup = SavedSetup::new(
-        folders.into_iter().map(SetupFolder::from_path).collect(),
-        agents,
-    );
-    setup.validate().context("invalid setup")?;
-    Ok(setup)
-}
-
 #[cfg(test)]
 mod tests {
     use std::env;
 
     use super::*;
-
-    #[test]
-    fn assigns_agents_round_robin_across_folders() {
-        let cwd = env::current_dir().expect("cwd");
-        let other = cwd.parent().unwrap_or(&cwd).to_path_buf();
-        let setup = SavedSetup::new(
-            vec![
-                SetupFolder {
-                    name: "one".into(),
-                    path: cwd,
-                },
-                SetupFolder {
-                    name: "two".into(),
-                    path: other,
-                },
-            ],
-            vec!["claude-1".into(), "claude-2".into(), "codex-2".into()],
-        );
-
-        let plan = setup.launch_plan().expect("launch plan");
-        assert_eq!(plan.panes[0].folder_name, "one");
-        assert_eq!(plan.panes[1].folder_name, "two");
-        assert_eq!(plan.panes[2].folder_name, "one");
-        assert_eq!(plan.grid.count(), 4);
-    }
-
-    #[test]
-    fn builds_vibe_run_command_for_agent() {
-        let cwd = env::current_dir().expect("cwd");
-        let setup = SavedSetup::new(
-            vec![SetupFolder {
-                name: "repo".into(),
-                path: cwd,
-            }],
-            vec!["claude-1".into()],
-        );
-
-        let plan = setup.launch_plan().expect("launch plan");
-        assert_eq!(plan.panes[0].command.command, "vibe");
-        assert_eq!(plan.panes[0].command.args, vec!["run", "claude-1", "--"]);
-    }
 
     #[test]
     fn detects_vibe_agent_panes() {
@@ -397,14 +250,5 @@ mod tests {
         };
 
         assert_eq!(spec.agent_label(), None);
-    }
-
-    #[test]
-    fn sanitizes_setup_names() {
-        assert_eq!(
-            sanitize_setup_name("Client Stack!"),
-            Some("client-stack".into())
-        );
-        assert_eq!(sanitize_setup_name("   "), None);
     }
 }


### PR DESCRIPTION
## Summary
- ports the viable saved-setup cleanup from origin/refactor/remove-setups onto current origin/main
- removes the unused Config::setups schema, save_setup helper, and obsolete SavedSetup/SetupFolder launch helpers
- keeps current startup picker, direct launch, and managed worktree launch planning intact
- adds coverage that legacy [setups] config tables are ignored instead of breaking config parsing
- updates roadmap/community setup wording and adds a devlog

Refs #76

## Validation
- npm test (43 passed, 1 ignored)