### PR TITLE
fix: handle keyed npm pack output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,15 @@ jobs:
           $parsed = $text | ConvertFrom-Json
           if ($parsed -is [array]) {
             $pack = $parsed[0].filename
-          } else {
+          } elseif ($parsed.filename) {
             $pack = $parsed.filename
+          } else {
+            foreach ($property in $parsed.PSObject.Properties) {
+              if ($property.Value.filename) {
+                $pack = $property.Value.filename
+                break
+              }
+            }
           }
 
           if (-not $pack) {
@@ -223,8 +230,15 @@ jobs:
           $parsed = $text | ConvertFrom-Json
           if ($parsed -is [array]) {
             $pack = $parsed[0].filename
-          } else {
+          } elseif ($parsed.filename) {
             $pack = $parsed.filename
+          } else {
+            foreach ($property in $parsed.PSObject.Properties) {
+              if ($property.Value.filename) {
+                $pack = $property.Value.filename
+                break
+              }
+            }
           }
 
           if (-not $pack) {


### PR DESCRIPTION
## Summary
- handle npm pack JSON objects keyed by package name, such as `gridbash.filename`
- keep support for array and direct object output shapes in both release paths

Closes #109.

## Validation
- parser check against array, direct object, and package-keyed object samples
- npm pack --json --ignore-scripts --dry-run parser check
- git diff --check