### PR TITLE
fix: parse npm pack json in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,13 +116,17 @@ jobs:
           }
 
           $text = $raw | Out-String
-          $match = [regex]::Match($text, '(?s)\[\s*\{.*?"filename"\s*:\s*"(?<filename>[^"]+)"')
-          if (-not $match.Success) {
+          $parsed = $text | ConvertFrom-Json
+          if ($parsed -is [array]) {
+            $pack = $parsed[0].filename
+          } else {
+            $pack = $parsed.filename
+          }
+
+          if (-not $pack) {
             $text | Write-Output
             throw "Could not parse npm pack filename."
           }
-
-          $pack = $match.Groups["filename"].Value
           "tarball=$pack" >> $env:GITHUB_OUTPUT
 
       - name: Publish npm package
@@ -216,13 +220,17 @@ jobs:
           }
 
           $text = $raw | Out-String
-          $match = [regex]::Match($text, '(?s)\[\s*\{.*?"filename"\s*:\s*"(?<filename>[^"]+)"')
-          if (-not $match.Success) {
+          $parsed = $text | ConvertFrom-Json
+          if ($parsed -is [array]) {
+            $pack = $parsed[0].filename
+          } else {
+            $pack = $parsed.filename
+          }
+
+          if (-not $pack) {
             $text | Write-Output
             throw "Could not parse npm pack filename."
           }
-
-          $pack = $match.Groups["filename"].Value
           "tarball=$pack" >> $env:GITHUB_OUTPUT
 
       - name: Resolve release notes


### PR DESCRIPTION
## Summary
- parse npm pack --json output with ConvertFrom-Json instead of a regex
- handle both array and object output shapes
- apply the fix to manual and tag release paths

Closes #109.

## Validation
- npm pack --json --ignore-scripts --dry-run parser check
- git diff --check