### PR TITLE
Add focused pane settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,17 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+Shift+Left / Alt+Shift+Right | Remove / add a column when safe |
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
-| Alt+p | Open the previous panes list and focus a pane from its conversation summary |
+| Alt+p | Open settings for the focused pane; use Reload past history to refresh its visible conversation snapshot |
 | Alt+r | Rename the focused pane |
 | Alt+t | Restart exited focused pane; when multiple panes are selected, restart exited selected panes |
 | Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |
 | Hover sleeping pane | Wake the pane and make its terminal contents visible again |
 | Alt+o | Open settings |
 | Alt+q | Quit |
+
+In focused-pane settings, press `Enter`, `Space`, or `r` to reload the visible
+conversation history snapshot. Press `Esc`, `q`, or `Alt+p` to close it, or
+`Alt+o` to switch to overall settings.
 
 When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter`,
 `r`, or `t` to restart it, or press `z` to put it to sleep. `Alt+t` still restarts

--- a/docs/devlogs/2026-07-09-add-focused-pane-settings.md
+++ b/docs/devlogs/2026-07-09-add-focused-pane-settings.md
@@ -1,0 +1,29 @@
+# Add focused pane settings
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Replaced the `Alt+p` previous-panes picker with a focused-pane settings view.
+
+## What Changed
+
+- `Alt+p` now opens settings inside the focused pane instead of drawing a global picker modal.
+- Added a `Reload past history` action that refreshes the pane's visible conversation snapshot.
+- Kept `Alt+o` dedicated to overall GridBash settings, including from the pane settings view.
+
+## Why It Matters
+
+- Pane-specific controls now live where the user is already looking, and the old redundant pane picker no longer competes with existing focus shortcuts.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check`
+- `cargo test`
+- `cargo clippy -- -D warnings`
+
+## Release Notes
+
+- Changed `Alt+p` to open focused-pane settings with a `Reload past history` action.

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,11 +62,11 @@ pub struct App {
     image_overlay: Option<ImagePreview>,
     settings: SettingsState,
     rename: RenamePaneState,
-    previous_panes: PreviousPanesState,
+    pane_settings: PaneSettingsState,
     status: String,
     next_pane_id: usize,
-    previous_panes_button: Option<Rect>,
-    previous_pane_rows: Vec<(usize, Rect)>,
+    pane_settings_button: Option<Rect>,
+    pane_settings_reload_button: Option<Rect>,
     event_tx: mpsc::UnboundedSender<PtyEvent>,
     event_rx: mpsc::UnboundedReceiver<PtyEvent>,
     usage_tx: std_mpsc::Sender<UsageEvent>,
@@ -361,18 +361,12 @@ pub struct RenamePaneView {
 }
 
 #[derive(Debug, Clone)]
-pub struct PreviousPanesView {
-    pub cursor: usize,
-    pub panes: Vec<PreviousPaneView>,
-}
-
-#[derive(Debug, Clone)]
-pub struct PreviousPaneView {
+pub struct PaneSettingsView {
     pub index: usize,
     pub label: String,
     pub folder: String,
     pub worktree: Option<String>,
-    pub summary: String,
+    pub history_summary: String,
     pub focused: bool,
     pub selected: bool,
     pub sleeping: bool,
@@ -380,36 +374,26 @@ pub struct PreviousPaneView {
 }
 
 #[derive(Debug, Clone, Default)]
-struct PreviousPanesState {
+struct PaneSettingsState {
     open: bool,
-    cursor: usize,
+    pane_index: usize,
+    history_summary: Option<String>,
 }
 
-impl PreviousPanesState {
-    fn begin(&mut self, focus: usize, pane_count: usize) {
+impl PaneSettingsState {
+    fn open(&mut self, pane_index: usize, history_summary: String) {
         self.open = true;
-        self.cursor = focus.min(pane_count.saturating_sub(1));
+        self.pane_index = pane_index;
+        self.history_summary = Some(history_summary);
     }
 
     fn close(&mut self) {
         self.open = false;
+        self.history_summary = None;
     }
 
-    fn move_cursor(&mut self, delta: isize, pane_count: usize) {
-        if pane_count == 0 {
-            self.cursor = 0;
-            return;
-        }
-
-        self.cursor = (self.cursor as isize + delta).clamp(0, pane_count as isize - 1) as usize;
-    }
-
-    fn move_to_start(&mut self) {
-        self.cursor = 0;
-    }
-
-    fn move_to_end(&mut self, pane_count: usize) {
-        self.cursor = pane_count.saturating_sub(1);
+    fn refresh_history(&mut self, history_summary: String) {
+        self.history_summary = Some(history_summary);
     }
 }
 
@@ -733,11 +717,11 @@ impl App {
             image_overlay: None,
             settings: SettingsState::default(),
             rename: RenamePaneState::default(),
-            previous_panes: PreviousPanesState::default(),
+            pane_settings: PaneSettingsState::default(),
             status,
             next_pane_id: 0,
-            previous_panes_button: None,
-            previous_pane_rows: Vec::new(),
+            pane_settings_button: None,
+            pane_settings_reload_button: None,
             event_tx,
             event_rx,
             usage_tx,
@@ -863,8 +847,8 @@ impl App {
                     let draw_state = ui::draw(frame, self);
                     self.grid_area = draw_state.grid_area;
                     self.rects = draw_state.pane_rects;
-                    self.previous_panes_button = draw_state.previous_panes_button;
-                    self.previous_pane_rows = draw_state.previous_pane_rows;
+                    self.pane_settings_button = draw_state.pane_settings_button;
+                    self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
                 })?;
                 self.sync_pane_sizes();
                 needs_render = false;
@@ -887,7 +871,7 @@ impl App {
                     }
                     Event::Paste(text)
                         if !self.settings.open
-                            && !self.previous_panes.open
+                            && !self.pane_settings.open
                             && self.image_overlay.is_none() =>
                     {
                         self.route_input(text.as_bytes())?;
@@ -1150,8 +1134,8 @@ impl App {
 
         let selection_cleared = self.clear_text_selection();
 
-        if self.previous_panes.open {
-            let outcome = self.handle_previous_panes_key(key);
+        if self.pane_settings.open {
+            let outcome = self.handle_pane_settings_key(key);
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
@@ -1285,7 +1269,7 @@ impl App {
                 Ok(Some(false))
             }
             'p' => {
-                self.open_previous_panes();
+                self.toggle_pane_settings();
                 Ok(Some(false))
             }
             'r' => {
@@ -1325,55 +1309,59 @@ impl App {
         self.status = format!("renaming pane {}", pane_index + 1);
     }
 
-    fn open_previous_panes(&mut self) {
-        if self.panes.is_empty() {
-            self.status = "no panes to list".into();
+    fn toggle_pane_settings(&mut self) {
+        if self.pane_settings.open && self.pane_settings.pane_index == self.focus {
+            self.close_pane_settings();
             return;
         }
 
-        self.previous_panes.begin(self.focus, self.panes.len());
-        self.status = "previous panes open".into();
+        self.open_pane_settings();
     }
 
-    fn close_previous_panes(&mut self) {
-        self.previous_panes.close();
-        self.status = "previous panes closed".into();
+    fn open_pane_settings(&mut self) {
+        if self.panes.is_empty() {
+            self.status = "no pane settings to show".into();
+            return;
+        }
+
+        let pane_index = self.focus.min(self.panes.len() - 1);
+        let history_summary = self.pane_history_summary(pane_index);
+        self.pane_settings.open(pane_index, history_summary);
+        self.status = format!("pane {} settings open", pane_index + 1);
     }
 
-    fn handle_previous_panes_key(&mut self, key: KeyEvent) -> KeyOutcome {
+    fn close_pane_settings(&mut self) {
+        let pane_number = self.pane_settings.pane_index + 1;
+        self.pane_settings.close();
+        self.status = format!("pane {pane_number} settings closed");
+    }
+
+    fn handle_pane_settings_key(&mut self, key: KeyEvent) -> KeyOutcome {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return KeyOutcome::Quit;
         }
         if key.modifiers.contains(KeyModifiers::ALT)
             && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
         {
-            self.close_previous_panes();
+            self.close_pane_settings();
+            return KeyOutcome::Render;
+        }
+        if key.modifiers.contains(KeyModifiers::ALT)
+            && matches!(key.code, KeyCode::Char('o') | KeyCode::Char('O'))
+        {
+            self.pane_settings.close();
+            self.settings.open = true;
+            self.status = "settings open".into();
             return KeyOutcome::Render;
         }
 
         let changed = match key.code {
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.close_previous_panes();
+                self.close_pane_settings();
                 true
             }
-            KeyCode::Up => {
-                self.previous_panes.move_cursor(-1, self.panes.len());
-                true
-            }
-            KeyCode::Down => {
-                self.previous_panes.move_cursor(1, self.panes.len());
-                true
-            }
-            KeyCode::Home => {
-                self.previous_panes.move_to_start();
-                true
-            }
-            KeyCode::End => {
-                self.previous_panes.move_to_end(self.panes.len());
-                true
-            }
-            KeyCode::Enter | KeyCode::Char(' ') => {
-                self.focus_previous_pane_entry(self.previous_panes.cursor);
+            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.reload_pane_history();
                 true
             }
             _ => false,
@@ -1386,21 +1374,17 @@ impl App {
         }
     }
 
-    fn focus_previous_pane_entry(&mut self, index: usize) {
+    fn reload_pane_history(&mut self) {
+        let index = self.pane_settings.pane_index;
         if index >= self.panes.len() {
-            self.previous_panes.close();
+            self.pane_settings.close();
             self.status = format!("pane {} is no longer available", index + 1);
             return;
         }
 
-        self.focus = index;
-        let woke = self.sleeping.remove(&index);
-        self.previous_panes.close();
-        self.status = if woke {
-            format!("woke pane {}", index + 1)
-        } else {
-            format!("focused pane {}", index + 1)
-        };
+        let history_summary = self.pane_history_summary(index);
+        self.pane_settings.refresh_history(history_summary);
+        self.status = format!("reloaded past history for pane {}", index + 1);
     }
 
     fn handle_rename_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -1591,19 +1575,15 @@ impl App {
 
         if self.mouse_enabled
             && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
-            && self.previous_panes_button_at(mouse.column, mouse.row)
+            && self.pane_settings_button_at(mouse.column, mouse.row)
         {
-            if self.previous_panes.open {
-                self.close_previous_panes();
-            } else {
-                self.open_previous_panes();
-            }
+            self.toggle_pane_settings();
             return Ok(true);
         }
 
-        if self.previous_panes.open {
+        if self.pane_settings.open {
             return Ok(if self.mouse_enabled {
-                self.handle_previous_panes_mouse(mouse)
+                self.handle_pane_settings_mouse(mouse)
             } else {
                 false
             });
@@ -1701,29 +1681,27 @@ impl App {
         Ok(changed)
     }
 
-    fn handle_previous_panes_mouse(&mut self, mouse: MouseEvent) -> bool {
+    fn handle_pane_settings_mouse(&mut self, mouse: MouseEvent) -> bool {
         if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
             return false;
         }
 
-        let Some(index) = self.previous_pane_row_at(mouse.column, mouse.row) else {
-            return false;
-        };
+        if self.pane_settings_reload_button_at(mouse.column, mouse.row) {
+            self.reload_pane_history();
+            return true;
+        }
 
-        self.previous_panes.cursor = index;
-        self.focus_previous_pane_entry(index);
-        true
+        false
     }
 
-    fn previous_panes_button_at(&self, x: u16, y: u16) -> bool {
-        self.previous_panes_button
+    fn pane_settings_button_at(&self, x: u16, y: u16) -> bool {
+        self.pane_settings_button
             .is_some_and(|rect| rect_contains(rect, x, y))
     }
 
-    fn previous_pane_row_at(&self, x: u16, y: u16) -> Option<usize> {
-        self.previous_pane_rows
-            .iter()
-            .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
+    fn pane_settings_reload_button_at(&self, x: u16, y: u16) -> bool {
+        self.pane_settings_reload_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
     }
 
     fn pane_cell_at(&self, x: u16, y: u16) -> Option<PaneCell> {
@@ -2224,8 +2202,8 @@ impl App {
         self.settings.open
     }
 
-    pub fn previous_panes_open(&self) -> bool {
-        self.previous_panes.open
+    pub fn pane_settings_open(&self) -> bool {
+        self.pane_settings.open
     }
 
     pub fn image_overlay_view(&self) -> Option<&ImagePreview> {
@@ -2275,44 +2253,29 @@ impl App {
         })
     }
 
-    pub fn previous_panes_view(&self) -> Option<PreviousPanesView> {
-        self.previous_panes.open.then(|| PreviousPanesView {
-            cursor: self
-                .previous_panes
-                .cursor
-                .min(self.panes.len().saturating_sub(1)),
-            panes: self
-                .panes
-                .iter()
-                .enumerate()
-                .map(|(index, pane)| {
-                    let agent_label = self
-                        .launch_plan
-                        .as_ref()
-                        .and_then(|plan| plan.panes.get(index))
-                        .and_then(|pane| pane.agent_label());
-                    let summary = conversation_summary(pane.screen())
-                        .unwrap_or_else(|| "waiting for output".into());
-                    let summary = agent_label
-                        .map(|label| format!("{label} | {summary}"))
-                        .unwrap_or(summary);
+    pub fn pane_settings_view(&self, index: usize) -> Option<PaneSettingsView> {
+        if !self.pane_settings.open || self.pane_settings.pane_index != index {
+            return None;
+        }
 
-                    PreviousPaneView {
-                        index,
-                        label: self.pane_label(index),
-                        folder: self
-                            .pane_folder(index)
-                            .map(str::to_string)
-                            .unwrap_or_else(|| path_label(pane.cwd())),
-                        worktree: self.pane_worktree(index).map(str::to_string),
-                        summary,
-                        focused: self.focus == index,
-                        selected: self.selected.contains(&index),
-                        sleeping: self.sleeping.contains(&index),
-                        exited: pane.exited,
-                    }
-                })
-                .collect(),
+        let pane = self.panes.get(index)?;
+        Some(PaneSettingsView {
+            index,
+            label: self.pane_label(index),
+            folder: self
+                .pane_folder(index)
+                .map(str::to_string)
+                .unwrap_or_else(|| path_label(pane.cwd())),
+            worktree: self.pane_worktree(index).map(str::to_string),
+            history_summary: self
+                .pane_settings
+                .history_summary
+                .clone()
+                .unwrap_or_else(|| self.pane_history_summary(index)),
+            focused: self.focus == index,
+            selected: self.selected.contains(&index),
+            sleeping: self.sleeping.contains(&index),
+            exited: pane.exited,
         })
     }
 
@@ -2340,6 +2303,21 @@ impl App {
         let summary = conversation_summary(pane.screen())
             .unwrap_or_else(|| "waiting for conversation".into());
         Some(truncate_chars(&format!("{label} | {summary}"), max_chars))
+    }
+
+    fn pane_history_summary(&self, index: usize) -> String {
+        let Some(pane) = self.panes.get(index) else {
+            return "pane is no longer available".into();
+        };
+
+        let summary =
+            conversation_summary(pane.screen()).unwrap_or_else(|| "waiting for output".into());
+        self.launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(index))
+            .and_then(|pane| pane.agent_label())
+            .map(|label| format!("{label} | {summary}"))
+            .unwrap_or(summary)
     }
 
     pub fn pane_usage_label(&self, index: usize) -> Option<String> {
@@ -3138,19 +3116,25 @@ mod tests {
     }
 
     #[test]
-    fn previous_panes_cursor_clamps_to_available_panes() {
-        let mut previous = PreviousPanesState::default();
-        previous.begin(8, 3);
-        assert_eq!(previous.cursor, 2);
+    fn pane_settings_tracks_active_pane_history() {
+        let mut settings = PaneSettingsState::default();
+        settings.open(2, "Assistant: ready".into());
+        assert!(settings.open);
+        assert_eq!(settings.pane_index, 2);
+        assert_eq!(
+            settings.history_summary.as_deref(),
+            Some("Assistant: ready")
+        );
 
-        previous.move_cursor(-5, 3);
-        assert_eq!(previous.cursor, 0);
+        settings.refresh_history("User: rerun tests".into());
+        assert_eq!(
+            settings.history_summary.as_deref(),
+            Some("User: rerun tests")
+        );
 
-        previous.move_cursor(10, 3);
-        assert_eq!(previous.cursor, 2);
-
-        previous.move_cursor(1, 0);
-        assert_eq!(previous.cursor, 0);
+        settings.close();
+        assert!(!settings.open);
+        assert!(settings.history_summary.is_none());
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,8 +10,8 @@ use vt100::Cell;
 
 use crate::{
     app::{
-        App, ExitedPaneRecoveryView, GridPalette, PaneSelection, PreviousPaneView,
-        PreviousPanesView, RenamePaneView, SettingsRow,
+        App, ExitedPaneRecoveryView, GridPalette, PaneSelection, PaneSettingsView, RenamePaneView,
+        SettingsRow,
     },
     image_preview::ImagePreview,
 };
@@ -28,13 +28,13 @@ const SETTINGS_TEXT: Color = Color::Rgb(230, 237, 243);
 pub struct DrawState {
     pub grid_area: Rect,
     pub pane_rects: Vec<Rect>,
-    pub previous_panes_button: Option<Rect>,
-    pub previous_pane_rows: Vec<(usize, Rect)>,
+    pub pane_settings_button: Option<Rect>,
+    pub pane_settings_reload_button: Option<Rect>,
 }
 
 const QUIET_MARKER: &str = " *";
 const STATUS_BRAND: &str = " GridBash ";
-const PREVIOUS_PANES_BUTTON: &str = " Panes ";
+const PANE_SETTINGS_BUTTON: &str = " Pane ";
 
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
@@ -48,10 +48,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let rects = app.pane_rects(grid_area);
     let palette = app.palette();
     let rename_view = app.rename_pane_view();
-    let previous_panes_view = app.previous_panes_view();
+    let pane_settings_open = app.pane_settings_open();
     let image_overlay = app.image_overlay_view();
     let exited_recovery = if app.settings_open()
-        || previous_panes_view.is_some()
+        || pane_settings_open
         || rename_view.is_some()
         || image_overlay.is_some()
     {
@@ -60,10 +60,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         app.exited_recovery_view()
     };
     let modal_open = app.settings_open()
-        || previous_panes_view.is_some()
+        || pane_settings_open
         || rename_view.is_some()
         || image_overlay.is_some()
         || exited_recovery.is_some();
+    let mut pane_settings_reload_button = None;
 
     for (index, pane) in app.panes().iter().enumerate() {
         let Some(rect) = rects.get(index).copied() else {
@@ -110,7 +111,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        if sleeping {
+        if let Some(view) = app.pane_settings_view(index) {
+            pane_settings_reload_button = render_pane_settings(frame, inner, &view, palette);
+        } else if sleeping {
             render_sleeping_screen(frame, inner);
         } else {
             render_screen(frame, inner, pane.screen(), app.selection_for_pane(index));
@@ -126,7 +129,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     } else {
         "focused pane"
     };
-    let previous_panes_button = previous_panes_button_rect(status_area);
+    let pane_settings_button = pane_settings_button_rect(status_area);
     let status = Line::from(vec![
         Span::styled(
             STATUS_BRAND,
@@ -137,8 +140,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         ),
         Span::raw(" "),
         Span::styled(
-            PREVIOUS_PANES_BUTTON,
-            previous_panes_button_style(app.previous_panes_open(), palette),
+            PANE_SETTINGS_BUTTON,
+            pane_settings_button_style(app.pane_settings_open(), palette),
         ),
         Span::raw(" "),
         Span::styled(
@@ -160,7 +163,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(format!("{} selected", app.selected().len())),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
-        Span::raw(" | Alt+p panes | Alt+t restart | Alt+x swap | Alt+z sleep | Alt+q quit"),
+        Span::raw(" | Alt+p pane settings | Alt+t restart | Alt+x swap | Alt+z sleep | Alt+q quit"),
     ]);
     frame.render_widget(
         Paragraph::new(status).style(Style::default().bg(APP_BG)),
@@ -170,11 +173,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     if app.settings_open() {
         render_settings(frame, area, &app.settings_rows(), palette);
     }
-    let previous_pane_rows = if let Some(view) = previous_panes_view.as_ref() {
-        render_previous_panes(frame, area, view, palette)
-    } else {
-        Vec::new()
-    };
     if let Some(rename) = rename_view.as_ref() {
         render_rename_pane(frame, area, rename);
     }
@@ -188,8 +186,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     DrawState {
         grid_area,
         pane_rects: rects,
-        previous_panes_button,
-        previous_pane_rows,
+        pane_settings_button,
+        pane_settings_reload_button,
     }
 }
 
@@ -266,9 +264,9 @@ fn pane_chrome(
     }
 }
 
-fn previous_panes_button_rect(status_area: Rect) -> Option<Rect> {
+fn pane_settings_button_rect(status_area: Rect) -> Option<Rect> {
     let offset = STATUS_BRAND.len() as u16 + 1;
-    let width = PREVIOUS_PANES_BUTTON.len() as u16;
+    let width = PANE_SETTINGS_BUTTON.len() as u16;
     if status_area.height == 0 || status_area.width < offset.saturating_add(width) {
         return None;
     }
@@ -281,7 +279,7 @@ fn previous_panes_button_rect(status_area: Rect) -> Option<Rect> {
     })
 }
 
-fn previous_panes_button_style(open: bool, palette: &GridPalette) -> Style {
+fn pane_settings_button_style(open: bool, palette: &GridPalette) -> Style {
     if open {
         Style::default()
             .fg(Color::Black)
@@ -295,148 +293,132 @@ fn previous_panes_button_style(open: bool, palette: &GridPalette) -> Style {
     }
 }
 
-fn render_previous_panes(
+fn render_pane_settings(
     frame: &mut Frame<'_>,
     area: Rect,
-    view: &PreviousPanesView,
+    view: &PaneSettingsView,
     palette: &GridPalette,
-) -> Vec<(usize, Rect)> {
-    let modal = previous_panes_modal_rect(area, view.panes.len());
-    let shadow = settings_shadow_rect(area, modal);
-    let mut row_hits = Vec::new();
-
-    if shadow != modal {
-        frame.render_widget(Clear, shadow);
-        frame.render_widget(
-            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
-            shadow,
-        );
+) -> Option<Rect> {
+    if area.width == 0 || area.height == 0 {
+        return None;
     }
 
-    frame.render_widget(Clear, modal);
+    frame.render_widget(Clear, area);
+    let lines = pane_settings_lines(view, area.width, palette);
+    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), area);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(
-            Style::default()
-                .fg(palette.focus())
-                .add_modifier(Modifier::BOLD),
-        )
-        .style(settings_panel_style())
-        .title(" Previous Panes ");
-    let inner = block.inner(modal);
-    frame.render_widget(block, modal);
-
-    if inner.width == 0 || inner.height == 0 {
-        return row_hits;
-    }
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(2),
-            Constraint::Min(1),
-            Constraint::Length(1),
-        ])
-        .split(inner);
-
-    let header = Line::from(vec![
-        Span::raw("  "),
-        Span::styled(
-            format!("{} panes", view.panes.len()),
-            Style::default()
-                .fg(palette.focus())
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled("  current session", Style::default().fg(Color::Gray)),
-    ]);
-    frame.render_widget(
-        Paragraph::new(vec![header, Line::from("")]).style(settings_panel_style()),
-        chunks[0],
-    );
-
-    let list_area = chunks[1];
-    let visible =
-        visible_previous_pane_range(view.panes.len(), view.cursor, list_area.height as usize);
-    let mut rows = Vec::new();
-
-    for (row_offset, index) in visible.enumerate() {
-        let Some(pane) = view.panes.get(index) else {
-            continue;
-        };
-        let row_area = Rect {
-            x: list_area.x,
-            y: list_area.y.saturating_add(row_offset as u16),
-            width: list_area.width,
-            height: 1,
-        };
-        row_hits.push((index, row_area));
-        rows.push(previous_pane_line(
-            pane,
-            view.cursor == index,
-            list_area.width,
-        ));
-    }
-
-    frame.render_widget(
-        Paragraph::new(rows).style(settings_panel_style()),
-        list_area,
-    );
-    frame.render_widget(
-        Paragraph::new(previous_panes_command_bar(chunks[2].width)).style(settings_panel_style()),
-        chunks[2],
-    );
-
-    row_hits
+    pane_settings_reload_rect(area)
 }
 
-fn previous_pane_line(pane: &PreviousPaneView, active: bool, width: u16) -> Line<'static> {
-    let (state, state_color) = previous_pane_state(pane);
-    let label_width = if width < 62 { 10 } else { 16 };
-    let location_width = if width < 62 { 14 } else { 24 };
-    let marker = if active { ">" } else { " " };
-    let location = pane
-        .worktree
-        .as_ref()
-        .map(|worktree| format!("{} | {worktree}", pane.folder))
-        .unwrap_or_else(|| pane.folder.clone());
-    let text = format!(
-        "{marker} {:>2} {:<label_width$} {:<8} {:<location_width$} {}",
-        pane.index + 1,
-        truncate_text(&pane.label, label_width),
-        state,
-        truncate_text(&location, location_width),
-        pane.summary,
-    );
-    let bg = active.then_some(SETTINGS_ROW_ACTIVE);
-    let fg = if active { SETTINGS_TEXT } else { state_color };
-
-    Line::from(Span::styled(
-        fixed_width(&text, width as usize),
-        row_style(fg, bg, active || pane.focused),
-    ))
-}
-
-fn previous_pane_state(pane: &PreviousPaneView) -> (&'static str, Color) {
-    if pane.exited {
+fn pane_settings_state(view: &PaneSettingsView) -> (&'static str, Color) {
+    if view.exited {
         ("exited", Color::Red)
-    } else if pane.sleeping {
+    } else if view.sleeping {
         ("asleep", Color::DarkGray)
-    } else if pane.focused {
+    } else if view.focused {
         ("focus", Color::Yellow)
-    } else if pane.selected {
+    } else if view.selected {
         ("selected", Color::Cyan)
     } else {
         ("live", SETTINGS_TEXT)
     }
 }
 
-fn previous_panes_command_bar(width: u16) -> Line<'static> {
-    if width < 44 {
+fn pane_settings_lines(
+    view: &PaneSettingsView,
+    width: u16,
+    palette: &GridPalette,
+) -> Vec<Line<'static>> {
+    let (state, state_color) = pane_settings_state(view);
+    let location = view
+        .worktree
+        .as_ref()
+        .map(|worktree| format!("{} | {worktree}", view.folder))
+        .unwrap_or_else(|| view.folder.clone());
+    let mut lines = Vec::new();
+
+    if width < 36 {
+        lines.push(Line::from(Span::styled(
+            fixed_width(" Pane Settings", width as usize),
+            Style::default()
+                .fg(palette.focus())
+                .bg(SETTINGS_BG)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(pane_settings_reload_line(width, palette));
+        lines.push(pane_settings_command_bar(width));
+        return lines;
+    }
+
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Pane Settings",
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("pane {} {}", view.index + 1, view.label),
+            Style::default().fg(SETTINGS_TEXT),
+        ),
+        Span::raw("  "),
+        Span::styled(state, Style::default().fg(state_color)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            truncate_text(&location, width.saturating_sub(2) as usize),
+            Style::default().fg(SETTINGS_MUTED),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(settings_section(
+        "HISTORY",
+        "visible conversation snapshot",
+        width,
+    ));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            truncate_text(&view.history_summary, width.saturating_sub(2) as usize),
+            Style::default().fg(SETTINGS_TEXT),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(pane_settings_reload_line(width, palette));
+    lines.push(Line::from(""));
+    lines.push(pane_settings_command_bar(width));
+
+    lines
+}
+
+fn pane_settings_reload_line(width: u16, palette: &GridPalette) -> Line<'static> {
+    let label = "[ Reload past history ]";
+    let text = if width as usize <= label.len() + 4 {
+        fixed_width(label, width as usize)
+    } else {
+        let left = ((width as usize).saturating_sub(label.len())) / 2;
+        let right = (width as usize).saturating_sub(left + label.len());
+        format!("{}{}{}", " ".repeat(left), label, " ".repeat(right))
+    };
+
+    Line::from(Span::styled(
+        text,
+        Style::default()
+            .fg(Color::Black)
+            .bg(palette.focus())
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn pane_settings_command_bar(width: u16) -> Line<'static> {
+    if width < 50 {
         return Line::from(vec![
             Span::raw("  "),
             command_key("Enter"),
-            Span::styled(" focus  ", Style::default().fg(Color::Gray)),
+            Span::styled(" reload  ", Style::default().fg(Color::Gray)),
             command_key("Esc"),
             Span::styled(" close", Style::default().fg(Color::Gray)),
         ]);
@@ -444,49 +426,27 @@ fn previous_panes_command_bar(width: u16) -> Line<'static> {
 
     Line::from(vec![
         Span::raw("  "),
-        command_key("Up/Down"),
-        Span::styled(" move  ", Style::default().fg(Color::Gray)),
-        command_key("Enter"),
-        Span::styled(" focus  ", Style::default().fg(Color::Gray)),
+        command_key("Enter/Space"),
+        Span::styled(" reload  ", Style::default().fg(Color::Gray)),
+        command_key("Alt+o"),
+        Span::styled(" global settings  ", Style::default().fg(Color::Gray)),
         command_key("Esc"),
         Span::styled(" close", Style::default().fg(Color::Gray)),
     ])
 }
 
-fn previous_panes_modal_rect(area: Rect, pane_count: usize) -> Rect {
-    let width = area.width.saturating_sub(4).min(96).max(area.width.min(1));
-    let desired_height = (pane_count as u16).saturating_add(6).clamp(8, 24);
-    let height = area
-        .height
-        .saturating_sub(2)
-        .min(desired_height)
-        .max(area.height.min(1));
-
-    Rect {
-        x: area.x + area.width.saturating_sub(width) / 2,
-        y: area.y + area.height.saturating_sub(height) / 2,
-        width,
-        height,
-    }
-}
-
-fn visible_previous_pane_range(
-    pane_count: usize,
-    cursor: usize,
-    capacity: usize,
-) -> std::ops::Range<usize> {
-    if pane_count == 0 || capacity == 0 {
-        return 0..0;
+fn pane_settings_reload_rect(area: Rect) -> Option<Rect> {
+    let row = if area.width < 36 { 1 } else { 6 };
+    if area.width == 0 || area.height <= row {
+        return None;
     }
 
-    let capacity = capacity.min(pane_count);
-    let cursor = cursor.min(pane_count - 1);
-    let mut start = cursor.saturating_sub(capacity / 2);
-    if start + capacity > pane_count {
-        start = pane_count - capacity;
-    }
-
-    start..start + capacity
+    Some(Rect {
+        x: area.x,
+        y: area.y.saturating_add(row),
+        width: area.width,
+        height: 1,
+    })
 }
 
 fn render_settings(frame: &mut Frame<'_>, area: Rect, rows: &[SettingsRow], palette: &GridPalette) {
@@ -1404,12 +1364,16 @@ mod tests {
     }
 
     #[test]
-    fn previous_pane_range_keeps_cursor_visible() {
-        assert_eq!(visible_previous_pane_range(10, 0, 4), 0..4);
-        assert_eq!(visible_previous_pane_range(10, 5, 4), 3..7);
-        assert_eq!(visible_previous_pane_range(10, 9, 4), 6..10);
-        assert_eq!(visible_previous_pane_range(3, 8, 10), 0..3);
-        assert_eq!(visible_previous_pane_range(3, 1, 0), 0..0);
+    fn pane_settings_reload_button_uses_expected_row() {
+        assert_eq!(
+            pane_settings_reload_rect(Rect::new(5, 10, 40, 12)),
+            Some(Rect::new(5, 16, 40, 1))
+        );
+        assert_eq!(
+            pane_settings_reload_rect(Rect::new(5, 10, 20, 4)),
+            Some(Rect::new(5, 11, 20, 1))
+        );
+        assert_eq!(pane_settings_reload_rect(Rect::new(5, 10, 40, 6)), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the Alt+p previous-panes picker with a settings view rendered inside the focused pane
- add a Reload past history action for the pane's visible conversation snapshot
- keep Alt+o dedicated to global settings and document the new controls

## Validation
- cargo fmt --check
- cargo check
- cargo test
- cargo clippy -- -D warnings

Closes #102