### PR TITLE
feat: check for updates on startup

### DIFF
--- a/docs/devlogs/2026-07-09-startup-update-check.md
+++ b/docs/devlogs/2026-07-09-startup-update-check.md
@@ -1,0 +1,35 @@
+# Startup update check
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added a startup update notice for npm-launched GridBash installs.
+
+## What Changed
+
+- The npm launcher now checks the latest GitHub release before starting the packaged binary.
+- The check is skipped for `--version`, help output, `--mcp`, non-TTY stderr, or when `GRIDBASH_NO_UPDATE_CHECK` is set.
+- Update-check failures are silent, and the launcher still starts GridBash normally.
+- Added focused launcher tests for version comparison, skip conditions, timeout parsing, and the local HTTP release-check path.
+
+## Why It Matters
+
+- Local installs can drift behind the latest release. A concise startup notice helps users notice available updates without blocking normal startup.
+
+## Validation
+
+- `npm run test:launcher`
+- `node --check npm/bin/gridbash.js`
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+- `node npm/scripts/prepare.js`
+- `npm pack --dry-run --ignore-scripts`
+- `GRIDBASH_ALLOW_WORKTREE_LINK=1 node npm/bin/gridbash.js --version`
+
+## Release Notes
+
+- GridBash now reports when a newer GitHub release is available at startup, while keeping protocol and version/help output clean.

--- a/npm/bin/gridbash.js
+++ b/npm/bin/gridbash.js
@@ -2,51 +2,294 @@
 
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const http = require("node:http");
+const https = require("node:https");
 const path = require("node:path");
+
+const DEFAULT_UPDATE_CHECK_TIMEOUT_MS = 900;
+const DEFAULT_UPDATE_CHECK_URL =
+  "https://api.github.com/repos/jasonsuhari/gridbash/releases/latest";
 
 function fail(message) {
   console.error(`gridbash: ${message}`);
   process.exit(1);
 }
 
-if (process.platform !== "win32") {
-  fail("this npm package currently ships the Windows x64 build only");
+function packageRoot() {
+  return path.resolve(__dirname, "..", "..");
 }
 
-if (process.arch !== "x64") {
-  fail(`unsupported architecture: ${process.arch}`);
+function readPackageVersion(root = packageRoot()) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+  } catch {
+    return undefined;
+  }
 }
 
-const exe = path.join(__dirname, "win32-x64", "gridbash.exe");
-const normalizedBinDir = path.resolve(__dirname).toLowerCase();
-const sourceManifest = path.resolve(__dirname, "..", "..", "Cargo.toml");
+function parseVersion(value) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value || "");
+  if (!match) {
+    return undefined;
+  }
 
-if (
-  (normalizedBinDir.includes(`${path.sep}.worktrees${path.sep}`.toLowerCase()) ||
-    fs.existsSync(sourceManifest)) &&
-  process.env.GRIDBASH_ALLOW_WORKTREE_LINK !== "1"
-) {
-  fail(
-    'global command resolves to a source checkout. Run "npm run install:local" from the intended checkout, or set GRIDBASH_ALLOW_WORKTREE_LINK=1 to override.'
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4],
+  };
+}
+
+function comparePrerelease(left, right) {
+  if (!left && !right) {
+    return 0;
+  }
+  if (!left) {
+    return 1;
+  }
+  if (!right) {
+    return -1;
+  }
+
+  const leftParts = left.split(".");
+  const rightParts = right.split(".");
+  const count = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    if (leftPart === rightPart) {
+      continue;
+    }
+
+    const leftNumber = /^\d+$/.test(leftPart) ? Number(leftPart) : undefined;
+    const rightNumber = /^\d+$/.test(rightPart) ? Number(rightPart) : undefined;
+    if (leftNumber !== undefined && rightNumber !== undefined) {
+      return Math.sign(leftNumber - rightNumber);
+    }
+    if (leftNumber !== undefined) {
+      return -1;
+    }
+    if (rightNumber !== undefined) {
+      return 1;
+    }
+    return leftPart < rightPart ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function compareVersions(left, right) {
+  const parsedLeft = parseVersion(left);
+  const parsedRight = parseVersion(right);
+  if (!parsedLeft || !parsedRight) {
+    return 0;
+  }
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (parsedLeft[key] !== parsedRight[key]) {
+      return Math.sign(parsedLeft[key] - parsedRight[key]);
+    }
+  }
+
+  return comparePrerelease(parsedLeft.prerelease, parsedRight.prerelease);
+}
+
+function updateCheckTimeoutMs(env = process.env) {
+  const value = Number.parseInt(env.GRIDBASH_UPDATE_CHECK_TIMEOUT_MS || "", 10);
+  if (!Number.isFinite(value)) {
+    return DEFAULT_UPDATE_CHECK_TIMEOUT_MS;
+  }
+
+  return Math.max(0, Math.min(5000, value));
+}
+
+function shouldSkipUpdateCheck(args, env = process.env, stderr = process.stderr) {
+  if (env.GRIDBASH_NO_UPDATE_CHECK || env.GRIDBASH_UPDATE_CHECK === "0") {
+    return true;
+  }
+  if (!stderr.isTTY) {
+    return true;
+  }
+
+  return args.some((arg) => ["--help", "-h", "--version", "-V", "--mcp"].includes(arg));
+}
+
+function fetchLatestRelease(url, timeoutMs) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      finish(undefined);
+      return;
+    }
+
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      finish(undefined);
+      return;
+    }
+
+    const transport = parsedUrl.protocol === "http:" ? http : https;
+    const request = transport.get(
+      parsedUrl,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "User-Agent": `gridbash/${readPackageVersion() || "unknown"}`,
+        },
+      },
+      (response) => {
+        if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+          response.resume();
+          finish(undefined);
+          return;
+        }
+
+        let raw = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          raw += chunk;
+          if (raw.length > 128 * 1024) {
+            request.destroy();
+            finish(undefined);
+          }
+        });
+        response.on("end", () => {
+          try {
+            const body = JSON.parse(raw);
+            const tagName = body.tag_name || body.name;
+            if (!tagName) {
+              finish(undefined);
+              return;
+            }
+
+            finish({
+              tagName,
+              version: tagName.replace(/^v/, ""),
+              url: body.html_url || DEFAULT_UPDATE_CHECK_URL,
+            });
+          } catch {
+            finish(undefined);
+          }
+        });
+      },
+    );
+
+    request.on("error", () => finish(undefined));
+    request.setTimeout(timeoutMs, () => {
+      request.destroy();
+      finish(undefined);
+    });
+  });
+}
+
+async function checkForUpdate(currentVersion, env = process.env) {
+  if (!currentVersion) {
+    return undefined;
+  }
+
+  const latest = await fetchLatestRelease(
+    env.GRIDBASH_UPDATE_CHECK_URL || DEFAULT_UPDATE_CHECK_URL,
+    updateCheckTimeoutMs(env),
   );
+  if (!latest || compareVersions(latest.version, currentVersion) <= 0) {
+    return undefined;
+  }
+
+  return latest;
 }
 
-if (!fs.existsSync(exe)) {
-  fail(`missing packaged binary at ${exe}. Run "npm run build" from the gridbash repo.`);
+function formatUpdateNotice(currentVersion, latest) {
+  return [
+    `gridbash: update available ${latest.tagName} (current v${currentVersion})`,
+    `gridbash: see ${latest.url}`,
+  ].join("\n");
 }
 
-const result = spawnSync(exe, process.argv.slice(2), {
-  cwd: process.cwd(),
-  stdio: "inherit",
-  windowsHide: false
-});
+async function maybePrintUpdateNotice(args, env = process.env, stderr = process.stderr) {
+  if (shouldSkipUpdateCheck(args, env, stderr)) {
+    return;
+  }
 
-if (result.error) {
-  fail(result.error.message);
+  const currentVersion = readPackageVersion();
+  const latest = await checkForUpdate(currentVersion, env);
+  if (latest) {
+    stderr.write(`${formatUpdateNotice(currentVersion, latest)}\n`);
+  }
 }
 
-if (result.signal) {
-  process.kill(process.pid, result.signal);
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (process.platform !== "win32") {
+    fail("this npm package currently ships the Windows x64 build only");
+  }
+
+  if (process.arch !== "x64") {
+    fail(`unsupported architecture: ${process.arch}`);
+  }
+
+  const exe = path.join(__dirname, "win32-x64", "gridbash.exe");
+  const normalizedBinDir = path.resolve(__dirname).toLowerCase();
+  const sourceManifest = path.resolve(__dirname, "..", "..", "Cargo.toml");
+
+  if (
+    (normalizedBinDir.includes(`${path.sep}.worktrees${path.sep}`.toLowerCase()) ||
+      fs.existsSync(sourceManifest)) &&
+    process.env.GRIDBASH_ALLOW_WORKTREE_LINK !== "1"
+  ) {
+    fail(
+      'global command resolves to a source checkout. Run "npm run install:local" from the intended checkout, or set GRIDBASH_ALLOW_WORKTREE_LINK=1 to override.',
+    );
+  }
+
+  if (!fs.existsSync(exe)) {
+    fail(`missing packaged binary at ${exe}. Run "npm run build" from the gridbash repo.`);
+  }
+
+  await maybePrintUpdateNotice(args);
+
+  const result = spawnSync(exe, args, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    windowsHide: false,
+  });
+
+  if (result.error) {
+    fail(result.error.message);
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  } else {
+    process.exit(result.status ?? 0);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => fail(error.message));
 } else {
-  process.exit(result.status ?? 0);
+  module.exports = {
+    checkForUpdate,
+    compareVersions,
+    fetchLatestRelease,
+    formatUpdateNotice,
+    shouldSkipUpdateCheck,
+    updateCheckTimeoutMs,
+  };
 }

--- a/npm/scripts/gridbash-launcher.test.js
+++ b/npm/scripts/gridbash-launcher.test.js
@@ -1,0 +1,78 @@
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const { test } = require("node:test");
+
+const {
+  checkForUpdate,
+  compareVersions,
+  formatUpdateNotice,
+  shouldSkipUpdateCheck,
+  updateCheckTimeoutMs,
+} = require("../bin/gridbash.js");
+
+function serveJson(payload) {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify(payload));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}/latest`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+test("compareVersions handles newer, older, and prerelease versions", () => {
+  assert.equal(compareVersions("0.1.6", "0.1.5"), 1);
+  assert.equal(compareVersions("v0.1.5", "0.1.5"), 0);
+  assert.equal(compareVersions("0.1.4", "0.1.5"), -1);
+  assert.equal(compareVersions("0.2.0", "0.1.99"), 1);
+  assert.equal(compareVersions("1.0.0", "1.0.0-beta.1"), 1);
+});
+
+test("shouldSkipUpdateCheck preserves help, version, MCP, and non-TTY paths", () => {
+  assert.equal(shouldSkipUpdateCheck(["--version"], {}, { isTTY: true }), true);
+  assert.equal(shouldSkipUpdateCheck(["--mcp"], {}, { isTTY: true }), true);
+  assert.equal(shouldSkipUpdateCheck([], { GRIDBASH_NO_UPDATE_CHECK: "1" }, { isTTY: true }), true);
+  assert.equal(shouldSkipUpdateCheck([], {}, { isTTY: false }), true);
+  assert.equal(shouldSkipUpdateCheck(["2x2"], {}, { isTTY: true }), false);
+});
+
+test("updateCheckTimeoutMs clamps overrides", () => {
+  assert.equal(updateCheckTimeoutMs({ GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "25" }), 25);
+  assert.equal(updateCheckTimeoutMs({ GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "10000" }), 5000);
+});
+
+test("checkForUpdate returns latest release only when it is newer", async () => {
+  const server = await serveJson({
+    tag_name: "v0.1.6",
+    html_url: "https://github.com/jasonsuhari/gridbash/releases/tag/v0.1.6",
+  });
+
+  try {
+    const latest = await checkForUpdate("0.1.5", {
+      GRIDBASH_UPDATE_CHECK_URL: server.url,
+      GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "500",
+    });
+
+    assert.deepEqual(latest, {
+      tagName: "v0.1.6",
+      version: "0.1.6",
+      url: "https://github.com/jasonsuhari/gridbash/releases/tag/v0.1.6",
+    });
+    assert.match(formatUpdateNotice("0.1.5", latest), /update available v0\.1\.6/);
+
+    const current = await checkForUpdate("0.1.6", {
+      GRIDBASH_UPDATE_CHECK_URL: server.url,
+      GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "500",
+    });
+    assert.equal(current, undefined);
+  } finally {
+    await server.close();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "install:local": "node npm/scripts/install-local.js",
     "prepare": "node npm/scripts/prepare.js",
     "release": "node npm/scripts/release.js",
+    "test:launcher": "node --test npm/scripts/gridbash-launcher.test.js",
     "test": "cargo test"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- add a short startup check against GitHub's latest GridBash release before launching the packaged exe
- keep failures silent and skip checks for help/version/MCP/non-TTY paths
- add focused Node launcher tests and a `test:launcher` script

Fixes #95

## Testing

- [x] `npm run test:launcher`
- [x] `node --check npm/bin/gridbash.js`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`
- [x] `node npm/scripts/prepare.js`
- [x] `npm pack --dry-run --ignore-scripts`
- [x] `GRIDBASH_ALLOW_WORKTREE_LINK=1 node npm/bin/gridbash.js --version`
- [ ] Not applicable or not run:

## Contributor Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I signed off my commits with `git commit -s`.
- [x] I updated docs, examples, or tests when behavior changed.
- [x] This is not a public report of a security vulnerability.

## Notes For Reviewers

The notice is intentionally emitted only by the npm launcher before the TUI starts. `--mcp` is skipped so MCP stdio remains clean, and `--version`/help output remains unchanged.