### PR TITLE
Add agent control tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -484,6 +511,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +541,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -587,6 +633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gridbash"
 version = "0.1.5"
 dependencies = [
@@ -594,6 +650,8 @@ dependencies = [
  "clap",
  "crossterm",
  "directories",
+ "getrandom 0.3.4",
+ "image",
  "portable-pty",
  "ratatui",
  "serde",
@@ -643,6 +701,34 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
 
 [[package]]
 name = "indexmap"
@@ -835,6 +921,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +940,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1091,6 +1197,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1250,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1484,6 +1615,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -1911,6 +2048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,3 +2194,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 directories = "6.0"
+getrandom = "0.3"
+image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 portable-pty = "0.9"
 ratatui = "0.30"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ With `--worktrees`, GridBash creates or reuses `.worktrees/gridbash-<base>-NN` f
 
 You can also run `gridbash --worktrees` and choose the grid dimensions in the startup picker.
 
+## Agent Control MCP
+
+GridBash can expose a local, opt-in control API for agents running inside its panes:
+
+```powershell
+gridbash --agent-api 2x3 --profile codex
+```
+
+When enabled, child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`, and `GRIDBASH_PANE_INDEX`. Configure an agent MCP server command to run:
+
+```powershell
+gridbash --mcp
+```
+
+The MCP server exposes:
+
+- `gridbash_show_image` to display a local png, jpg, gif, or webp in a GridBash overlay.
+- `gridbash_send_command` to send command text to one or more 1-based pane numbers.
+- `gridbash_set_status` to update the GridBash status bar.
+
+The control API binds to localhost, uses a per-session token, and is off by default.
+
 ## Startup Picker Controls
 
 | Input | Action |

--- a/docs/devlogs/2026-07-07-agent-control-tools.md
+++ b/docs/devlogs/2026-07-07-agent-control-tools.md
@@ -1,0 +1,33 @@
+# Agent control tools
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Added an opt-in GridBash agent control surface for MCP-capable panes.
+
+## What Changed
+
+- Added `--agent-api` to start a localhost-only control server with a per-session token.
+- Added `--mcp` to run a stdio MCP server exposing `gridbash_show_image`, `gridbash_send_command`, and `gridbash_set_status`.
+- Injected control endpoint, token, and pane index environment variables into child panes when the agent API is enabled.
+- Added an in-app image overlay that renders local images as truecolor terminal cells.
+- Documented the agent control setup in the README.
+
+## Why It Matters
+
+- Manager agents can now send targeted commands to other panes and update the GridBash status line without broad UI automation.
+- Agents can surface local image artifacts directly in GridBash for quick visual review.
+- The control path remains disabled by default and scoped to the current local session.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- MCP stdio smoke test for `initialize` and `tools/list`.
+
+## Release Notes
+
+- Added opt-in MCP tools for showing images, sending pane commands, and setting the GridBash status line.

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,8 @@ use crate::{
     cli::{Cli, GridMode},
     composer::Composer,
     config::Config,
+    control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
+    image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     profiles::find_profile,
     pty::{PtyEvent, PtyPane},
@@ -53,6 +55,9 @@ pub struct App {
     sleeping: BTreeSet<usize>,
     rects: Vec<Rect>,
     mouse_enabled: bool,
+    control_handle: Option<ControlHandle>,
+    control_rx: Option<std_mpsc::Receiver<ControlEnvelope>>,
+    image_overlay: Option<ImagePreview>,
     settings: SettingsState,
     rename: RenamePaneState,
     status: String,
@@ -409,6 +414,28 @@ impl App {
             });
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let (usage_tx, usage_rx) = std_mpsc::channel();
+        let agent_api_enabled = cli.agent_api || cli.agent_api_port != 0;
+        let (control_handle, control_rx) = if agent_api_enabled {
+            let (control_tx, control_rx) = std_mpsc::channel();
+            (
+                Some(control::start_control_server(
+                    cli.agent_api_port,
+                    control_tx,
+                )?),
+                Some(control_rx),
+            )
+        } else {
+            (None, None)
+        };
+        let base_status = if mouse_enabled {
+            "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
+        } else {
+            "Alt+arrows move | Alt+Shift+arrows resize | Alt+s select | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
+        };
+        let status = control_handle
+            .as_ref()
+            .map(|control| format!("agent API {} | {base_status}", control.endpoint()))
+            .unwrap_or_else(|| base_status.into());
 
         Ok(Self {
             config,
@@ -424,15 +451,12 @@ impl App {
             sleeping: BTreeSet::new(),
             rects: Vec::new(),
             mouse_enabled,
+            control_handle,
+            control_rx,
+            image_overlay: None,
             settings: SettingsState::default(),
             rename: RenamePaneState::default(),
-            status: if mouse_enabled {
-                "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
-                    .into()
-            } else {
-                "Alt+arrows move | Alt+Shift+arrows resize | Alt+s select | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
-                    .into()
-            },
+            status,
             next_pane_id: 0,
             event_tx,
             event_rx,
@@ -510,16 +534,34 @@ impl App {
         let launch = spec.resolved_command()?;
         let id = PaneId(self.next_pane_id);
         self.next_pane_id += 1;
+        let pane_index = self.panes.len();
+        let extra_env = self.pane_env(pane_index);
         let pane = PtyPane::spawn(
             id,
             0,
             &launch.command,
             &launch.args,
             &spec.cwd,
+            &extra_env,
             self.event_tx.clone(),
         )?;
         self.panes.push(pane);
         Ok(())
+    }
+
+    fn pane_env(&self, pane_index: usize) -> Vec<(String, String)> {
+        let Some(control) = &self.control_handle else {
+            return Vec::new();
+        };
+
+        vec![
+            (
+                "GRIDBASH_CONTROL_ADDR".into(),
+                control.endpoint().to_string(),
+            ),
+            ("GRIDBASH_CONTROL_TOKEN".into(), control.token().to_string()),
+            ("GRIDBASH_PANE_INDEX".into(), (pane_index + 1).to_string()),
+        ]
     }
 
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
@@ -529,6 +571,7 @@ impl App {
         loop {
             needs_render |= self.drain_pty_events();
             needs_render |= self.drain_usage_events();
+            needs_render |= self.drain_control_events();
             needs_render |= self.decay_activity();
 
             if needs_render {
@@ -659,6 +702,135 @@ impl App {
         changed
     }
 
+    fn drain_control_events(&mut self) -> bool {
+        let mut changed = false;
+
+        loop {
+            let envelope = self.control_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+            let Some(envelope) = envelope else {
+                break;
+            };
+
+            let response = self.handle_control_command(envelope.command);
+            changed = true;
+            let _ = envelope.response_tx.send(response);
+        }
+
+        changed
+    }
+
+    fn handle_control_command(&mut self, command: ControlCommand) -> ControlResponse {
+        match command {
+            ControlCommand::SetStatus { message } => self.set_control_status(message),
+            ControlCommand::SendCommand {
+                panes,
+                command,
+                submit,
+            } => self.send_control_command(&panes, &command, submit),
+            ControlCommand::ShowImage { path, title } => self.show_control_image(path, title),
+        }
+    }
+
+    fn set_control_status(&mut self, message: String) -> ControlResponse {
+        let message = truncate_chars(message.trim(), 180);
+        if message.is_empty() {
+            return ControlResponse::error("status message cannot be empty");
+        }
+
+        self.status = message.clone();
+        ControlResponse::ok(format!("status set: {message}"))
+    }
+
+    fn send_control_command(
+        &mut self,
+        pane_numbers: &[usize],
+        command: &str,
+        submit: bool,
+    ) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        let command_bytes = command.as_bytes();
+
+        for index in &targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            if !command_bytes.is_empty()
+                && let Err(error) = pane.write(command_bytes)
+            {
+                return ControlResponse::error(format!(
+                    "failed to send command to pane {}: {error:#}",
+                    index + 1
+                ));
+            }
+            if submit && let Err(error) = pane.write(b"\r") {
+                return ControlResponse::error(format!(
+                    "failed to submit command in pane {}: {error:#}",
+                    index + 1
+                ));
+            }
+        }
+
+        let panes = pane_number_list(&targets);
+        self.status = if submit {
+            format!("agent sent command to pane(s) {panes}")
+        } else {
+            format!("agent wrote text to pane(s) {panes}")
+        };
+        ControlResponse::ok(self.status.clone())
+    }
+
+    fn show_control_image(
+        &mut self,
+        path: std::path::PathBuf,
+        title: Option<String>,
+    ) -> ControlResponse {
+        let preview = match image_preview::load_image_preview(&path, title, 72, 24) {
+            Ok(preview) => preview,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        let title = preview.title.clone();
+        let data = serde_json::json!({
+            "path": preview.path.display().to_string(),
+            "source_width": preview.source_width,
+            "source_height": preview.source_height,
+            "preview_columns": preview.cell_width,
+            "preview_rows": preview.cell_height
+        });
+
+        self.status = format!(
+            "showing image {title} ({}x{})",
+            preview.source_width, preview.source_height
+        );
+        self.image_overlay = Some(preview);
+        ControlResponse::with_data(self.status.clone(), data)
+    }
+
+    fn control_pane_indices(&self, pane_numbers: &[usize]) -> Result<Vec<usize>> {
+        if pane_numbers.is_empty() {
+            return Err(anyhow!("at least one target pane is required"));
+        }
+
+        let mut targets = BTreeSet::new();
+        for pane_number in pane_numbers {
+            if *pane_number == 0 || *pane_number > self.panes.len() {
+                return Err(anyhow!("pane {pane_number} is not available"));
+            }
+            let index = pane_number - 1;
+            if self.sleeping.contains(&index) {
+                return Err(anyhow!("pane {pane_number} is asleep"));
+            }
+            if self.panes.get(index).is_some_and(|pane| pane.exited) {
+                return Err(anyhow!("pane {pane_number} has exited"));
+            }
+            targets.insert(index);
+        }
+
+        Ok(targets.into_iter().collect())
+    }
+
     fn decay_activity(&mut self) -> bool {
         if self.last_activity_decay.elapsed() < Duration::from_millis(250) {
             return false;
@@ -673,6 +845,10 @@ impl App {
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
+        if self.image_overlay.is_some() {
+            return Ok(self.handle_image_overlay_key(key));
+        }
+
         if self.rename.open {
             return self.handle_rename_key(key);
         }
@@ -702,6 +878,21 @@ impl App {
         } else {
             KeyOutcome::Continue
         })
+    }
+
+    fn handle_image_overlay_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return KeyOutcome::Quit;
+        }
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => {
+                self.image_overlay = None;
+                self.status = "image closed".into();
+                KeyOutcome::Render
+            }
+            _ => KeyOutcome::Continue,
+        }
     }
 
     fn handle_app_key(&mut self, key: KeyEvent) -> Result<Option<bool>> {
@@ -1410,6 +1601,10 @@ impl App {
         self.settings.open
     }
 
+    pub fn image_overlay_view(&self) -> Option<&ImagePreview> {
+        self.image_overlay.as_ref()
+    }
+
     pub fn settings_rows(&self) -> Vec<SettingsRow> {
         self.settings.rows()
     }
@@ -1779,6 +1974,14 @@ fn awake_input_targets_for(
 
 fn pane_word(count: usize) -> &'static str {
     if count == 1 { "pane" } else { "panes" }
+}
+
+fn pane_number_list(indices: &[usize]) -> String {
+    indices
+        .iter()
+        .map(|index| (index + 1).to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn control_byte(ch: char) -> Option<u8> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,18 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub no_mouse: bool,
 
+    /// Enable the local agent control API for child agent tools.
+    #[arg(long)]
+    pub agent_api: bool,
+
+    /// Localhost port for the agent control API. Use 0 to pick an available port.
+    #[arg(long, default_value_t = 0)]
+    pub agent_api_port: u16,
+
+    /// Run the GridBash MCP server over stdio.
+    #[arg(long)]
+    pub mcp: bool,
+
     /// Print detected launch profiles and exit.
     #[arg(long)]
     pub list_profiles: bool,

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,500 @@
+use std::{
+    env,
+    io::{self, BufRead, Read, Write},
+    net::{Shutdown, TcpListener, TcpStream},
+    path::PathBuf,
+    sync::mpsc::{self, Sender},
+    thread,
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
+const CONTROL_READ_TIMEOUT: Duration = Duration::from_secs(8);
+const CONTROL_REQUEST_LIMIT_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct ControlHandle {
+    endpoint: String,
+    token: String,
+}
+
+impl ControlHandle {
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlCommand {
+    SetStatus {
+        message: String,
+    },
+    SendCommand {
+        panes: Vec<usize>,
+        command: String,
+        submit: bool,
+    },
+    ShowImage {
+        path: PathBuf,
+        title: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+pub struct ControlEnvelope {
+    pub command: ControlCommand,
+    pub response_tx: Sender<ControlResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlResponse {
+    pub ok: bool,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl ControlResponse {
+    pub fn ok(message: impl Into<String>) -> Self {
+        Self {
+            ok: true,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub fn with_data(message: impl Into<String>, data: Value) -> Self {
+        Self {
+            ok: true,
+            message: message.into(),
+            data: Some(data),
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            message: message.into(),
+            data: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ControlWireRequest {
+    token: String,
+    command: ControlCommand,
+}
+
+pub fn start_control_server(
+    port: u16,
+    command_tx: Sender<ControlEnvelope>,
+) -> Result<ControlHandle> {
+    let listener = TcpListener::bind(("127.0.0.1", port)).context("failed to bind agent API")?;
+    let endpoint = listener
+        .local_addr()
+        .context("failed to read agent API address")?
+        .to_string();
+    let token = new_token()?;
+    let server_token = token.clone();
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => handle_control_stream(stream, &server_token, &command_tx),
+                Err(error) => eprintln!("gridbash agent API accept failed: {error}"),
+            }
+        }
+    });
+
+    Ok(ControlHandle { endpoint, token })
+}
+
+fn handle_control_stream(mut stream: TcpStream, token: &str, command_tx: &Sender<ControlEnvelope>) {
+    let _ = stream.set_read_timeout(Some(CONTROL_READ_TIMEOUT));
+    let response = read_control_request(&mut stream).and_then(|request| {
+        if request.token != token {
+            return Ok(ControlResponse::error("invalid GridBash control token"));
+        }
+
+        let (response_tx, response_rx) = mpsc::channel();
+        command_tx
+            .send(ControlEnvelope {
+                command: request.command,
+                response_tx,
+            })
+            .context("GridBash app is not accepting control commands")?;
+        response_rx
+            .recv_timeout(CONTROL_READ_TIMEOUT)
+            .context("GridBash app did not answer the control command")
+    });
+
+    let response = response.unwrap_or_else(|error| ControlResponse::error(format!("{error:#}")));
+    let _ = serde_json::to_writer(&mut stream, &response);
+    let _ = stream.flush();
+}
+
+fn read_control_request(stream: &mut TcpStream) -> Result<ControlWireRequest> {
+    let mut body = String::new();
+    stream
+        .take(CONTROL_REQUEST_LIMIT_BYTES)
+        .read_to_string(&mut body)
+        .context("failed to read control request")?;
+    serde_json::from_str(&body).context("invalid control request JSON")
+}
+
+fn new_token() -> Result<String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| anyhow!("failed to create agent API token: {error}"))?;
+    Ok(hex_encode(&bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(TABLE[(byte >> 4) as usize] as char);
+        output.push(TABLE[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+pub fn run_mcp_server() -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = line.context("failed to read MCP input")?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let response = handle_mcp_line(&line);
+        if let Some(response) = response {
+            writeln!(stdout, "{}", serde_json::to_string(&response)?)
+                .context("failed to write MCP response")?;
+            stdout.flush().context("failed to flush MCP response")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_mcp_line(line: &str) -> Option<Value> {
+    let value = match serde_json::from_str::<Value>(line) {
+        Ok(value) => value,
+        Err(error) => {
+            return Some(rpc_error(
+                Value::Null,
+                -32700,
+                format!("Parse error: {error}"),
+            ));
+        }
+    };
+
+    let id = value.get("id").cloned();
+    let Some(method) = value.get("method").and_then(Value::as_str) else {
+        return id.map(|id| rpc_error(id, -32600, "Invalid request"));
+    };
+
+    match method {
+        "notifications/initialized" => None,
+        "initialize" => id.map(|id| rpc_result(id, initialize_result())),
+        "ping" => id.map(|id| rpc_result(id, json!({}))),
+        "tools/list" => id.map(|id| rpc_result(id, tools_list_result())),
+        "tools/call" => id.map(|id| {
+            let params = value.get("params").cloned().unwrap_or_else(|| json!({}));
+            match handle_tool_call(params) {
+                Ok(result) => rpc_result(id, result),
+                Err(error) => rpc_error(id, -32602, format!("{error:#}")),
+            }
+        }),
+        _ => id.map(|id| rpc_error(id, -32601, format!("Method not found: {method}"))),
+    }
+}
+
+fn initialize_result() -> Value {
+    json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": {
+                "listChanged": false
+            }
+        },
+        "serverInfo": {
+            "name": "gridbash",
+            "title": "GridBash Agent Control",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "instructions": "Use these tools only against the current GridBash session. Mutating tools send input into live panes."
+    })
+}
+
+fn tools_list_result() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "gridbash_show_image",
+                "title": "Show Image",
+                "description": "Display a local image path as an overlay in the running GridBash session.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Local filesystem path to a png, jpg, gif, or webp image."
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Optional overlay title."
+                        }
+                    },
+                    "required": ["path"]
+                }
+            },
+            {
+                "name": "gridbash_send_command",
+                "title": "Send Command",
+                "description": "Send command text to one or more 1-based GridBash panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to receive the command.",
+                            "items": {
+                                "type": "integer",
+                                "minimum": 1
+                            },
+                            "minItems": 1
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "Text to write into each target pane."
+                        },
+                        "submit": {
+                            "type": "boolean",
+                            "description": "When true, append Enter after the command.",
+                            "default": true
+                        }
+                    },
+                    "required": ["panes", "command"]
+                }
+            },
+            {
+                "name": "gridbash_set_status",
+                "title": "Set Status",
+                "description": "Set the GridBash status bar text for the current session.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "message": {
+                            "type": "string",
+                            "description": "Short status message to show in the GridBash status bar."
+                        }
+                    },
+                    "required": ["message"]
+                }
+            }
+        ]
+    })
+}
+
+fn handle_tool_call(params: Value) -> Result<Value> {
+    let tool_name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing tool name"))?;
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    let command = tool_arguments_to_command(tool_name, arguments)?;
+    let response = call_gridbash_control(command)?;
+    Ok(tool_response(response.ok, response.message, response.data))
+}
+
+fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<ControlCommand> {
+    match tool_name {
+        "gridbash_show_image" => {
+            #[derive(Deserialize)]
+            struct Args {
+                path: PathBuf,
+                title: Option<String>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid image args")?;
+            Ok(ControlCommand::ShowImage {
+                path: absolute_tool_path(args.path)?,
+                title: args.title,
+            })
+        }
+        "gridbash_send_command" => {
+            #[derive(Deserialize)]
+            struct Args {
+                panes: Vec<usize>,
+                command: String,
+                submit: Option<bool>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid command args")?;
+            if args.panes.is_empty() {
+                return Err(anyhow!("at least one pane is required"));
+            }
+            Ok(ControlCommand::SendCommand {
+                panes: args.panes,
+                command: args.command,
+                submit: args.submit.unwrap_or(true),
+            })
+        }
+        "gridbash_set_status" => {
+            #[derive(Deserialize)]
+            struct Args {
+                message: String,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid status args")?;
+            Ok(ControlCommand::SetStatus {
+                message: args.message,
+            })
+        }
+        _ => Err(anyhow!("unknown GridBash tool: {tool_name}")),
+    }
+}
+
+fn absolute_tool_path(path: PathBuf) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path);
+    }
+
+    Ok(env::current_dir()
+        .context("failed to resolve MCP server current directory")?
+        .join(path))
+}
+
+fn call_gridbash_control(command: ControlCommand) -> Result<ControlResponse> {
+    let endpoint = env::var("GRIDBASH_CONTROL_ADDR")
+        .context("GRIDBASH_CONTROL_ADDR is not set; start GridBash with --agent-api")?;
+    let token = env::var("GRIDBASH_CONTROL_TOKEN")
+        .context("GRIDBASH_CONTROL_TOKEN is not set; start GridBash with --agent-api")?;
+    let mut stream = TcpStream::connect(&endpoint)
+        .with_context(|| format!("failed to connect to GridBash control API at {endpoint}"))?;
+    stream
+        .set_read_timeout(Some(CONTROL_READ_TIMEOUT))
+        .context("failed to set GridBash control read timeout")?;
+    stream
+        .set_write_timeout(Some(CONTROL_READ_TIMEOUT))
+        .context("failed to set GridBash control write timeout")?;
+
+    serde_json::to_writer(&mut stream, &json!({ "token": token, "command": command }))
+        .context("failed to send GridBash control request")?;
+    stream
+        .shutdown(Shutdown::Write)
+        .context("failed to finish GridBash control request")?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .context("failed to read GridBash control response")?;
+    serde_json::from_str(&response).context("invalid GridBash control response")
+}
+
+fn tool_response(ok: bool, message: String, data: Option<Value>) -> Value {
+    let text = if let Some(data) = data {
+        format!(
+            "{message}\n{}",
+            serde_json::to_string_pretty(&data).unwrap_or(data.to_string())
+        )
+    } else {
+        message
+    };
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "isError": !ok
+    })
+}
+
+fn rpc_result(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn rpc_error(id: Value, code: i64, message: impl Into<String>) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message.into()
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_lists_the_gridbash_control_tools() {
+        let response =
+            handle_mcp_line(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#).expect("response");
+        let names = response["result"]["tools"]
+            .as_array()
+            .expect("tools")
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("name"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                "gridbash_show_image",
+                "gridbash_send_command",
+                "gridbash_set_status"
+            ]
+        );
+    }
+
+    #[test]
+    fn send_command_defaults_to_submit() {
+        let command = tool_arguments_to_command(
+            "gridbash_send_command",
+            json!({
+                "panes": [2],
+                "command": "cargo test"
+            }),
+        )
+        .expect("command");
+
+        assert!(matches!(
+            command,
+            ControlCommand::SendCommand {
+                panes,
+                command,
+                submit: true
+            } if panes == vec![2] && command == "cargo test"
+        ));
+    }
+}

--- a/src/image_preview.rs
+++ b/src/image_preview.rs
@@ -1,0 +1,134 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use image::{GenericImageView, ImageReader, imageops::FilterType};
+
+const PREVIEW_BG: [u8; 3] = [11, 15, 20];
+
+#[derive(Debug, Clone)]
+pub struct ImagePreview {
+    pub title: String,
+    pub path: PathBuf,
+    pub source_width: u32,
+    pub source_height: u32,
+    pub cell_width: u16,
+    pub cell_height: u16,
+    pub rows: Vec<Vec<ImageCell>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageCell {
+    pub upper: [u8; 3],
+    pub lower: [u8; 3],
+}
+
+pub fn load_image_preview(
+    path: impl AsRef<Path>,
+    title: Option<String>,
+    max_cell_width: u16,
+    max_cell_height: u16,
+) -> Result<ImagePreview> {
+    let path = path.as_ref();
+    let image = ImageReader::open(path)
+        .with_context(|| format!("failed to open image {}", path.display()))?
+        .with_guessed_format()
+        .context("failed to detect image format")?
+        .decode()
+        .with_context(|| format!("failed to decode image {}", path.display()))?;
+    let (source_width, source_height) = image.dimensions();
+    if source_width == 0 || source_height == 0 {
+        return Err(anyhow!("image has no pixels"));
+    }
+
+    let max_pixel_width = u32::from(max_cell_width.max(1));
+    let max_pixel_height = u32::from(max_cell_height.max(1)) * 2;
+    let (target_width, target_height) = fit_dimensions(
+        source_width,
+        source_height,
+        max_pixel_width,
+        max_pixel_height,
+    );
+    let resized = image
+        .resize_exact(target_width, target_height, FilterType::Triangle)
+        .to_rgba8();
+
+    let cell_width = target_width as u16;
+    let cell_height = target_height.div_ceil(2) as u16;
+    let mut rows = Vec::with_capacity(cell_height as usize);
+    for cell_y in 0..cell_height {
+        let upper_y = u32::from(cell_y) * 2;
+        let lower_y = (upper_y + 1).min(target_height - 1);
+        let mut row = Vec::with_capacity(cell_width as usize);
+        for x in 0..target_width {
+            row.push(ImageCell {
+                upper: composite_rgba(resized.get_pixel(x, upper_y).0),
+                lower: composite_rgba(resized.get_pixel(x, lower_y).0),
+            });
+        }
+        rows.push(row);
+    }
+
+    let title = title
+        .and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .or_else(|| {
+            path.file_name()
+                .and_then(|value| value.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "image".into());
+
+    Ok(ImagePreview {
+        title,
+        path: path.to_path_buf(),
+        source_width,
+        source_height,
+        cell_width,
+        cell_height,
+        rows,
+    })
+}
+
+fn fit_dimensions(width: u32, height: u32, max_width: u32, max_height: u32) -> (u32, u32) {
+    let width_scale = max_width as f64 / width as f64;
+    let height_scale = max_height as f64 / height as f64;
+    let scale = width_scale.min(height_scale).clamp(0.01, 1.0);
+    let target_width = ((width as f64) * scale).round().max(1.0) as u32;
+    let target_height = ((height as f64) * scale).round().max(1.0) as u32;
+    (
+        target_width.min(max_width.max(1)),
+        target_height.min(max_height.max(1)),
+    )
+}
+
+fn composite_rgba(pixel: [u8; 4]) -> [u8; 3] {
+    let alpha = pixel[3] as u16;
+    [
+        blend_channel(pixel[0], PREVIEW_BG[0], alpha),
+        blend_channel(pixel[1], PREVIEW_BG[1], alpha),
+        blend_channel(pixel[2], PREVIEW_BG[2], alpha),
+    ]
+}
+
+fn blend_channel(fg: u8, bg: u8, alpha: u16) -> u8 {
+    (((fg as u16 * alpha) + (bg as u16 * (255 - alpha))) / 255) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_dimensions_preserves_aspect_ratio_inside_cell_budget() {
+        assert_eq!(fit_dimensions(400, 200, 100, 60), (100, 50));
+        assert_eq!(fit_dimensions(200, 400, 100, 60), (30, 60));
+    }
+
+    #[test]
+    fn transparent_pixels_blend_against_preview_background() {
+        assert_eq!(composite_rgba([255, 0, 0, 0]), PREVIEW_BG);
+        assert_eq!(composite_rgba([255, 0, 0, 255]), [255, 0, 0]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ mod app;
 mod cli;
 mod composer;
 mod config;
+mod control;
+mod image_preview;
 mod layout;
 mod onboarding;
 mod profiles;
@@ -25,6 +27,11 @@ use crate::{
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if cli.mcp {
+        return control::run_mcp_server();
+    }
+
     let mut config = Config::load(cli.config.as_deref())?;
 
     if let Some(profile) = cli.set_default_profile.as_deref() {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -54,6 +54,7 @@ impl PtyPane {
         command: &Path,
         args: &[String],
         cwd: &Path,
+        extra_env: &[(String, String)],
         event_tx: mpsc::UnboundedSender<PtyEvent>,
     ) -> Result<Self> {
         let pty_system = native_pty_system();
@@ -73,6 +74,9 @@ impl PtyPane {
         command_builder.cwd(cwd);
         command_builder.env("TERM", "xterm-256color");
         command_builder.env("COLORTERM", "truecolor");
+        for (key, value) in extra_env {
+            command_builder.env(key, value);
+        }
 
         let child = pair
             .slave
@@ -315,6 +319,7 @@ mod tests {
                 "set /p GRIDBASH_IN= & echo GRIDBASH_READY:!GRIDBASH_IN!".to_string(),
             ],
             &cwd,
+            &[],
             event_tx,
         )
         .expect("spawn cmd pty");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,7 +8,10 @@ use ratatui::{
 use std::path::Path;
 use vt100::Cell;
 
-use crate::app::{App, PaneSelection, RenamePaneView, SettingsRow};
+use crate::{
+    app::{App, PaneSelection, RenamePaneView, SettingsRow},
+    image_preview::ImagePreview,
+};
 
 const APP_BG: Color = Color::Rgb(11, 15, 20);
 const SETTINGS_BG: Color = Color::Rgb(9, 14, 19);
@@ -35,7 +38,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let status_area = chunks[1];
     let rects = app.pane_rects(grid_area);
     let rename_view = app.rename_pane_view();
-    let modal_open = app.settings_open() || rename_view.is_some();
+    let image_overlay = app.image_overlay_view();
+    let modal_open = app.settings_open() || rename_view.is_some() || image_overlay.is_some();
 
     for (index, pane) in app.panes().iter().enumerate() {
         let Some(rect) = rects.get(index).copied() else {
@@ -128,6 +132,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
     if let Some(rename) = rename_view.as_ref() {
         render_rename_pane(frame, area, rename);
+    }
+    if let Some(image) = image_overlay {
+        render_image_overlay(frame, area, image);
     }
 
     DrawState {
@@ -307,6 +314,106 @@ fn render_rename_pane(frame: &mut Frame<'_>, area: Rect, rename: &RenamePaneView
             .x
             .saturating_add(cursor.min(input_inner.width.saturating_sub(1)));
         frame.set_cursor_position((x, input_inner.y));
+    }
+}
+
+fn render_image_overlay(frame: &mut Frame<'_>, area: Rect, image: &ImagePreview) {
+    let modal = image_modal_rect(area, image);
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(Style::default().fg(SETTINGS_TEXT).bg(APP_BG))
+        .title(format!(" Image | {} ", truncate_text(&image.title, 48)));
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let mut lines = Vec::new();
+    lines.push(image_meta_line(image, inner.width));
+    lines.push(Line::from(""));
+
+    let available_image_rows = inner.height.saturating_sub(4) as usize;
+    let max_columns = inner.width as usize;
+    for row in image.rows.iter().take(available_image_rows) {
+        lines.push(image_row(row, max_columns));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        command_key("Esc"),
+        Span::styled(" close  ", Style::default().fg(Color::Gray)),
+        command_key("q"),
+        Span::styled(" close", Style::default().fg(Color::Gray)),
+    ]));
+
+    frame.render_widget(
+        Paragraph::new(lines).style(Style::default().fg(SETTINGS_TEXT).bg(APP_BG)),
+        inner,
+    );
+}
+
+fn image_meta_line(image: &ImagePreview, width: u16) -> Line<'static> {
+    let text = format!(
+        "{}x{} -> {}x{} cells | {}",
+        image.source_width,
+        image.source_height,
+        image.cell_width,
+        image.cell_height,
+        image.path.display()
+    );
+
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            truncate_text(&text, width.saturating_sub(2) as usize),
+            Style::default().fg(Color::Gray),
+        ),
+    ])
+}
+
+fn image_row(row: &[crate::image_preview::ImageCell], max_columns: usize) -> Line<'static> {
+    let spans = row
+        .iter()
+        .take(max_columns)
+        .map(|cell| {
+            Span::styled(
+                "▀",
+                Style::default()
+                    .fg(rgb(cell.upper))
+                    .bg(rgb(cell.lower))
+                    .add_modifier(Modifier::BOLD),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    Line::from(spans)
+}
+
+fn rgb(value: [u8; 3]) -> Color {
+    Color::Rgb(value[0], value[1], value[2])
+}
+
+fn image_modal_rect(area: Rect, image: &ImagePreview) -> Rect {
+    let desired_width = image.cell_width.saturating_add(4).clamp(36, 92);
+    let desired_height = image.cell_height.saturating_add(6).clamp(10, 34);
+    let width = area.width.saturating_sub(4).min(desired_width).max(1);
+    let height = area.height.saturating_sub(2).min(desired_height).max(1);
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
     }
 }
 


### PR DESCRIPTION
Closes #70

## Summary
- add opt-in GridBash agent control API behind --agent-api
- add stdio MCP mode with image, pane command, and status tools
- render local images inside GridBash as truecolor terminal-cell overlays
- document the setup and add a devlog

## Validation
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- MCP stdio smoke test for initialize and tools/list
- cargo run --quiet -- --help