### PR TITLE
Add previous panes list

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+Shift+Left / Alt+Shift+Right | Remove / add a column when safe |
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
+| Alt+p | Open the previous panes list and focus a pane from its conversation summary |
 | Alt+r | Rename the focused pane |
 | Alt+t | Restart exited focused pane; when multiple panes are selected, restart exited selected panes |
 | Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |

--- a/docs/devlogs/2026-07-09-add-previous-panes-list-button.md
+++ b/docs/devlogs/2026-07-09-add-previous-panes-list-button.md
@@ -1,0 +1,28 @@
+# Add previous panes list button
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added a status-bar Panes button that opens a Codex-style list of current pane conversations.
+
+## What Changed
+
+- Added `Alt+p` and a clickable `Panes` status-bar control.
+- Added a Previous Panes modal with pane labels, state, folder/worktree context, and the latest visible conversation summary.
+- Let users move through the list with arrows and focus a pane with Enter, Space, or a row click.
+
+## Why It Matters
+
+- Dense GridBash sessions are easier to navigate because users can jump by conversation context instead of scanning every pane manually.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test`
+- `cargo clippy -- -D warnings`
+
+## Release Notes
+
+- Added a previous panes list button and `Alt+p` selector for focusing panes by their conversation summary.

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,8 +62,11 @@ pub struct App {
     image_overlay: Option<ImagePreview>,
     settings: SettingsState,
     rename: RenamePaneState,
+    previous_panes: PreviousPanesState,
     status: String,
     next_pane_id: usize,
+    previous_panes_button: Option<Rect>,
+    previous_pane_rows: Vec<(usize, Rect)>,
     event_tx: mpsc::UnboundedSender<PtyEvent>,
     event_rx: mpsc::UnboundedReceiver<PtyEvent>,
     usage_tx: std_mpsc::Sender<UsageEvent>,
@@ -344,6 +347,59 @@ pub struct RenamePaneView {
     pub pane_label: String,
     pub value: String,
     pub cursor: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreviousPanesView {
+    pub cursor: usize,
+    pub panes: Vec<PreviousPaneView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreviousPaneView {
+    pub index: usize,
+    pub label: String,
+    pub folder: String,
+    pub worktree: Option<String>,
+    pub summary: String,
+    pub focused: bool,
+    pub selected: bool,
+    pub sleeping: bool,
+    pub exited: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PreviousPanesState {
+    open: bool,
+    cursor: usize,
+}
+
+impl PreviousPanesState {
+    fn begin(&mut self, focus: usize, pane_count: usize) {
+        self.open = true;
+        self.cursor = focus.min(pane_count.saturating_sub(1));
+    }
+
+    fn close(&mut self) {
+        self.open = false;
+    }
+
+    fn move_cursor(&mut self, delta: isize, pane_count: usize) {
+        if pane_count == 0 {
+            self.cursor = 0;
+            return;
+        }
+
+        self.cursor = (self.cursor as isize + delta).clamp(0, pane_count as isize - 1) as usize;
+    }
+
+    fn move_to_start(&mut self) {
+        self.cursor = 0;
+    }
+
+    fn move_to_end(&mut self, pane_count: usize) {
+        self.cursor = pane_count.saturating_sub(1);
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -659,8 +715,11 @@ impl App {
             image_overlay: None,
             settings: SettingsState::default(),
             rename: RenamePaneState::default(),
+            previous_panes: PreviousPanesState::default(),
             status,
             next_pane_id: 0,
+            previous_panes_button: None,
+            previous_pane_rows: Vec::new(),
             event_tx,
             event_rx,
             usage_tx,
@@ -786,6 +845,8 @@ impl App {
                     let draw_state = ui::draw(frame, self);
                     self.grid_area = draw_state.grid_area;
                     self.rects = draw_state.pane_rects;
+                    self.previous_panes_button = draw_state.previous_panes_button;
+                    self.previous_pane_rows = draw_state.previous_pane_rows;
                 })?;
                 self.sync_pane_sizes();
                 needs_render = false;
@@ -806,7 +867,11 @@ impl App {
                         self.rename.insert_text(&text);
                         needs_render = true;
                     }
-                    Event::Paste(text) if !self.settings.open => {
+                    Event::Paste(text)
+                        if !self.settings.open
+                            && !self.previous_panes.open
+                            && self.image_overlay.is_none() =>
+                    {
                         self.route_input(text.as_bytes())?;
                     }
                     Event::Mouse(mouse)
@@ -1067,6 +1132,11 @@ impl App {
 
         let selection_cleared = self.clear_text_selection();
 
+        if self.previous_panes.open {
+            let outcome = self.handle_previous_panes_key(key);
+            return Ok(render_if_selection_cleared(outcome, selection_cleared));
+        }
+
         if self.settings.open {
             let outcome = self.handle_settings_key(key)?;
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
@@ -1190,6 +1260,10 @@ impl App {
                 self.status = "settings open".into();
                 Ok(Some(false))
             }
+            'p' => {
+                self.open_previous_panes();
+                Ok(Some(false))
+            }
             'r' => {
                 self.begin_rename();
                 Ok(Some(false))
@@ -1211,6 +1285,84 @@ impl App {
             .and_then(|name| name.clone());
         self.rename.begin(pane_index, current_name.as_deref());
         self.status = format!("renaming pane {}", pane_index + 1);
+    }
+
+    fn open_previous_panes(&mut self) {
+        if self.panes.is_empty() {
+            self.status = "no panes to list".into();
+            return;
+        }
+
+        self.previous_panes.begin(self.focus, self.panes.len());
+        self.status = "previous panes open".into();
+    }
+
+    fn close_previous_panes(&mut self) {
+        self.previous_panes.close();
+        self.status = "previous panes closed".into();
+    }
+
+    fn handle_previous_panes_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return KeyOutcome::Quit;
+        }
+        if key.modifiers.contains(KeyModifiers::ALT)
+            && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
+        {
+            self.close_previous_panes();
+            return KeyOutcome::Render;
+        }
+
+        let changed = match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.close_previous_panes();
+                true
+            }
+            KeyCode::Up => {
+                self.previous_panes.move_cursor(-1, self.panes.len());
+                true
+            }
+            KeyCode::Down => {
+                self.previous_panes.move_cursor(1, self.panes.len());
+                true
+            }
+            KeyCode::Home => {
+                self.previous_panes.move_to_start();
+                true
+            }
+            KeyCode::End => {
+                self.previous_panes.move_to_end(self.panes.len());
+                true
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.focus_previous_pane_entry(self.previous_panes.cursor);
+                true
+            }
+            _ => false,
+        };
+
+        if changed {
+            KeyOutcome::Render
+        } else {
+            KeyOutcome::Continue
+        }
+    }
+
+    fn focus_previous_pane_entry(&mut self, index: usize) {
+        if index >= self.panes.len() {
+            self.previous_panes.close();
+            self.status = format!("pane {} is no longer available", index + 1);
+            return;
+        }
+
+        self.focus = index;
+        let woke = self.sleeping.remove(&index);
+        self.previous_panes.close();
+        self.status = if woke {
+            format!("woke pane {}", index + 1)
+        } else {
+            format!("focused pane {}", index + 1)
+        };
     }
 
     fn handle_rename_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -1395,6 +1547,26 @@ impl App {
             return Ok(false);
         }
 
+        if self.mouse_enabled
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && self.previous_panes_button_at(mouse.column, mouse.row)
+        {
+            if self.previous_panes.open {
+                self.close_previous_panes();
+            } else {
+                self.open_previous_panes();
+            }
+            return Ok(true);
+        }
+
+        if self.previous_panes.open {
+            return Ok(if self.mouse_enabled {
+                self.handle_previous_panes_mouse(mouse)
+            } else {
+                false
+            });
+        }
+
         if let Some(index) = pane_at(&self.rects, mouse.column, mouse.row)
             && self.sleeping.remove(&index)
         {
@@ -1449,6 +1621,31 @@ impl App {
         }
 
         Ok(false)
+    }
+
+    fn handle_previous_panes_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+
+        let Some(index) = self.previous_pane_row_at(mouse.column, mouse.row) else {
+            return false;
+        };
+
+        self.previous_panes.cursor = index;
+        self.focus_previous_pane_entry(index);
+        true
+    }
+
+    fn previous_panes_button_at(&self, x: u16, y: u16) -> bool {
+        self.previous_panes_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn previous_pane_row_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.previous_pane_rows
+            .iter()
+            .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
     }
 
     fn pane_cell_at(&self, x: u16, y: u16) -> Option<PaneCell> {
@@ -1921,6 +2118,10 @@ impl App {
         self.settings.open
     }
 
+    pub fn previous_panes_open(&self) -> bool {
+        self.previous_panes.open
+    }
+
     pub fn image_overlay_view(&self) -> Option<&ImagePreview> {
         self.image_overlay.as_ref()
     }
@@ -1952,6 +2153,47 @@ impl App {
             pane_label: self.pane_label(self.rename.pane_index),
             value: self.rename.value.clone(),
             cursor: self.rename.cursor,
+        })
+    }
+
+    pub fn previous_panes_view(&self) -> Option<PreviousPanesView> {
+        self.previous_panes.open.then(|| PreviousPanesView {
+            cursor: self
+                .previous_panes
+                .cursor
+                .min(self.panes.len().saturating_sub(1)),
+            panes: self
+                .panes
+                .iter()
+                .enumerate()
+                .map(|(index, pane)| {
+                    let agent_label = self
+                        .launch_plan
+                        .as_ref()
+                        .and_then(|plan| plan.panes.get(index))
+                        .and_then(|pane| pane.agent_label());
+                    let summary = conversation_summary(pane.screen())
+                        .unwrap_or_else(|| "waiting for output".into());
+                    let summary = agent_label
+                        .map(|label| format!("{label} | {summary}"))
+                        .unwrap_or(summary);
+
+                    PreviousPaneView {
+                        index,
+                        label: self.pane_label(index),
+                        folder: self
+                            .pane_folder(index)
+                            .map(str::to_string)
+                            .unwrap_or_else(|| path_label(pane.cwd())),
+                        worktree: self.pane_worktree(index).map(str::to_string),
+                        summary,
+                        focused: self.focus == index,
+                        selected: self.selected.contains(&index),
+                        sleeping: self.sleeping.contains(&index),
+                        exited: pane.exited,
+                    }
+                })
+                .collect(),
         })
     }
 
@@ -2211,6 +2453,27 @@ fn pane_inner_rect(rect: Rect) -> Option<Rect> {
         width,
         height,
     })
+}
+
+fn rect_contains(rect: Rect, x: u16, y: u16) -> bool {
+    x >= rect.x
+        && x < rect.x.saturating_add(rect.width)
+        && y >= rect.y
+        && y < rect.y.saturating_add(rect.height)
+}
+
+fn path_label(path: &std::path::Path) -> String {
+    let mut label = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| path.display().to_string());
+
+    if !matches!(label.chars().last(), Some('/') | Some('\\')) {
+        label.push('/');
+    }
+
+    label
 }
 
 fn extract_selection_text(screen: &vt100::Screen, selection: PaneSelection, width: u16) -> String {
@@ -2563,6 +2826,22 @@ mod tests {
             "Quiet border"
         );
         assert_eq!(rows[SettingsState::BASE_ROW_COUNT + 3].value, "magenta");
+    }
+
+    #[test]
+    fn previous_panes_cursor_clamps_to_available_panes() {
+        let mut previous = PreviousPanesState::default();
+        previous.begin(8, 3);
+        assert_eq!(previous.cursor, 2);
+
+        previous.move_cursor(-5, 3);
+        assert_eq!(previous.cursor, 0);
+
+        previous.move_cursor(10, 3);
+        assert_eq!(previous.cursor, 2);
+
+        previous.move_cursor(1, 0);
+        assert_eq!(previous.cursor, 0);
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,7 +9,10 @@ use std::path::Path;
 use vt100::Cell;
 
 use crate::{
-    app::{App, GridPalette, PaneSelection, RenamePaneView, SettingsRow},
+    app::{
+        App, GridPalette, PaneSelection, PreviousPaneView, PreviousPanesView, RenamePaneView,
+        SettingsRow,
+    },
     image_preview::ImagePreview,
 };
 
@@ -25,9 +28,13 @@ const SETTINGS_TEXT: Color = Color::Rgb(230, 237, 243);
 pub struct DrawState {
     pub grid_area: Rect,
     pub pane_rects: Vec<Rect>,
+    pub previous_panes_button: Option<Rect>,
+    pub previous_pane_rows: Vec<(usize, Rect)>,
 }
 
 const QUIET_MARKER: &str = " *";
+const STATUS_BRAND: &str = " GridBash ";
+const PREVIOUS_PANES_BUTTON: &str = " Panes ";
 
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
@@ -41,8 +48,12 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let rects = app.pane_rects(grid_area);
     let palette = app.palette();
     let rename_view = app.rename_pane_view();
+    let previous_panes_view = app.previous_panes_view();
     let image_overlay = app.image_overlay_view();
-    let modal_open = app.settings_open() || rename_view.is_some() || image_overlay.is_some();
+    let modal_open = app.settings_open()
+        || previous_panes_view.is_some()
+        || rename_view.is_some()
+        || image_overlay.is_some();
 
     for (index, pane) in app.panes().iter().enumerate() {
         let Some(rect) = rects.get(index).copied() else {
@@ -105,13 +116,19 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     } else {
         "focused pane"
     };
+    let previous_panes_button = previous_panes_button_rect(status_area);
     let status = Line::from(vec![
         Span::styled(
-            " GridBash ",
+            STATUS_BRAND,
             Style::default()
                 .fg(Color::Black)
                 .bg(palette.accent())
                 .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            PREVIOUS_PANES_BUTTON,
+            previous_panes_button_style(app.previous_panes_open(), palette),
         ),
         Span::raw(" "),
         Span::styled(
@@ -133,7 +150,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(format!("{} selected", app.selected().len())),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
-        Span::raw(" | Alt+t restart | Alt+x swap | Alt+z sleep | Alt+q quit"),
+        Span::raw(" | Alt+p panes | Alt+t restart | Alt+x swap | Alt+z sleep | Alt+q quit"),
     ]);
     frame.render_widget(
         Paragraph::new(status).style(Style::default().bg(APP_BG)),
@@ -143,6 +160,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     if app.settings_open() {
         render_settings(frame, area, &app.settings_rows(), palette);
     }
+    let previous_pane_rows = if let Some(view) = previous_panes_view.as_ref() {
+        render_previous_panes(frame, area, view, palette)
+    } else {
+        Vec::new()
+    };
     if let Some(rename) = rename_view.as_ref() {
         render_rename_pane(frame, area, rename);
     }
@@ -153,6 +175,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     DrawState {
         grid_area,
         pane_rects: rects,
+        previous_panes_button,
+        previous_pane_rows,
     }
 }
 
@@ -229,6 +253,229 @@ fn pane_chrome(
         badge,
         quiet_marker,
     }
+}
+
+fn previous_panes_button_rect(status_area: Rect) -> Option<Rect> {
+    let offset = STATUS_BRAND.len() as u16 + 1;
+    let width = PREVIOUS_PANES_BUTTON.len() as u16;
+    if status_area.height == 0 || status_area.width < offset.saturating_add(width) {
+        return None;
+    }
+
+    Some(Rect {
+        x: status_area.x.saturating_add(offset),
+        y: status_area.y,
+        width,
+        height: 1,
+    })
+}
+
+fn previous_panes_button_style(open: bool, palette: &GridPalette) -> Style {
+    if open {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(Color::Black)
+            .bg(palette.focus())
+            .add_modifier(Modifier::BOLD)
+    }
+}
+
+fn render_previous_panes(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    view: &PreviousPanesView,
+    palette: &GridPalette,
+) -> Vec<(usize, Rect)> {
+    let modal = previous_panes_modal_rect(area, view.panes.len());
+    let shadow = settings_shadow_rect(area, modal);
+    let mut row_hits = Vec::new();
+
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Previous Panes ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    if inner.width == 0 || inner.height == 0 {
+        return row_hits;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let header = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            format!("{} panes", view.panes.len()),
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  current session", Style::default().fg(Color::Gray)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(vec![header, Line::from("")]).style(settings_panel_style()),
+        chunks[0],
+    );
+
+    let list_area = chunks[1];
+    let visible =
+        visible_previous_pane_range(view.panes.len(), view.cursor, list_area.height as usize);
+    let mut rows = Vec::new();
+
+    for (row_offset, index) in visible.enumerate() {
+        let Some(pane) = view.panes.get(index) else {
+            continue;
+        };
+        let row_area = Rect {
+            x: list_area.x,
+            y: list_area.y.saturating_add(row_offset as u16),
+            width: list_area.width,
+            height: 1,
+        };
+        row_hits.push((index, row_area));
+        rows.push(previous_pane_line(
+            pane,
+            view.cursor == index,
+            list_area.width,
+        ));
+    }
+
+    frame.render_widget(
+        Paragraph::new(rows).style(settings_panel_style()),
+        list_area,
+    );
+    frame.render_widget(
+        Paragraph::new(previous_panes_command_bar(chunks[2].width)).style(settings_panel_style()),
+        chunks[2],
+    );
+
+    row_hits
+}
+
+fn previous_pane_line(pane: &PreviousPaneView, active: bool, width: u16) -> Line<'static> {
+    let (state, state_color) = previous_pane_state(pane);
+    let label_width = if width < 62 { 10 } else { 16 };
+    let location_width = if width < 62 { 14 } else { 24 };
+    let marker = if active { ">" } else { " " };
+    let location = pane
+        .worktree
+        .as_ref()
+        .map(|worktree| format!("{} | {worktree}", pane.folder))
+        .unwrap_or_else(|| pane.folder.clone());
+    let text = format!(
+        "{marker} {:>2} {:<label_width$} {:<8} {:<location_width$} {}",
+        pane.index + 1,
+        truncate_text(&pane.label, label_width),
+        state,
+        truncate_text(&location, location_width),
+        pane.summary,
+    );
+    let bg = active.then_some(SETTINGS_ROW_ACTIVE);
+    let fg = if active { SETTINGS_TEXT } else { state_color };
+
+    Line::from(Span::styled(
+        fixed_width(&text, width as usize),
+        row_style(fg, bg, active || pane.focused),
+    ))
+}
+
+fn previous_pane_state(pane: &PreviousPaneView) -> (&'static str, Color) {
+    if pane.exited {
+        ("exited", Color::Red)
+    } else if pane.sleeping {
+        ("asleep", Color::DarkGray)
+    } else if pane.focused {
+        ("focus", Color::Yellow)
+    } else if pane.selected {
+        ("selected", Color::Cyan)
+    } else {
+        ("live", SETTINGS_TEXT)
+    }
+}
+
+fn previous_panes_command_bar(width: u16) -> Line<'static> {
+    if width < 44 {
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" focus  ", Style::default().fg(Color::Gray)),
+            command_key("Esc"),
+            Span::styled(" close", Style::default().fg(Color::Gray)),
+        ]);
+    }
+
+    Line::from(vec![
+        Span::raw("  "),
+        command_key("Up/Down"),
+        Span::styled(" move  ", Style::default().fg(Color::Gray)),
+        command_key("Enter"),
+        Span::styled(" focus  ", Style::default().fg(Color::Gray)),
+        command_key("Esc"),
+        Span::styled(" close", Style::default().fg(Color::Gray)),
+    ])
+}
+
+fn previous_panes_modal_rect(area: Rect, pane_count: usize) -> Rect {
+    let width = area.width.saturating_sub(4).min(96).max(area.width.min(1));
+    let desired_height = (pane_count as u16).saturating_add(6).clamp(8, 24);
+    let height = area
+        .height
+        .saturating_sub(2)
+        .min(desired_height)
+        .max(area.height.min(1));
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn visible_previous_pane_range(
+    pane_count: usize,
+    cursor: usize,
+    capacity: usize,
+) -> std::ops::Range<usize> {
+    if pane_count == 0 || capacity == 0 {
+        return 0..0;
+    }
+
+    let capacity = capacity.min(pane_count);
+    let cursor = cursor.min(pane_count - 1);
+    let mut start = cursor.saturating_sub(capacity / 2);
+    if start + capacity > pane_count {
+        start = pane_count - capacity;
+    }
+
+    start..start + capacity
 }
 
 fn render_settings(frame: &mut Frame<'_>, area: Rect, rows: &[SettingsRow], palette: &GridPalette) {
@@ -771,7 +1018,7 @@ fn fixed_width(text: &str, width: usize) -> String {
 }
 
 fn truncate_text(text: &str, width: usize) -> String {
-    if text.len() <= width {
+    if text.chars().count() <= width {
         return text.to_string();
     }
     if width == 0 {
@@ -781,7 +1028,7 @@ fn truncate_text(text: &str, width: usize) -> String {
         return ".".repeat(width);
     }
 
-    format!("{}...", &text[..width - 3])
+    format!("{}...", text.chars().take(width - 3).collect::<String>())
 }
 
 fn folder_label(cwd: &Path) -> String {
@@ -1066,6 +1313,24 @@ mod tests {
         assert_eq!(
             pane_title("api", QUIET_MARKER, "gridbash/", None, None, ""),
             " api * | gridbash/ "
+        );
+    }
+
+    #[test]
+    fn previous_pane_range_keeps_cursor_visible() {
+        assert_eq!(visible_previous_pane_range(10, 0, 4), 0..4);
+        assert_eq!(visible_previous_pane_range(10, 5, 4), 3..7);
+        assert_eq!(visible_previous_pane_range(10, 9, 4), 6..10);
+        assert_eq!(visible_previous_pane_range(3, 8, 10), 0..3);
+        assert_eq!(visible_previous_pane_range(3, 1, 0), 0..0);
+    }
+
+    #[test]
+    fn truncates_non_ascii_text_without_slicing_inside_a_character() {
+        assert_eq!(truncate_text("alpha beta", 8), "alpha...");
+        assert_eq!(
+            truncate_text("codex says 東京 ready", 15),
+            "codex says 東..."
         );
     }
 


### PR DESCRIPTION
## Summary\n- Add a clickable Panes control to the GridBash status bar.\n- Add an Alt+p Previous Panes modal that lists current pane labels, state, folder/worktree context, and latest visible conversation summary.\n- Allow focusing panes from the list with keyboard selection or row click.\n\nCloses #88\n\n## Validation\n- cargo fmt --check\n- cargo test\n- cargo clippy -- -D warnings\n\nNote: replaces #92, which used the same diff without the required DCO signoff.