### PR TITLE
fix: restart exited terminal panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
 | Alt+r | Rename the focused pane |
+| Alt+t | Restart exited focused pane; when multiple panes are selected, restart exited selected panes |
 | Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |
 | Hover sleeping pane | Wake the pane and make its terminal contents visible again |
 | Alt+o | Open sample settings |

--- a/docs/devlogs/2026-07-07-restart-exited-terminal-panes.md
+++ b/docs/devlogs/2026-07-07-restart-exited-terminal-panes.md
@@ -1,0 +1,30 @@
+# Restart exited terminal panes
+
+Date: 2026-07-07
+Release target: unreleased
+
+## Summary
+
+- Added an in-app recovery path for panes whose terminal process has exited.
+- Tracks #79.
+
+## What Changed
+
+- Added `Alt+t` to restart exited focused panes, or exited selected panes when multiple panes are selected.
+- Respawned panes reuse their original launch spec, cwd, profile, and worktree metadata.
+- Typing into an exited pane now shows a restart hint instead of trying to write into a dead PTY.
+- Updated the in-app footer/status hints and README controls table.
+
+## Why It Matters
+
+- When an agent exits after noisy Windows cleanup output, the pane previously looked like a broken terminal with no recovery action.
+- Users can now revive the pane in place without rebuilding the whole GridBash session.
+
+## Validation
+
+- Added targeted unit coverage for selecting only exited panes as restart candidates.
+- Ran `cargo test`.
+
+## Release Notes
+
+- New recovery shortcut: press `Alt+t` to restart exited terminal panes.

--- a/src/app.rs
+++ b/src/app.rs
@@ -427,10 +427,10 @@ impl App {
             settings: SettingsState::default(),
             rename: RenamePaneState::default(),
             status: if mouse_enabled {
-                "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
+                "Drag copies | Alt+arrows move | Alt+Shift+arrows resize | Alt+r rename | Alt+t restart | Alt+x swap | Alt+z sleep"
                     .into()
             } else {
-                "Alt+arrows move | Alt+Shift+arrows resize | Alt+s select | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+o settings"
+                "Alt+arrows move | Alt+Shift+arrows resize | Alt+s select | Alt+r rename | Alt+t restart | Alt+x swap | Alt+z sleep"
                     .into()
             },
             next_pane_id: 0,
@@ -507,19 +507,23 @@ impl App {
     }
 
     fn spawn_pane_spec(&mut self, spec: &PaneLaunchSpec) -> Result<()> {
+        let pane = self.spawn_pane_instance(spec)?;
+        self.panes.push(pane);
+        Ok(())
+    }
+
+    fn spawn_pane_instance(&mut self, spec: &PaneLaunchSpec) -> Result<PtyPane> {
         let launch = spec.resolved_command()?;
         let id = PaneId(self.next_pane_id);
         self.next_pane_id += 1;
-        let pane = PtyPane::spawn(
+        PtyPane::spawn(
             id,
             0,
             &launch.command,
             &launch.args,
             &spec.cwd,
             self.event_tx.clone(),
-        )?;
-        self.panes.push(pane);
-        Ok(())
+        )
     }
 
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
@@ -695,8 +699,14 @@ impl App {
         }
 
         if let Some(bytes) = terminal_key_bytes(key) {
-            self.route_input(&bytes)?;
+            let status_changed = self.route_input(&bytes)?;
+            return Ok(if selection_cleared || status_changed {
+                KeyOutcome::Render
+            } else {
+                KeyOutcome::Continue
+            });
         }
+
         Ok(if selection_cleared {
             KeyOutcome::Render
         } else {
@@ -767,6 +777,10 @@ impl App {
             }
             'z' => {
                 self.toggle_sleep_for_targets();
+                Ok(Some(false))
+            }
+            't' => {
+                self.restart_exited_targets();
                 Ok(Some(false))
             }
             'x' => {
@@ -1303,15 +1317,35 @@ impl App {
         self.status = format!("{} {} {}", action, targets.len(), pane_word(targets.len()));
     }
 
-    fn route_input(&mut self, bytes: &[u8]) -> Result<()> {
+    fn route_input(&mut self, bytes: &[u8]) -> Result<bool> {
         let targets = self.input_targets();
+        let mut skipped_exited = 0;
+
         for index in targets {
-            self.panes
+            let pane = self
+                .panes
                 .get(index)
-                .ok_or_else(|| anyhow!("invalid pane index {index}"))?
-                .write(bytes)?;
+                .ok_or_else(|| anyhow!("invalid pane index {index}"))?;
+            if pane.exited {
+                skipped_exited += 1;
+                continue;
+            }
+            pane.write(bytes)?;
         }
-        Ok(())
+
+        if skipped_exited > 0 {
+            self.status = if skipped_exited == 1 {
+                "pane exited; press Alt+t to restart it".into()
+            } else {
+                format!(
+                    "skipped {skipped_exited} exited {}; press Alt+t to restart them",
+                    pane_word(skipped_exited)
+                )
+            };
+            return Ok(true);
+        }
+
+        Ok(false)
     }
 
     fn input_targets(&self) -> Vec<usize> {
@@ -1320,6 +1354,62 @@ impl App {
 
     fn target_panes(&self) -> Vec<usize> {
         input_targets_for(self.focus, &self.selected, self.panes.len())
+    }
+
+    fn restart_exited_targets(&mut self) {
+        let targets = self.target_panes();
+        if targets.is_empty() {
+            self.status = "no panes to restart".into();
+            return;
+        }
+
+        let exited = self
+            .panes
+            .iter()
+            .map(|pane| pane.exited)
+            .collect::<Vec<_>>();
+        let restart = restart_targets_for(&targets, &exited);
+        if restart.indices.is_empty() {
+            self.status = "no exited target panes; Alt+t restarts exited panes".into();
+            return;
+        }
+
+        let Some(plan) = self.launch_plan.as_ref() else {
+            self.status = "cannot restart panes without a launch plan".into();
+            return;
+        };
+        let specs = restart
+            .indices
+            .iter()
+            .filter_map(|index| plan.panes.get(*index).cloned().map(|spec| (*index, spec)))
+            .collect::<Vec<_>>();
+
+        let mut restarted = 0;
+        for (index, spec) in specs {
+            let pane = match self.spawn_pane_instance(&spec) {
+                Ok(pane) => pane,
+                Err(error) => {
+                    self.status = format!("restart failed for pane {}: {error:#}", index + 1);
+                    return;
+                }
+            };
+
+            self.panes[index] = pane;
+            self.sleeping.remove(&index);
+            restarted += 1;
+        }
+
+        self.sync_pane_sizes();
+        self.status = if restart.running > 0 {
+            format!(
+                "restarted {restarted} {}; skipped {} running {}",
+                pane_word(restarted),
+                restart.running,
+                pane_word(restart.running)
+            )
+        } else {
+            format!("restarted {restarted} {}", pane_word(restarted))
+        };
     }
 
     fn focus_next(&mut self) {
@@ -1623,6 +1713,27 @@ fn input_targets_for(focus: usize, selected: &BTreeSet<usize>, pane_count: usize
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct RestartTargets {
+    indices: Vec<usize>,
+    running: usize,
+}
+
+fn restart_targets_for(targets: &[usize], exited: &[bool]) -> RestartTargets {
+    let mut indices = Vec::new();
+    let mut running = 0;
+
+    for index in targets {
+        match exited.get(*index) {
+            Some(true) => indices.push(*index),
+            Some(false) => running += 1,
+            None => {}
+        }
+    }
+
+    RestartTargets { indices, running }
+}
+
 fn normalized_pane_name(value: &str) -> Option<String> {
     let name = value
         .trim()
@@ -1912,6 +2023,28 @@ mod tests {
     fn input_targets_clamps_focus_to_available_panes() {
         assert_eq!(input_targets_for(8, &selected(&[]), 4), vec![3]);
         assert!(input_targets_for(0, &selected(&[]), 0).is_empty());
+    }
+
+    #[test]
+    fn restart_targets_include_only_exited_panes() {
+        assert_eq!(
+            restart_targets_for(&[0, 1, 2], &[true, false, true]),
+            RestartTargets {
+                indices: vec![0, 2],
+                running: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn restart_targets_ignore_invalid_indices() {
+        assert_eq!(
+            restart_targets_for(&[1, 4], &[false, true]),
+            RestartTargets {
+                indices: vec![1],
+                running: 0,
+            }
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -116,7 +116,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(format!("{} selected", app.selected().len())),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
-        Span::raw(" | Alt+x swap | Alt+z sleep | hover wakes | Alt+q quit"),
+        Span::raw(" | Alt+t restart | Alt+x swap | Alt+z sleep | Alt+q quit"),
     ]);
     frame.render_widget(
         Paragraph::new(status).style(Style::default().bg(APP_BG)),


### PR DESCRIPTION
## Summary
- Add Alt+t to restart exited focused panes or exited selected panes in place.
- Reuse each pane's original launch spec, cwd, profile, and worktree metadata when respawning.
- Show a restart hint when typing into an exited pane instead of writing into a dead PTY.
- Update README controls and devlog.

Fixes #79.

## Validation
- cargo test