### PR TITLE
feat: add push-to-talk voice mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
 | Alt+c | Focus or unfocus the command bar |
+| Alt+v | Listen for one dictated utterance; press again to cancel |
 | Alt+p | Open settings for the focused pane; use Reload past history to refresh its visible conversation snapshot |
 | Alt+Shift+p | Open the previous panes list |
 | Alt+r | Rename the focused pane |
@@ -289,6 +290,13 @@ When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter
 exited target panes directly.
 
 Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. When the one-line command bar is focused, typing stays in that bar; Enter runs the command from the cwd shown in the prompt and keeps output hidden until expanded.
+
+Voice mode uses the installed Windows speech recognizer and the default microphone.
+Press `Alt+v` to listen for one utterance (up to 15 seconds). The transcript is
+inserted into the command bar or the panes that were targeted when listening
+started. GridBash never presses Enter for dictated text, so you can review or edit
+it before submitting. Press `Alt+v` while listening to cancel. A Windows speech
+language pack matching the desired dictation language must be installed.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
 

--- a/docs/devlogs/2026-07-09-add-voice-mode.md
+++ b/docs/devlogs/2026-07-09-add-voice-mode.md
@@ -1,0 +1,31 @@
+# Add voice mode
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added cancellable push-to-talk dictation for GridBash terminal and command-bar input.
+
+## What Changed
+
+- Added `Alt+v` to listen for one utterance with the installed Windows speech recognizer.
+- Preserved the command bar or pane targets selected when listening starts and never auto-submitted dictated text.
+- Added cancellation, no-speech, unavailable-recognizer, microphone-error, and changed-tab status handling.
+- Added a visible `MIC` state plus shortcut and setup documentation.
+
+## Why It Matters
+
+- Longer agent prompts can be dictated without leaving the keyboard-driven GridBash workflow or risking immediate command execution.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test` (98 passed, 1 existing interactive ConPTY smoke test ignored)
+- `cargo build --release`
+- Confirmed `System.Speech` loads and one Windows speech recognizer is installed on the development machine.
+
+## Release Notes
+
+- Press `Alt+v` to dictate into the current command bar or pane targets. Press it again to cancel; review the inserted text and submit it normally when ready.

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ use crate::{
     ui,
     usage::{self, UsageEvent, UsageTarget},
     vibe,
+    voice::{VoiceInput, VoiceOutcome},
     worktrees::ManagedWorktreeOptions,
 };
 
@@ -90,6 +91,8 @@ pub struct App {
     command_line: CommandLineState,
     command_tx: mpsc::UnboundedSender<CommandRunEvent>,
     command_rx: mpsc::UnboundedReceiver<CommandRunEvent>,
+    voice: VoiceInput,
+    voice_destination: Option<VoiceDestination>,
     control_handle: Option<ControlHandle>,
     control_rx: Option<std_mpsc::Receiver<ControlEnvelope>>,
     image_overlay: Option<ImagePreview>,
@@ -169,6 +172,12 @@ enum KeyOutcome {
     Render,
     AuthLogin(AuthProfile),
     Quit,
+}
+
+#[derive(Debug, Clone)]
+enum VoiceDestination {
+    CommandLine,
+    Panes { tab: usize, panes: Vec<PaneId> },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1459,10 +1468,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
+        "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
             .into()
     } else {
-        "Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
+        "Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
             .into()
     }
 }
@@ -1590,6 +1599,8 @@ impl App {
             command_line: CommandLineState::new(init.command_cwd),
             command_tx,
             command_rx,
+            voice: VoiceInput::new(),
+            voice_destination: None,
             control_handle: init.control_handle,
             control_rx: init.control_rx,
             image_overlay: None,
@@ -1863,6 +1874,7 @@ impl App {
             needs_render |= self.drain_usage_events();
             needs_render |= self.drain_auth_refresh();
             needs_render |= self.drain_command_events();
+            needs_render |= self.drain_voice_events()?;
             needs_render |= self.drain_control_events();
             needs_render |= self.decay_activity();
             needs_render |= self.update_follow_up_prompt();
@@ -2339,6 +2351,58 @@ impl App {
         changed
     }
 
+    fn drain_voice_events(&mut self) -> Result<bool> {
+        let Some(outcome) = self.voice.poll() else {
+            return Ok(false);
+        };
+        let destination = self.voice_destination.take();
+
+        match outcome {
+            VoiceOutcome::Transcript(transcript) => match destination {
+                Some(VoiceDestination::CommandLine) => {
+                    let chars = transcript.chars().count();
+                    self.command_line.insert_text(&transcript);
+                    self.status = format!("voice inserted {chars} chars into command line");
+                }
+                Some(VoiceDestination::Panes { tab, panes }) if tab == self.active_tab => {
+                    let targets = panes
+                        .iter()
+                        .filter_map(|pane_id| {
+                            self.panes.iter().position(|pane| pane.id() == *pane_id)
+                        })
+                        .collect::<Vec<_>>();
+                    if targets.is_empty() {
+                        self.status = "voice target is no longer available".into();
+                    } else {
+                        let pane_count = targets.len();
+                        let status_changed =
+                            self.route_input_to_targets(transcript.as_bytes(), targets)?;
+                        if !status_changed {
+                            self.status = format!(
+                                "voice inserted into {pane_count} {}",
+                                pane_word(pane_count)
+                            );
+                        }
+                    }
+                }
+                Some(VoiceDestination::Panes { .. }) => {
+                    self.status = "voice result discarded after tab changed".into();
+                }
+                None => {
+                    self.status = "voice result had no input target".into();
+                }
+            },
+            VoiceOutcome::NoSpeech => {
+                self.status = "voice heard no speech; press Alt+v to try again".into();
+            }
+            VoiceOutcome::Error(error) => {
+                self.status = format!("voice unavailable: {error}");
+            }
+        }
+
+        Ok(true)
+    }
+
     fn drain_control_events(&mut self) -> bool {
         let mut changed = false;
 
@@ -2682,6 +2746,10 @@ impl App {
             'c' => {
                 self.command_line.focused = !self.command_line.focused;
                 self.status = self.focus_status();
+                Ok(Some(false))
+            }
+            'v' => {
+                self.toggle_voice_input();
                 Ok(Some(false))
             }
             'e' => {
@@ -4487,8 +4555,45 @@ impl App {
         }
     }
 
+    fn toggle_voice_input(&mut self) {
+        if self.voice.cancel() {
+            self.voice_destination = None;
+            self.status = "voice capture canceled".into();
+            return;
+        }
+
+        let destination = if self.command_line.focused {
+            VoiceDestination::CommandLine
+        } else {
+            let panes = self
+                .input_targets()
+                .into_iter()
+                .filter_map(|index| self.panes.get(index).map(PtyPane::id))
+                .collect::<Vec<_>>();
+            if panes.is_empty() {
+                self.status = "no awake panes available for voice input".into();
+                return;
+            }
+            VoiceDestination::Panes {
+                tab: self.active_tab,
+                panes,
+            }
+        };
+
+        self.voice_destination = Some(destination);
+        self.voice.start();
+        self.status = format!(
+            "voice listening for {} (Alt+v cancels; speech is not submitted)",
+            self.input_scope_label()
+        );
+    }
+
     fn route_input(&mut self, bytes: &[u8]) -> Result<bool> {
         let targets = self.input_targets();
+        self.route_input_to_targets(bytes, targets)
+    }
+
+    fn route_input_to_targets(&mut self, bytes: &[u8], targets: Vec<usize>) -> Result<bool> {
         let mut skipped_exited = 0;
 
         for index in targets {
@@ -4991,6 +5096,10 @@ impl App {
 
     pub fn command_running(&self) -> bool {
         self.command_line.running
+    }
+
+    pub fn voice_listening(&self) -> bool {
+        self.voice.is_listening()
     }
 
     pub fn input_scope_label(&self) -> &'static str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod setup;
 mod ui;
 mod usage;
 mod vibe;
+mod voice;
 mod worktrees;
 
 use anyhow::Result;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -194,9 +194,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         ),
         Span::raw(" "),
         Span::styled(
-            "LIVE",
+            if app.voice_listening() { "MIC" } else { "LIVE" },
             Style::default()
-                .fg(palette.focus())
+                .fg(if app.voice_listening() {
+                    palette.accent()
+                } else {
+                    palette.focus()
+                })
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" | "),
@@ -215,7 +219,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,0 +1,250 @@
+use std::{
+    io::Read,
+    process::{Child, Command, ExitStatus, Stdio},
+    sync::mpsc::{self, Receiver, Sender, TryRecvError},
+    thread,
+    time::Duration,
+};
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const NO_SPEECH_EXIT_CODE: i32 = 2;
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+const RECOGNIZE_SCRIPT: &str = r#"
+$ErrorActionPreference = 'Stop'
+$recognizer = $null
+try {
+    Add-Type -AssemblyName System.Speech
+    $recognizer = New-Object System.Speech.Recognition.SpeechRecognitionEngine
+    $recognizer.LoadGrammar((New-Object System.Speech.Recognition.DictationGrammar))
+    $recognizer.SetInputToDefaultAudioDevice()
+    $result = $recognizer.Recognize([TimeSpan]::FromSeconds(15))
+    if ($null -eq $result) { exit 2 }
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    [Console]::Out.Write($result.Text)
+} catch {
+    [Console]::Error.Write($_.Exception.Message)
+    exit 1
+} finally {
+    if ($null -ne $recognizer) { $recognizer.Dispose() }
+}
+"#;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoiceOutcome {
+    Transcript(String),
+    NoSpeech,
+    Error(String),
+}
+
+#[derive(Debug)]
+struct VoiceEvent {
+    request_id: u64,
+    outcome: VoiceOutcome,
+}
+
+pub struct VoiceInput {
+    event_tx: Sender<VoiceEvent>,
+    event_rx: Receiver<VoiceEvent>,
+    cancel_tx: Option<Sender<()>>,
+    active_request: Option<u64>,
+    next_request: u64,
+}
+
+impl VoiceInput {
+    pub fn new() -> Self {
+        let (event_tx, event_rx) = mpsc::channel();
+        Self {
+            event_tx,
+            event_rx,
+            cancel_tx: None,
+            active_request: None,
+            next_request: 0,
+        }
+    }
+
+    pub fn start(&mut self) {
+        if self.is_listening() {
+            return;
+        }
+
+        let request_id = self.next_request;
+        self.next_request = self.next_request.wrapping_add(1);
+        let (cancel_tx, cancel_rx) = mpsc::channel();
+        let event_tx = self.event_tx.clone();
+
+        thread::spawn(move || {
+            if let Some(outcome) = recognize(cancel_rx) {
+                let _ = event_tx.send(VoiceEvent {
+                    request_id,
+                    outcome,
+                });
+            }
+        });
+
+        self.cancel_tx = Some(cancel_tx);
+        self.active_request = Some(request_id);
+    }
+
+    pub fn cancel(&mut self) -> bool {
+        let Some(cancel_tx) = self.cancel_tx.take() else {
+            return false;
+        };
+        let _ = cancel_tx.send(());
+        self.active_request = None;
+        true
+    }
+
+    pub fn is_listening(&self) -> bool {
+        self.active_request.is_some()
+    }
+
+    pub fn poll(&mut self) -> Option<VoiceOutcome> {
+        while let Ok(event) = self.event_rx.try_recv() {
+            if self.active_request == Some(event.request_id) {
+                self.active_request = None;
+                self.cancel_tx = None;
+                return Some(event.outcome);
+            }
+        }
+        None
+    }
+}
+
+impl Default for VoiceInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for VoiceInput {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+fn recognize(cancel_rx: Receiver<()>) -> Option<VoiceOutcome> {
+    let mut command = Command::new("powershell.exe");
+    command
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            RECOGNIZE_SCRIPT,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return Some(VoiceOutcome::Error(format!(
+                "could not start Windows speech recognition: {error}"
+            )));
+        }
+    };
+
+    loop {
+        match cancel_rx.try_recv() {
+            Ok(()) | Err(TryRecvError::Disconnected) => {
+                terminate(&mut child);
+                return None;
+            }
+            Err(TryRecvError::Empty) => {}
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(read_outcome(&mut child, status)),
+            Ok(None) => thread::sleep(PROCESS_POLL_INTERVAL),
+            Err(error) => {
+                terminate(&mut child);
+                return Some(VoiceOutcome::Error(format!(
+                    "speech recognition failed: {error}"
+                )));
+            }
+        }
+    }
+}
+
+fn terminate(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn read_outcome(child: &mut Child, status: ExitStatus) -> VoiceOutcome {
+    let stdout = read_pipe(child.stdout.take());
+    let stderr = read_pipe(child.stderr.take());
+
+    if status.success() {
+        let transcript = normalize_transcript(&stdout);
+        return if transcript.is_empty() {
+            VoiceOutcome::NoSpeech
+        } else {
+            VoiceOutcome::Transcript(transcript)
+        };
+    }
+
+    if status.code() == Some(NO_SPEECH_EXIT_CODE) {
+        return VoiceOutcome::NoSpeech;
+    }
+
+    let detail = normalize_transcript(&stderr);
+    if detail.is_empty() {
+        VoiceOutcome::Error(format!("Windows speech recognition exited with {status}"))
+    } else {
+        VoiceOutcome::Error(detail)
+    }
+}
+
+fn read_pipe<R: Read>(pipe: Option<R>) -> String {
+    let mut bytes = Vec::new();
+    if let Some(mut pipe) = pipe {
+        let _ = pipe.read_to_end(&mut bytes);
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn normalize_transcript(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_normalization_removes_transport_whitespace() {
+        assert_eq!(
+            normalize_transcript("  hello\r\n   voice   mode  "),
+            "hello voice mode"
+        );
+    }
+
+    #[test]
+    fn completed_request_returns_one_result_and_becomes_idle() {
+        let mut input = VoiceInput::new();
+        input.active_request = Some(7);
+        input
+            .event_tx
+            .send(VoiceEvent {
+                request_id: 7,
+                outcome: VoiceOutcome::Transcript("hello".into()),
+            })
+            .expect("voice event");
+
+        assert!(input.is_listening());
+        assert_eq!(input.poll(), Some(VoiceOutcome::Transcript("hello".into())));
+        assert!(!input.is_listening());
+        assert_eq!(input.poll(), None);
+    }
+}


### PR DESCRIPTION
## Summary
- add cancellable `Alt+v` push-to-talk dictation using the installed Windows speech recognizer
- route transcripts to the command bar or pane targets captured when listening starts without auto-submitting
- show listening, cancellation, no-speech, unavailable-recognizer, microphone-error, and changed-tab states
- document voice mode and record the change in dev notes

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (98 passed, 1 existing interactive ConPTY smoke test ignored)
- `cargo build --release`
- loaded `System.Speech` and confirmed one installed recognizer on the development machine

Closes #116