### PR TITLE
Fix exited pane recovery dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+o | Open settings |
 | Alt+q | Quit |
 
+When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter`,
+`r`, or `t` to restart it, or press `z` to put it to sleep. `Alt+t` still restarts
+exited target panes directly when your terminal reports Alt shortcuts as modified
+key events.
+
 Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.

--- a/docs/devlogs/2026-07-09-fix-exited-pane-recovery-dialog.md
+++ b/docs/devlogs/2026-07-09-fix-exited-pane-recovery-dialog.md
@@ -1,0 +1,32 @@
+# Fix exited pane recovery dialog
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added an obvious in-app recovery dialog for focused panes whose terminal process has exited.
+
+## What Changed
+
+- Focused exited panes now show a modal with restart and sleep actions when no other modal is open.
+- Pressing `Enter`, `r`, or `t` in the dialog restarts the focused exited pane.
+- Pressing `z` or `s` in the dialog puts the focused exited pane to sleep.
+- The dialog holds a leading `Esc` key so terminals that encode `Alt+t` as `Esc` then `t` can still restart an exited focused pane.
+- Updated README controls to document the recovery dialog.
+
+## Why It Matters
+
+- Exited panes no longer rely on a hidden shortcut or status bar hint for recovery.
+- The restart path now works in the common terminal encoding where Alt shortcuts arrive as an escape-prefixed character sequence.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+
+## Release Notes
+
+- Exited panes now show a restart/sleep recovery dialog when focused.

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,6 +161,13 @@ enum SwapSelection {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitedRecoveryAction {
+    Restart,
+    Sleep,
+    HoldAltPrefix,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PaletteRole {
     Accent,
     Focus,
@@ -344,6 +351,12 @@ pub struct RenamePaneView {
     pub pane_label: String,
     pub value: String,
     pub cursor: usize,
+}
+
+pub struct ExitedPaneRecoveryView {
+    pub pane_index: usize,
+    pub pane_label: String,
+    pub target_count: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1082,6 +1095,12 @@ impl App {
             });
         }
 
+        if self.exited_recovery_view().is_some()
+            && let Some(outcome) = self.handle_exited_recovery_key(key)
+        {
+            return Ok(outcome);
+        }
+
         if let Some(bytes) = terminal_key_bytes(key) {
             let status_changed = self.route_input(&bytes)?;
             return Ok(if selection_cleared || status_changed {
@@ -1196,6 +1215,20 @@ impl App {
                 Ok(Some(false))
             }
             _ => Ok(None),
+        }
+    }
+
+    fn handle_exited_recovery_key(&mut self, key: KeyEvent) -> Option<KeyOutcome> {
+        match exited_recovery_action_for(key)? {
+            ExitedRecoveryAction::Restart => {
+                self.restart_focused_exited_pane();
+                Some(KeyOutcome::Render)
+            }
+            ExitedRecoveryAction::Sleep => {
+                self.toggle_sleep_for_focused_pane();
+                Some(KeyOutcome::Render)
+            }
+            ExitedRecoveryAction::HoldAltPrefix => Some(KeyOutcome::Render),
         }
     }
 
@@ -1689,13 +1722,17 @@ impl App {
 
     fn toggle_sleep_for_targets(&mut self) {
         let targets = self.target_panes();
+        self.toggle_sleep_for_panes(&targets);
+    }
+
+    fn toggle_sleep_for_panes(&mut self, targets: &[usize]) {
         if targets.is_empty() {
             return;
         }
 
         let should_sleep = targets.iter().any(|index| !self.sleeping.contains(index));
         if should_sleep {
-            for index in &targets {
+            for index in targets {
                 self.sleeping.insert(*index);
                 self.selected.remove(index);
             }
@@ -1706,7 +1743,7 @@ impl App {
                 self.focus = index;
             }
         } else {
-            for index in &targets {
+            for index in targets {
                 self.sleeping.remove(index);
             }
             self.focus = targets[0];
@@ -1734,7 +1771,7 @@ impl App {
 
         if skipped_exited > 0 {
             self.status = if skipped_exited == 1 {
-                "pane exited; press Alt+t to restart it".into()
+                "pane exited; press R or Enter to restart, Z to sleep".into()
             } else {
                 format!(
                     "skipped {skipped_exited} exited {}; press Alt+t to restart them",
@@ -1755,8 +1792,32 @@ impl App {
         input_targets_for(self.focus, &self.selected, self.panes.len())
     }
 
+    fn toggle_sleep_for_focused_pane(&mut self) {
+        if self.panes.is_empty() {
+            self.status = "no panes to sleep".into();
+            return;
+        }
+
+        let target = self.focus.min(self.panes.len() - 1);
+        self.toggle_sleep_for_panes(&[target]);
+    }
+
+    fn restart_focused_exited_pane(&mut self) {
+        if self.panes.is_empty() {
+            self.status = "no panes to restart".into();
+            return;
+        }
+
+        let target = self.focus.min(self.panes.len() - 1);
+        self.restart_exited_panes(&[target]);
+    }
+
     fn restart_exited_targets(&mut self) {
         let targets = self.target_panes();
+        self.restart_exited_panes(&targets);
+    }
+
+    fn restart_exited_panes(&mut self, targets: &[usize]) {
         if targets.is_empty() {
             self.status = "no panes to restart".into();
             return;
@@ -1767,7 +1828,7 @@ impl App {
             .iter()
             .map(|pane| pane.exited)
             .collect::<Vec<_>>();
-        let restart = restart_targets_for(&targets, &exited);
+        let restart = restart_targets_for(targets, &exited);
         if restart.indices.is_empty() {
             self.status = "no exited target panes; Alt+t restarts exited panes".into();
             return;
@@ -1901,6 +1962,19 @@ impl App {
 
     pub fn image_overlay_view(&self) -> Option<&ImagePreview> {
         self.image_overlay.as_ref()
+    }
+
+    pub fn exited_recovery_view(&self) -> Option<ExitedPaneRecoveryView> {
+        let pane = self.panes.get(self.focus)?;
+        if !pane.exited || self.sleeping.contains(&self.focus) {
+            return None;
+        }
+
+        Some(ExitedPaneRecoveryView {
+            pane_index: self.focus,
+            pane_label: self.pane_label(self.focus),
+            target_count: 1,
+        })
     }
 
     pub fn settings_rows(&self) -> Vec<SettingsRow> {
@@ -2143,6 +2217,23 @@ fn restart_targets_for(targets: &[usize], exited: &[bool]) -> RestartTargets {
     }
 
     RestartTargets { indices, running }
+}
+
+fn exited_recovery_action_for(key: KeyEvent) -> Option<ExitedRecoveryAction> {
+    if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) {
+        return None;
+    }
+
+    match key.code {
+        KeyCode::Enter => Some(ExitedRecoveryAction::Restart),
+        KeyCode::Esc => Some(ExitedRecoveryAction::HoldAltPrefix),
+        KeyCode::Char(ch) => match ch.to_ascii_lowercase() {
+            'r' | 't' => Some(ExitedRecoveryAction::Restart),
+            's' | 'z' => Some(ExitedRecoveryAction::Sleep),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn normalized_pane_name(value: &str) -> Option<String> {
@@ -2463,6 +2554,42 @@ mod tests {
                 indices: vec![1],
                 running: 0,
             }
+        );
+    }
+
+    #[test]
+    fn exited_recovery_keys_map_to_dialog_actions() {
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::Restart)
+        );
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::Restart)
+        );
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::Restart)
+        );
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::Sleep)
+        );
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::Sleep)
+        );
+    }
+
+    #[test]
+    fn exited_recovery_keeps_escape_for_alt_prefixes() {
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            Some(ExitedRecoveryAction::HoldAltPrefix)
+        );
+        assert_eq!(
+            exited_recovery_action_for(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT)),
+            None
         );
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use vt100::Cell;
 
 use crate::{
-    app::{App, GridPalette, PaneSelection, RenamePaneView, SettingsRow},
+    app::{App, ExitedPaneRecoveryView, GridPalette, PaneSelection, RenamePaneView, SettingsRow},
     image_preview::ImagePreview,
 };
 
@@ -42,7 +42,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let palette = app.palette();
     let rename_view = app.rename_pane_view();
     let image_overlay = app.image_overlay_view();
-    let modal_open = app.settings_open() || rename_view.is_some() || image_overlay.is_some();
+    let exited_recovery = if app.settings_open() || rename_view.is_some() || image_overlay.is_some()
+    {
+        None
+    } else {
+        app.exited_recovery_view()
+    };
+    let modal_open = app.settings_open()
+        || rename_view.is_some()
+        || image_overlay.is_some()
+        || exited_recovery.is_some();
 
     for (index, pane) in app.panes().iter().enumerate() {
         let Some(rect) = rects.get(index).copied() else {
@@ -148,6 +157,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
     if let Some(image) = image_overlay {
         render_image_overlay(frame, area, image);
+    }
+    if let Some(recovery) = exited_recovery.as_ref() {
+        render_exited_recovery(frame, area, recovery, palette);
     }
 
     DrawState {
@@ -343,6 +355,70 @@ fn render_rename_pane(frame: &mut Frame<'_>, area: Rect, rename: &RenamePaneView
             .saturating_add(cursor.min(input_inner.width.saturating_sub(1)));
         frame.set_cursor_position((x, input_inner.y));
     }
+}
+
+fn render_exited_recovery(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    recovery: &ExitedPaneRecoveryView,
+    palette: &GridPalette,
+) {
+    let modal = exited_recovery_modal_rect(area);
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.exited())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(Style::default().fg(SETTINGS_TEXT).bg(APP_BG))
+        .title(format!(" Pane {} Exited ", recovery.pane_index + 1));
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let target = if recovery.target_count == 1 {
+        format!(
+            "Pane {} ({}) is no longer running.",
+            recovery.pane_index + 1,
+            recovery.pane_label
+        )
+    } else {
+        format!("{} panes are no longer running.", recovery.target_count)
+    };
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                truncate_text(&target, inner.width.saturating_sub(2) as usize),
+                Style::default()
+                    .fg(Color::LightRed)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" restart  ", Style::default().fg(Color::Gray)),
+            command_key("r/t"),
+            Span::styled(" restart  ", Style::default().fg(Color::Gray)),
+            command_key("z"),
+            Span::styled(" sleep", Style::default().fg(Color::Gray)),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
+            command_key("Alt+arrows"),
+            Span::styled(" focus another pane", Style::default().fg(Color::Gray)),
+        ]),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(lines).style(Style::default().fg(SETTINGS_TEXT).bg(APP_BG)),
+        inner,
+    );
 }
 
 fn render_image_overlay(frame: &mut Frame<'_>, area: Rect, image: &ImagePreview) {
@@ -732,6 +808,18 @@ fn settings_modal_rect(area: Rect, row_count: usize) -> Rect {
         .saturating_sub(2)
         .min(desired_height)
         .max(area.height.min(1));
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn exited_recovery_modal_rect(area: Rect) -> Rect {
+    let width = area.width.saturating_sub(4).min(62).max(area.width.min(1));
+    let height = area.height.saturating_sub(2).min(9).max(area.height.min(1));
 
     Rect {
         x: area.x + area.width.saturating_sub(width) / 2,


### PR DESCRIPTION
## Summary
- Add a focused exited-pane recovery dialog with restart and sleep actions.
- Let Esc-prefixed Alt+t recover an exited focused pane by holding the escape prefix in the dialog.
- Document the recovery path and add a devlog entry.

## Validation
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- cargo build --release

Fixes #89