### PR TITLE
fix: mute quiet pane border

### DIFF
--- a/docs/devlogs/2026-07-09-configurable-pane-border-color.md
+++ b/docs/devlogs/2026-07-09-configurable-pane-border-color.md
@@ -1,0 +1,29 @@
+# Configurable pane border color
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Made quiet pane borders muted by default and kept pane chrome colors editable in settings.
+
+## What Changed
+
+- Changed the default quiet-output pane border from magenta to dark gray.
+- Removed bold styling from quiet-output borders so panes with the `*` quiet marker match the muted idle chrome by default.
+- Added dark gray to the runtime palette choices so users can cycle quiet/selected/focus colors through a muted border option.
+- Updated tests for settings palette rows and quiet pane chrome.
+
+## Why It Matters
+
+- Quiet panes should not look selected or urgent just because output paused. The `*` marker still communicates quiet output while the border remains visually consistent unless the user chooses a brighter color.
+
+## Validation
+
+- TODO before merge: `cargo fmt --check`
+- TODO before merge: `cargo clippy -- -D warnings`
+- TODO before merge: `cargo test`
+
+## Release Notes
+
+- Quiet pane borders now default to muted gray instead of magenta, and the settings palette includes dark gray as an editable pane chrome color.

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,12 +211,13 @@ enum PaletteColor {
     Orange,
     Red,
     Magenta,
+    DarkGray,
     Gray,
     White,
 }
 
 impl PaletteColor {
-    const ALL: [Self; 12] = [
+    const ALL: [Self; 13] = [
         Self::Cyan,
         Self::Sky,
         Self::Blue,
@@ -227,6 +228,7 @@ impl PaletteColor {
         Self::Orange,
         Self::Red,
         Self::Magenta,
+        Self::DarkGray,
         Self::Gray,
         Self::White,
     ];
@@ -243,6 +245,7 @@ impl PaletteColor {
             Self::Orange => Color::Rgb(249, 115, 22),
             Self::Red => Color::Red,
             Self::Magenta => Color::Magenta,
+            Self::DarkGray => Color::DarkGray,
             Self::Gray => Color::Gray,
             Self::White => Color::White,
         }
@@ -260,6 +263,7 @@ impl PaletteColor {
             Self::Orange => "orange",
             Self::Red => "red",
             Self::Magenta => "magenta",
+            Self::DarkGray => "dark gray",
             Self::Gray => "gray",
             Self::White => "white",
         }
@@ -290,7 +294,7 @@ impl Default for GridPalette {
             accent: PaletteColor::Cyan,
             focus: PaletteColor::Yellow,
             selected: PaletteColor::Cyan,
-            quiet: PaletteColor::Magenta,
+            quiet: PaletteColor::DarkGray,
             exited: PaletteColor::Red,
         }
     }
@@ -2953,7 +2957,7 @@ mod tests {
             rows[SettingsState::BASE_ROW_COUNT + 3].label,
             "Quiet border"
         );
-        assert_eq!(rows[SettingsState::BASE_ROW_COUNT + 3].value, "magenta");
+        assert_eq!(rows[SettingsState::BASE_ROW_COUNT + 3].value, "dark gray");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -239,9 +239,7 @@ fn pane_chrome(
     } else if exited {
         Style::default().fg(palette.exited())
     } else if quiet {
-        Style::default()
-            .fg(palette.quiet())
-            .add_modifier(Modifier::BOLD)
+        Style::default().fg(palette.quiet())
     } else {
         Style::default().fg(Color::DarkGray)
     };
@@ -1430,6 +1428,7 @@ mod tests {
         let active_quiet = pane_chrome(false, false, true, false, false, true, &palette);
 
         assert_eq!(quiet.quiet_marker, QUIET_MARKER);
+        assert_eq!(quiet.border_style, Style::default().fg(Color::DarkGray));
         assert_eq!(quiet.border_style, active_quiet.border_style);
     }
 }


### PR DESCRIPTION
## Summary

- change quiet-output pane borders from magenta/bold to muted dark gray by default
- add dark gray to the runtime palette choices used by settings
- update the devlog and tests for quiet pane chrome

Fixes #99

## Testing

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [x] `node npm/scripts/prepare.js`
- [x] `npm pack --dry-run --ignore-scripts`
- [ ] Not applicable or not run:

## Contributor Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I signed off my commits with `git commit -s`.
- [x] I updated docs, examples, or tests when behavior changed.
- [x] This is not a public report of a security vulnerability.

## Notes For Reviewers

The bright pink border in the screenshot was the quiet-output state (`*` marker), not selection. Selection and focus border colors are still editable via the existing Settings > Theme palette rows.