### PR TITLE
feat: rename panes from pane settings

### DIFF
--- a/docs/devlogs/2026-07-09-rename-panes-from-per-pane-settings.md
+++ b/docs/devlogs/2026-07-09-rename-panes-from-per-pane-settings.md
@@ -1,0 +1,29 @@
+# Rename panes from per-pane settings
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added pane renaming directly to the focused pane settings overlay.
+
+## What Changed
+
+- Added a visible `Rename pane` action alongside history reload.
+- Added `N` and `Alt+r` keyboard access plus mouse activation.
+- Reused the existing rename editor so validation and saved session behavior stay consistent.
+
+## Why It Matters
+
+- Pane names can now be changed where pane-specific details are already managed, making the feature easier to discover.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `npm run test:launcher`
+
+## Release Notes
+
+- Pane settings now includes a rename action with keyboard and mouse support.

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,6 +109,7 @@ pub struct App {
     previous_panes_button: Option<Rect>,
     previous_pane_rows: Vec<(usize, Rect)>,
     pane_settings_button: Option<Rect>,
+    pane_settings_rename_button: Option<Rect>,
     pane_settings_reload_button: Option<Rect>,
     event_tx: mpsc::UnboundedSender<PtyEvent>,
     event_rx: mpsc::UnboundedReceiver<PtyEvent>,
@@ -1608,6 +1609,7 @@ impl App {
             previous_panes_button: None,
             previous_pane_rows: Vec::new(),
             pane_settings_button: None,
+            pane_settings_rename_button: None,
             pane_settings_reload_button: None,
             event_tx,
             event_rx,
@@ -1874,6 +1876,7 @@ impl App {
                     self.previous_panes_button = draw_state.previous_panes_button;
                     self.previous_pane_rows = draw_state.previous_pane_rows;
                     self.pane_settings_button = draw_state.pane_settings_button;
+                    self.pane_settings_rename_button = draw_state.pane_settings_rename_button;
                     self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
                 })?;
                 self.sync_pane_sizes();
@@ -2952,6 +2955,15 @@ impl App {
         }
 
         let pane_index = self.focus.min(self.panes.len() - 1);
+        self.begin_rename_for(pane_index);
+    }
+
+    fn begin_rename_for(&mut self, pane_index: usize) {
+        if pane_index >= self.panes.len() {
+            self.status = format!("pane {} is no longer available", pane_index + 1);
+            return;
+        }
+
         let current_name = self
             .pane_names
             .get(pane_index)
@@ -3004,6 +3016,10 @@ impl App {
             self.pane_settings.close();
             self.settings.open = true;
             self.status = "settings open".into();
+            return KeyOutcome::Render;
+        }
+        if pane_settings_rename_requested(&key) {
+            self.begin_rename_for(self.pane_settings.pane_index);
             return KeyOutcome::Render;
         }
 
@@ -3795,6 +3811,10 @@ impl App {
             self.reload_pane_history();
             return true;
         }
+        if self.pane_settings_rename_button_at(mouse.column, mouse.row) {
+            self.begin_rename_for(self.pane_settings.pane_index);
+            return true;
+        }
 
         false
     }
@@ -3817,6 +3837,11 @@ impl App {
 
     fn pane_settings_reload_button_at(&self, x: u16, y: u16) -> bool {
         self.pane_settings_reload_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn pane_settings_rename_button_at(&self, x: u16, y: u16) -> bool {
+        self.pane_settings_rename_button
             .is_some_and(|rect| rect_contains(rect, x, y))
     }
 
@@ -5754,6 +5779,12 @@ fn render_if_selection_cleared(outcome: KeyOutcome, selection_cleared: bool) -> 
     }
 }
 
+fn pane_settings_rename_requested(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char('n') | KeyCode::Char('N'))
+        || (key.modifiers.contains(KeyModifiers::ALT)
+            && matches!(key.code, KeyCode::Char('r') | KeyCode::Char('R')))
+}
+
 fn pane_inner_rect(rect: Rect) -> Option<Rect> {
     let width = rect.width.checked_sub(2)?;
     let height = rect.height.checked_sub(2)?;
@@ -6347,6 +6378,22 @@ mod tests {
 
         rename.delete();
         assert_eq!(rename.value, "ab");
+    }
+
+    #[test]
+    fn pane_settings_rename_keys_do_not_replace_plain_reload_key() {
+        assert!(pane_settings_rename_requested(&KeyEvent::new(
+            KeyCode::Char('n'),
+            KeyModifiers::NONE,
+        )));
+        assert!(pane_settings_rename_requested(&KeyEvent::new(
+            KeyCode::Char('r'),
+            KeyModifiers::ALT,
+        )));
+        assert!(!pane_settings_rename_requested(&KeyEvent::new(
+            KeyCode::Char('r'),
+            KeyModifiers::NONE,
+        )));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,6 +33,7 @@ pub struct DrawState {
     pub previous_panes_button: Option<Rect>,
     pub previous_pane_rows: Vec<(usize, Rect)>,
     pub pane_settings_button: Option<Rect>,
+    pub pane_settings_rename_button: Option<Rect>,
     pub pane_settings_reload_button: Option<Rect>,
 }
 
@@ -95,6 +96,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || prompt_view.is_some()
         || image_overlay.is_some()
         || exited_recovery.is_some();
+    let mut pane_settings_rename_button = None;
     let mut pane_settings_reload_button = None;
     render_tabs(frame, tab_area, &app.tab_labels(), palette);
 
@@ -147,7 +149,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
         if let Some(view) = app.pane_settings_view(index) {
-            pane_settings_reload_button = render_pane_settings(frame, inner, &view, palette);
+            let buttons = render_pane_settings(frame, inner, &view, palette);
+            pane_settings_rename_button = buttons.rename;
+            pane_settings_reload_button = buttons.reload;
         } else if sleeping {
             render_sleeping_screen(frame, inner);
         } else {
@@ -251,6 +255,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         previous_panes_button,
         previous_pane_rows,
         pane_settings_button,
+        pane_settings_rename_button,
         pane_settings_reload_button,
     }
 }
@@ -676,16 +681,25 @@ fn render_pane_settings(
     area: Rect,
     view: &PaneSettingsView,
     palette: &GridPalette,
-) -> Option<Rect> {
+) -> PaneSettingsButtons {
     if area.width == 0 || area.height == 0 {
-        return None;
+        return PaneSettingsButtons::default();
     }
 
     frame.render_widget(Clear, area);
     let lines = pane_settings_lines(view, area.width, palette);
     frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), area);
 
-    pane_settings_reload_rect(area)
+    PaneSettingsButtons {
+        rename: pane_settings_rename_rect(area),
+        reload: pane_settings_reload_rect(area),
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct PaneSettingsButtons {
+    rename: Option<Rect>,
+    reload: Option<Rect>,
 }
 
 fn pane_settings_state(view: &PaneSettingsView) -> (&'static str, Color) {
@@ -723,6 +737,7 @@ fn pane_settings_lines(
                 .bg(SETTINGS_BG)
                 .add_modifier(Modifier::BOLD),
         )));
+        lines.push(pane_settings_rename_line(width, palette));
         lines.push(pane_settings_reload_line(width, palette));
         lines.push(pane_settings_command_bar(width));
         return lines;
@@ -765,6 +780,7 @@ fn pane_settings_lines(
         ),
     ]));
     lines.push(Line::from(""));
+    lines.push(pane_settings_rename_line(width, palette));
     lines.push(pane_settings_reload_line(width, palette));
     lines.push(Line::from(""));
     lines.push(pane_settings_command_bar(width));
@@ -772,8 +788,15 @@ fn pane_settings_lines(
     lines
 }
 
+fn pane_settings_rename_line(width: u16, palette: &GridPalette) -> Line<'static> {
+    pane_settings_action_line("[ Rename pane ]", width, palette.selected())
+}
+
 fn pane_settings_reload_line(width: u16, palette: &GridPalette) -> Line<'static> {
-    let label = "[ Reload past history ]";
+    pane_settings_action_line("[ Reload past history ]", width, palette.focus())
+}
+
+fn pane_settings_action_line(label: &str, width: u16, background: Color) -> Line<'static> {
     let text = if width as usize <= label.len() + 4 {
         fixed_width(label, width as usize)
     } else {
@@ -786,7 +809,7 @@ fn pane_settings_reload_line(width: u16, palette: &GridPalette) -> Line<'static>
         text,
         Style::default()
             .fg(Color::Black)
-            .bg(palette.focus())
+            .bg(background)
             .add_modifier(Modifier::BOLD),
     ))
 }
@@ -795,7 +818,9 @@ fn pane_settings_command_bar(width: u16) -> Line<'static> {
     if width < 50 {
         return Line::from(vec![
             Span::raw("  "),
-            command_key("Enter"),
+            command_key("N"),
+            Span::styled(" rename  ", Style::default().fg(Color::Gray)),
+            command_key("R"),
             Span::styled(" reload  ", Style::default().fg(Color::Gray)),
             command_key("Esc"),
             Span::styled(" close", Style::default().fg(Color::Gray)),
@@ -804,7 +829,9 @@ fn pane_settings_command_bar(width: u16) -> Line<'static> {
 
     Line::from(vec![
         Span::raw("  "),
-        command_key("Enter/Space"),
+        command_key("N"),
+        Span::styled(" rename  ", Style::default().fg(Color::Gray)),
+        command_key("R/Enter"),
         Span::styled(" reload  ", Style::default().fg(Color::Gray)),
         command_key("Alt+o"),
         Span::styled(" global settings  ", Style::default().fg(Color::Gray)),
@@ -813,8 +840,15 @@ fn pane_settings_command_bar(width: u16) -> Line<'static> {
     ])
 }
 
+fn pane_settings_rename_rect(area: Rect) -> Option<Rect> {
+    pane_settings_action_rect(area, if area.width < 36 { 1 } else { 6 })
+}
+
 fn pane_settings_reload_rect(area: Rect) -> Option<Rect> {
-    let row = if area.width < 36 { 1 } else { 6 };
+    pane_settings_action_rect(area, if area.width < 36 { 2 } else { 7 })
+}
+
+fn pane_settings_action_rect(area: Rect, row: u16) -> Option<Rect> {
     if area.width == 0 || area.height <= row {
         return None;
     }
@@ -2523,15 +2557,24 @@ mod tests {
     }
 
     #[test]
-    fn pane_settings_reload_button_uses_expected_row() {
+    fn pane_settings_action_buttons_use_expected_rows() {
         assert_eq!(
-            pane_settings_reload_rect(Rect::new(5, 10, 40, 12)),
+            pane_settings_rename_rect(Rect::new(5, 10, 40, 12)),
             Some(Rect::new(5, 16, 40, 1))
         );
         assert_eq!(
-            pane_settings_reload_rect(Rect::new(5, 10, 20, 4)),
+            pane_settings_reload_rect(Rect::new(5, 10, 40, 12)),
+            Some(Rect::new(5, 17, 40, 1))
+        );
+        assert_eq!(
+            pane_settings_rename_rect(Rect::new(5, 10, 20, 4)),
             Some(Rect::new(5, 11, 20, 1))
         );
+        assert_eq!(
+            pane_settings_reload_rect(Rect::new(5, 10, 20, 4)),
+            Some(Rect::new(5, 12, 20, 1))
+        );
+        assert_eq!(pane_settings_rename_rect(Rect::new(5, 10, 40, 6)), None);
         assert_eq!(pane_settings_reload_rect(Rect::new(5, 10, 40, 6)), None);
     }
 


### PR DESCRIPTION
## Summary

- add a visible Rename pane action to per-pane settings
- support mouse activation plus N and Alt+r shortcuts
- reuse the existing rename editor and preserve history reload behavior
- add focused keyboard and hit-region coverage

## Validation

- cargo fmt -- --check
- cargo test (96 passed, 1 ignored)
- cargo clippy --all-targets -- -D warnings
- npm run test:launcher (4 passed)

Closes #117