### PR TITLE
feat: add auth profile selection and cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ language pack matching the desired dictation language must be installed.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
 
-Settings includes a General tab for local runtime display controls and an Auth tab for GridBash-wide Claude/Codex auth defaults.
+Settings includes a General tab for local runtime display controls and an Auth tab for GridBash-wide Claude/Codex auth defaults and launch policy. Pane Settings lets each Claude or Codex pane select its own compatible auth account; applying a different account restarts only that pane.
 
 Pane titles add a small quiet-output marker after roughly three seconds without output. The marker means a pane produced output and then went idle; it does not mean the process exited or completed its task.
 
@@ -311,10 +311,14 @@ The settings screen includes sample controls plus live color controls for the ac
 GridBash can launch Claude and Codex with isolated auth/config directories. It discovers profiles from:
 
 ```text
-GRIDBASH_AUTH_HOME > CLAUDE_PROFILES_HOME > [auth].home > %USERPROFILE%\.claude-profiles
+GRIDBASH_AUTH_HOME > [auth].home > CLAUDE_PROFILES_HOME (legacy) > %USERPROFILE%\.gridbash-auth
 ```
 
 Claude profiles launch with `CLAUDE_CONFIG_DIR=<profile-dir>`. Codex profiles launch with `CODEX_HOME=<profile-dir>`.
+
+The default home changed from `%USERPROFILE%\.claude-profiles` to `%USERPROFILE%\.gridbash-auth`. Existing profiles are not moved automatically. Move them to the new directory, set `[auth].home` to the old directory, or keep using the legacy `CLAUDE_PROFILES_HOME` override.
+
+Auth assignment is manual by default. In manual mode, new panes use the configured default for their agent kind and keep any per-pane selection. When auto-cycle is enabled, new compatible panes are assigned round-robin across ready auth profiles of the matching kind. Changing the policy does not restart panes that are already running.
 
 Auth settings controls:
 
@@ -323,10 +327,13 @@ Auth settings controls:
 | Tab | Switch Settings tabs |
 | Up / Down | Move through auth profiles |
 | d | Set selected profile as the GridBash-wide default for its kind |
+| c | Toggle manual assignment / auto-cycle for new panes |
 | n | Create a profile directory |
 | l | Open the selected profile's login command |
 | r | Refresh local account and usage status |
 | Esc / q | Close settings |
+
+For a Claude or Codex pane, open Pane Settings with `Alt+P`, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the pane's history snapshot.
 
 Usage status is best-effort. GridBash reads local auth metadata, masks account emails, and uses short-timeout `curl.exe` requests only while the Auth settings view is refreshed.
 
@@ -354,7 +361,8 @@ profile = "powershell"
 manager_profile = "claude-1"
 
 [auth]
-home = "C:\\Users\\Jason\\.claude-profiles"
+home = "C:\\Users\\Jason\\.gridbash-auth"
+auto_cycle = false
 usage_status = true
 
 [auth.defaults]

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,8 @@ prompts = [
 ]
 
 [auth]
-home = "C:\\Users\\Jason\\.claude-profiles"
+home = "C:\\Users\\Jason\\.gridbash-auth"
+auto_cycle = false
 usage_status = true
 
 [auth.defaults]

--- a/docs/devlogs/2026-07-09-add-auth-profile-selection-and-cycling.md
+++ b/docs/devlogs/2026-07-09-add-auth-profile-selection-and-cycling.md
@@ -1,0 +1,34 @@
+# add auth profile selection and cycling
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added GridBash-owned auth storage, per-pane auth account switching, and optional round-robin auth assignment for Claude and Codex panes.
+
+## What Changed
+
+- Changed the default auth profile home from `%USERPROFILE%\.claude-profiles` to `%USERPROFILE%\.gridbash-auth`, while retaining the legacy environment override for explicit compatibility.
+- Added a manual-by-default `auth.auto_cycle` setting and an Auth Settings control that toggles round-robin assignment across ready profiles.
+- Added a compatible account picker to Pane Settings. Applying a selection updates the pane launch environment, restarts only that pane, refreshes usage monitoring, and saves the selection in session metadata.
+- Keyed pane usage labels by the applied auth directory so panes using the same launch profile but different accounts show the correct account usage.
+- Documented migration choices for existing profile directories and the new global/per-pane controls.
+
+## Why It Matters
+
+- Auth storage now belongs clearly to GridBash instead of appearing Claude-specific.
+- Users with several Claude or Codex accounts can either pin accounts pane by pane or distribute new panes automatically without changing shell environment variables by hand.
+
+## Validation
+
+- `cargo test` (101 passed, 1 ignored after merging current `main`)
+- `cargo clippy --all-targets -- -D warnings`
+- `npm test` (101 passed, 1 ignored)
+
+## Release Notes
+
+- GridBash auth profiles now default to `%USERPROFILE%\.gridbash-auth`.
+- Choose an auth account from Pane Settings, or enable account auto-cycle from the global Auth Settings tab.
+
+Tracks #118.

--- a/src/app.rs
+++ b/src/app.rs
@@ -634,6 +634,17 @@ pub struct PaneSettingsView {
     pub selected: bool,
     pub sleeping: bool,
     pub exited: bool,
+    pub auth_kind: Option<AgentKind>,
+    pub auth_options: Vec<PaneAuthOption>,
+    pub auth_cursor: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct PaneAuthOption {
+    pub name: String,
+    pub account_label: Option<String>,
+    pub ready: bool,
+    pub current: bool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -641,13 +652,15 @@ struct PaneSettingsState {
     open: bool,
     pane_index: usize,
     history_summary: Option<String>,
+    auth_cursor: usize,
 }
 
 impl PaneSettingsState {
-    fn open(&mut self, pane_index: usize, history_summary: String) {
+    fn open(&mut self, pane_index: usize, history_summary: String, auth_cursor: usize) {
         self.open = true;
         self.pane_index = pane_index;
         self.history_summary = Some(history_summary);
+        self.auth_cursor = auth_cursor;
     }
 
     fn close(&mut self) {
@@ -2291,16 +2304,13 @@ impl App {
 
         while let Ok(event) = self.usage_rx.try_recv() {
             match event {
-                UsageEvent::Profile {
-                    profile_name,
-                    label,
-                } => match label {
+                UsageEvent::Profile { usage_key, label } => match label {
                     Some(label) => {
-                        changed |= self.profile_usage.get(&profile_name) != Some(&label);
-                        self.profile_usage.insert(profile_name, label);
+                        changed |= self.profile_usage.get(&usage_key) != Some(&label);
+                        self.profile_usage.insert(usage_key, label);
                     }
                     None => {
-                        changed |= self.profile_usage.remove(&profile_name).is_some();
+                        changed |= self.profile_usage.remove(&usage_key).is_some();
                     }
                 },
                 UsageEvent::ApiSpend { label } => {
@@ -2580,7 +2590,7 @@ impl App {
         }
 
         if self.pane_settings.open {
-            let outcome = self.handle_pane_settings_key(key);
+            let outcome = self.handle_pane_settings_key(key)?;
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
@@ -3057,8 +3067,27 @@ impl App {
 
         self.previous_panes.close();
         let pane_index = self.focus.min(self.panes.len() - 1);
+        if self.auth_profiles.is_empty() {
+            match auth::discover_profiles(&self.config.auth) {
+                Ok(profiles) => self.auth_profiles = profiles,
+                Err(error) => {
+                    self.status = format!("failed to load auth profiles: {error:#}");
+                }
+            }
+        }
         let history_summary = self.pane_history_summary(pane_index);
-        self.pane_settings.open(pane_index, history_summary);
+        let current_auth = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(pane_index))
+            .and_then(|spec| spec.auth_name.as_deref());
+        let auth_cursor = self
+            .compatible_auth_profiles(pane_index)
+            .iter()
+            .position(|profile| Some(profile.name.as_str()) == current_auth)
+            .unwrap_or(0);
+        self.pane_settings
+            .open(pane_index, history_summary, auth_cursor);
         self.status = format!("pane {} settings open", pane_index + 1);
     }
 
@@ -3068,15 +3097,15 @@ impl App {
         self.status = format!("pane {pane_number} settings closed");
     }
 
-    fn handle_pane_settings_key(&mut self, key: KeyEvent) -> KeyOutcome {
+    fn handle_pane_settings_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
-            return KeyOutcome::Quit;
+            return Ok(KeyOutcome::Quit);
         }
         if key.modifiers.contains(KeyModifiers::ALT)
             && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
         {
             self.close_pane_settings();
-            return KeyOutcome::Render;
+            return Ok(KeyOutcome::Render);
         }
         if key.modifiers.contains(KeyModifiers::ALT)
             && matches!(key.code, KeyCode::Char('o') | KeyCode::Char('O'))
@@ -3084,11 +3113,11 @@ impl App {
             self.pane_settings.close();
             self.settings.open = true;
             self.status = "settings open".into();
-            return KeyOutcome::Render;
+            return Ok(KeyOutcome::Render);
         }
         if pane_settings_rename_requested(&key) {
             self.begin_rename_for(self.pane_settings.pane_index);
-            return KeyOutcome::Render;
+            return Ok(KeyOutcome::Render);
         }
 
         let changed = match key.code {
@@ -3096,7 +3125,23 @@ impl App {
                 self.close_pane_settings();
                 true
             }
-            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('r') | KeyCode::Char('R') => {
+            KeyCode::Left | KeyCode::Up => {
+                self.move_pane_auth_cursor(-1);
+                true
+            }
+            KeyCode::Right | KeyCode::Down => {
+                self.move_pane_auth_cursor(1);
+                true
+            }
+            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('a') | KeyCode::Char('A') => {
+                if self.selected_pane_auth_profile().is_some() {
+                    self.apply_selected_pane_auth()?;
+                } else {
+                    self.reload_pane_history();
+                }
+                true
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') => {
                 self.reload_pane_history();
                 true
             }
@@ -3104,10 +3149,78 @@ impl App {
         };
 
         if changed {
-            KeyOutcome::Render
+            Ok(KeyOutcome::Render)
         } else {
-            KeyOutcome::Continue
+            Ok(KeyOutcome::Continue)
         }
+    }
+
+    fn compatible_auth_profiles(&self, pane_index: usize) -> Vec<&AuthProfile> {
+        let kind = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(pane_index))
+            .and_then(|spec| spec.command.agent_kind);
+        self.auth_profiles
+            .iter()
+            .filter(|profile| Some(profile.kind) == kind)
+            .collect()
+    }
+
+    fn move_pane_auth_cursor(&mut self, delta: isize) {
+        let len = self
+            .compatible_auth_profiles(self.pane_settings.pane_index)
+            .len();
+        if len == 0 {
+            self.pane_settings.auth_cursor = 0;
+            return;
+        }
+
+        self.pane_settings.auth_cursor =
+            (self.pane_settings.auth_cursor as isize + delta).rem_euclid(len as isize) as usize;
+    }
+
+    fn selected_pane_auth_profile(&self) -> Option<&AuthProfile> {
+        self.compatible_auth_profiles(self.pane_settings.pane_index)
+            .get(self.pane_settings.auth_cursor)
+            .copied()
+    }
+
+    fn apply_selected_pane_auth(&mut self) -> Result<()> {
+        let pane_index = self.pane_settings.pane_index;
+        let Some(profile) = self.selected_pane_auth_profile().cloned() else {
+            self.status = "no compatible auth profile selected".into();
+            return Ok(());
+        };
+        let auth_env = auth::env_for_profile(&self.config.auth, profile.kind, &profile.name)?;
+        let mut spec = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(pane_index))
+            .cloned()
+            .ok_or_else(|| anyhow!("pane {} has no launch settings", pane_index + 1))?;
+        set_spec_auth(&mut spec, auth_env);
+        let pane = self.spawn_pane_instance(&spec, pane_index)?;
+
+        self.panes[pane_index] = pane;
+        if let Some(plan) = &mut self.launch_plan {
+            plan.panes[pane_index] = spec;
+        }
+        if let Some(idle) = self.pane_idle.get_mut(pane_index) {
+            *idle = PaneIdleState::new(Instant::now());
+        }
+        self.sleeping.remove(&pane_index);
+        self.pane_settings
+            .refresh_history("waiting for output".into());
+        self.start_usage_for_active_tab();
+        self.save_session_snapshot()?;
+        self.status = format!(
+            "pane {} restarted with {} auth {}",
+            pane_index + 1,
+            profile.kind.display_name(),
+            profile.name
+        );
+        Ok(())
     }
 
     fn reload_pane_history(&mut self) {
@@ -3656,6 +3769,10 @@ impl App {
                 self.set_selected_auth_default()?;
                 true
             }
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                self.toggle_auth_auto_cycle()?;
+                true
+            }
             KeyCode::Char('n') | KeyCode::Char('N') => {
                 self.start_auth_create()?;
                 true
@@ -4121,9 +4238,13 @@ impl App {
 
         let templates = plan.panes.clone();
         while plan.panes.len() < target_count {
-            let spec = templates[plan.panes.len() % templates.len()].clone();
+            let mut spec = templates[plan.panes.len() % templates.len()].clone();
+            if self.config.auth.auto_cycle {
+                clear_spec_auth(&mut spec);
+            }
             plan.panes.push(spec);
         }
+        apply_auth_defaults(plan, &self.config)?;
 
         Ok(plan.panes[self.panes.len()..target_count].to_vec())
     }
@@ -4897,6 +5018,10 @@ impl App {
             .unwrap_or_else(|error| format!("unresolved: {error:#}"))
     }
 
+    pub fn auth_auto_cycle(&self) -> bool {
+        self.config.auth.auto_cycle
+    }
+
     pub fn activity_badges_enabled(&self) -> bool {
         self.settings.activity_badges
     }
@@ -4968,6 +5093,21 @@ impl App {
         }
 
         let pane = self.panes.get(index)?;
+        let spec = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(index));
+        let current_auth = spec.and_then(|spec| spec.auth_name.as_deref());
+        let auth_options = self
+            .compatible_auth_profiles(index)
+            .into_iter()
+            .map(|profile| PaneAuthOption {
+                name: profile.name.clone(),
+                account_label: profile.account_label.clone(),
+                ready: profile.ready,
+                current: Some(profile.name.as_str()) == current_auth,
+            })
+            .collect();
         Some(PaneSettingsView {
             index,
             label: self.pane_label(index),
@@ -4985,6 +5125,9 @@ impl App {
             selected: self.selected.contains(&index),
             sleeping: self.sleeping.contains(&index),
             exited: pane.exited,
+            auth_kind: spec.and_then(|spec| spec.command.agent_kind),
+            auth_options,
+            auth_cursor: self.pane_settings.auth_cursor,
         })
     }
 
@@ -5170,12 +5313,17 @@ impl App {
     pub fn pane_usage_label(&self, index: usize) -> Option<String> {
         let mut parts = Vec::new();
 
-        if let Some(profile_name) = self
+        if let Some(usage_key) = self
             .launch_plan
             .as_ref()
             .and_then(|plan| plan.panes.get(index))
-            .map(|pane| pane.profile_name.as_str())
-            && let Some(label) = self.profile_usage.get(profile_name)
+            .map(|pane| {
+                pane.auth_dir
+                    .as_ref()
+                    .map(|dir| dir.display().to_string())
+                    .unwrap_or_else(|| pane.profile_name.clone())
+            })
+            && let Some(label) = self.profile_usage.get(&usage_key)
         {
             parts.push(label.clone());
         }
@@ -5281,6 +5429,19 @@ impl App {
                     .settings
                     .auth_cursor
                     .min(self.auth_profiles.len().saturating_sub(1));
+                if self.pane_settings.open {
+                    let pane_index = self.pane_settings.pane_index;
+                    let current_auth = self
+                        .launch_plan
+                        .as_ref()
+                        .and_then(|plan| plan.panes.get(pane_index))
+                        .and_then(|spec| spec.auth_name.as_deref());
+                    self.pane_settings.auth_cursor = self
+                        .compatible_auth_profiles(pane_index)
+                        .iter()
+                        .position(|profile| Some(profile.name.as_str()) == current_auth)
+                        .unwrap_or(0);
+                }
                 self.status = format!("loaded {} auth profiles", self.auth_profiles.len());
             }
             Err(error) => self.status = format!("auth refresh failed: {error}"),
@@ -5319,6 +5480,18 @@ impl App {
             profile.name,
             path.display()
         );
+        Ok(())
+    }
+
+    fn toggle_auth_auto_cycle(&mut self) -> Result<()> {
+        self.config.auth.auto_cycle = !self.config.auth.auto_cycle;
+        let path = self.config.save(self.config_path.as_deref())?;
+        let mode = if self.config.auth.auto_cycle {
+            "auto-cycle ready profiles"
+        } else {
+            "manual profile selection"
+        };
+        self.status = format!("auth launch mode: {mode} ({})", path.display());
         Ok(())
     }
 
@@ -5459,19 +5632,72 @@ fn resolve_direct_launch_plan(
 }
 
 fn apply_auth_defaults(plan: &mut LaunchPlan, config: &Config) -> Result<()> {
+    let cycle_profiles = if config.auth.auto_cycle {
+        auth::discover_profiles(&config.auth)?
+    } else {
+        Vec::new()
+    };
+    let mut claude_index = plan
+        .panes
+        .iter()
+        .filter(|spec| spec.auth_name.is_some() && spec.auth_kind == Some(AgentKind::Claude))
+        .count();
+    let mut codex_index = plan
+        .panes
+        .iter()
+        .filter(|spec| spec.auth_name.is_some() && spec.auth_kind == Some(AgentKind::Codex))
+        .count();
+
     for spec in &mut plan.panes {
         let Some(kind) = spec.command.agent_kind else {
             continue;
         };
-        let Some(auth_env) = auth::env_for_default(&config.auth, kind)? else {
+
+        if let Some(name) = spec.auth_name.clone() {
+            let auth_env = auth::env_for_profile(&config.auth, kind, &name)?;
+            set_spec_auth(spec, auth_env);
             continue;
+        }
+
+        let auth_env = if config.auth.auto_cycle {
+            let ready = cycle_profiles
+                .iter()
+                .filter(|profile| profile.kind == kind && profile.ready)
+                .collect::<Vec<_>>();
+            let index = match kind {
+                AgentKind::Claude => &mut claude_index,
+                AgentKind::Codex => &mut codex_index,
+            };
+            let selected = ready.get(*index % ready.len().max(1)).copied();
+            *index += 1;
+            selected
+                .map(|profile| auth::env_for_profile(&config.auth, kind, &profile.name))
+                .transpose()?
+        } else {
+            auth::env_for_default(&config.auth, kind)?
         };
-        spec.env.extend(auth_env.env_map());
-        spec.auth_name = Some(auth_env.name);
-        spec.auth_kind = Some(auth_env.kind);
-        spec.auth_dir = Some(auth_env.dir);
+
+        if let Some(auth_env) = auth_env {
+            set_spec_auth(spec, auth_env);
+        }
     }
     Ok(())
+}
+
+fn clear_spec_auth(spec: &mut PaneLaunchSpec) {
+    spec.env.remove(AgentKind::Claude.env_var());
+    spec.env.remove(AgentKind::Codex.env_var());
+    spec.auth_name = None;
+    spec.auth_kind = None;
+    spec.auth_dir = None;
+}
+
+fn set_spec_auth(spec: &mut PaneLaunchSpec, auth_env: auth::AuthEnv) {
+    clear_spec_auth(spec);
+    spec.env.extend(auth_env.env_map());
+    spec.auth_name = Some(auth_env.name);
+    spec.auth_kind = Some(auth_env.kind);
+    spec.auth_dir = Some(auth_env.dir);
 }
 
 fn uses_direct_launch(cli: &Cli) -> bool {
@@ -6555,6 +6781,41 @@ mod tests {
     }
 
     #[test]
+    fn auto_cycles_ready_auth_profiles_across_matching_panes() {
+        let temp = TempHome::new();
+        for name in ["codex-1", "codex-2"] {
+            let dir = temp.path.join(name);
+            fs::create_dir(&dir).expect("codex dir");
+            fs::write(dir.join(".profile-kind"), "codex").expect("kind");
+            fs::write(dir.join("auth.json"), r#"{"tokens":{}}"#).expect("auth");
+        }
+        let mut config = Config::default();
+        config.auth.home = Some(temp.path.clone());
+        config.auth.auto_cycle = true;
+        let mut plan = LaunchPlan::legacy(
+            "codex".into(),
+            Profile {
+                command: "codex".into(),
+                args: vec![],
+                title: Some("codex".into()),
+                agent_kind: Some(AgentKind::Codex),
+            },
+            env::current_dir().expect("cwd"),
+            3,
+            GridSize {
+                rows: 1,
+                columns: 3,
+            },
+        );
+
+        apply_auth_defaults(&mut plan, &config).expect("apply auth");
+
+        assert_eq!(plan.panes[0].auth_name.as_deref(), Some("codex-1"));
+        assert_eq!(plan.panes[1].auth_name.as_deref(), Some("codex-2"));
+        assert_eq!(plan.panes[2].auth_name.as_deref(), Some("codex-1"));
+    }
+
+    #[test]
     fn command_line_edits_at_cursor() {
         let mut command = CommandLineState::new(PathBuf::from("C:\\repo"));
         command.insert_text("abc");
@@ -6604,13 +6865,14 @@ mod tests {
     #[test]
     fn pane_settings_tracks_active_pane_history() {
         let mut settings = PaneSettingsState::default();
-        settings.open(2, "Assistant: ready".into());
+        settings.open(2, "Assistant: ready".into(), 1);
         assert!(settings.open);
         assert_eq!(settings.pane_index, 2);
         assert_eq!(
             settings.history_summary.as_deref(),
             Some("Assistant: ready")
         );
+        assert_eq!(settings.auth_cursor, 1);
 
         settings.refresh_history("User: rerun tests".into());
         assert_eq!(

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -30,6 +30,8 @@ pub enum AgentKind {
 pub struct AuthConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub home: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub auto_cycle: bool,
     #[serde(default, skip_serializing_if = "AuthDefaults::is_empty")]
     pub defaults: AuthDefaults,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -122,7 +124,10 @@ impl AgentKind {
 
 impl AuthConfig {
     pub fn is_empty(&self) -> bool {
-        self.home.is_none() && self.defaults.is_empty() && self.usage_status.is_none()
+        self.home.is_none()
+            && !self.auto_cycle
+            && self.defaults.is_empty()
+            && self.usage_status.is_none()
     }
 
     pub fn usage_enabled(&self) -> bool {
@@ -180,9 +185,9 @@ impl AuthEnv {
 
 pub fn resolve_home(config: &AuthConfig) -> Result<PathBuf> {
     non_empty_env_path(GRIDBASH_AUTH_HOME)
-        .or_else(|| non_empty_env_path(CLAUDE_PROFILES_HOME))
         .or_else(|| config.home.clone())
-        .or_else(|| BaseDirs::new().map(|dirs| dirs.home_dir().join(".claude-profiles")))
+        .or_else(|| non_empty_env_path(CLAUDE_PROFILES_HOME))
+        .or_else(|| BaseDirs::new().map(|dirs| dirs.home_dir().join(".gridbash-auth")))
         .ok_or_else(|| anyhow!("failed to resolve auth profile home"))
 }
 
@@ -641,6 +646,7 @@ mod tests {
         fn config(&self) -> AuthConfig {
             AuthConfig {
                 home: Some(self.path.clone()),
+                auto_cycle: false,
                 defaults: AuthDefaults::default(),
                 usage_status: Some(false),
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,7 +162,8 @@ mod tests {
         let config: Config = toml::from_str(
             r#"
             [auth]
-            home = "C:\\Users\\Jason\\.claude-profiles"
+            home = "C:\\Users\\Jason\\.gridbash-auth"
+            auto_cycle = true
             usage_status = true
 
             [auth.defaults]
@@ -174,7 +175,15 @@ mod tests {
 
         assert_eq!(config.auth.defaults.claude.as_deref(), Some("claude-1"));
         assert_eq!(config.auth.defaults.codex.as_deref(), Some("codex-2"));
+        assert!(config.auth.auto_cycle);
         assert_eq!(config.auth.usage_status, Some(true));
+    }
+
+    #[test]
+    fn auth_auto_cycle_defaults_to_manual() {
+        let config: Config = toml::from_str("[auth]\n").expect("parse config");
+
+        assert!(!config.auth.auto_cycle);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,6 +11,7 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    auth::AgentKind,
     cli::ResumeArgs,
     layout::GridSize,
     profiles::Profile,
@@ -53,6 +54,10 @@ pub struct SavedPane {
     pub folder_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_kind: Option<AgentKind>,
     #[serde(default)]
     pub history: SavedPaneHistory,
 }
@@ -97,8 +102,8 @@ impl SavedSession {
                 cwd: pane.cwd.clone(),
                 folder_name: pane.folder_name.clone(),
                 worktree_name: pane.worktree_name.clone(),
-                auth_name: None,
-                auth_kind: None,
+                auth_name: pane.auth_name.clone(),
+                auth_kind: pane.auth_kind,
                 auth_dir: None,
             })
             .collect::<Vec<_>>();
@@ -185,6 +190,8 @@ impl SavedPane {
             cwd: spec.cwd.clone(),
             folder_name: spec.folder_name.clone(),
             worktree_name: spec.worktree_name.clone(),
+            auth_name: spec.auth_name.clone(),
+            auth_kind: spec.auth_kind,
             history,
         }
     }
@@ -452,18 +459,20 @@ mod tests {
             rows: 1,
             columns: 2,
         };
-        let plan = LaunchPlan::legacy(
+        let mut plan = LaunchPlan::legacy(
             "cmd".into(),
             Profile {
                 command: "cmd".into(),
                 args: Vec::new(),
                 title: Some("cmd".into()),
-                agent_kind: None,
+                agent_kind: Some(AgentKind::Codex),
             },
             cwd.clone(),
             2,
             grid,
         );
+        plan.panes[0].auth_name = Some("codex-2".into());
+        plan.panes[0].auth_kind = Some(AgentKind::Codex);
 
         let session = SavedSession::new("test".into(), &plan);
         let restored = session.launch_plan().expect("launch plan");
@@ -472,6 +481,8 @@ mod tests {
         assert_eq!(restored.panes.len(), 2);
         assert_eq!(restored.panes[0].profile_name, "cmd");
         assert_eq!(restored.panes[0].cwd, cwd);
+        assert_eq!(restored.panes[0].auth_name.as_deref(), Some("codex-2"));
+        assert_eq!(restored.panes[0].auth_kind, Some(AgentKind::Codex));
     }
 
     #[test]
@@ -513,6 +524,8 @@ mod tests {
             cwd: PathBuf::from("."),
             folder_name: folder_name.into(),
             worktree_name: None,
+            auth_name: None,
+            auth_kind: None,
             history: SavedPaneHistory::default(),
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -695,8 +695,8 @@ fn render_pane_settings(
     frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), area);
 
     PaneSettingsButtons {
-        rename: pane_settings_rename_rect(area),
-        reload: pane_settings_reload_rect(area),
+        rename: pane_settings_rename_rect(area, view.auth_kind.is_some()),
+        reload: pane_settings_reload_rect(area, view.auth_kind.is_some()),
     }
 }
 
@@ -741,9 +741,23 @@ fn pane_settings_lines(
                 .bg(SETTINGS_BG)
                 .add_modifier(Modifier::BOLD),
         )));
+        if let Some(kind) = view.auth_kind {
+            let auth = view
+                .auth_options
+                .get(view.auth_cursor)
+                .map(|option| option.name.as_str())
+                .unwrap_or("none");
+            lines.push(Line::from(Span::styled(
+                fixed_width(
+                    &format!(" {} auth: {auth}", kind.display_name()),
+                    width as usize,
+                ),
+                Style::default().fg(SETTINGS_TEXT),
+            )));
+        }
         lines.push(pane_settings_rename_line(width, palette));
         lines.push(pane_settings_reload_line(width, palette));
-        lines.push(pane_settings_command_bar(width));
+        lines.push(pane_settings_command_bar(width, view.auth_kind.is_some()));
         return lines;
     }
 
@@ -770,7 +784,49 @@ fn pane_settings_lines(
             Style::default().fg(SETTINGS_MUTED),
         ),
     ]));
-    lines.push(Line::from(""));
+    if let Some(kind) = view.auth_kind {
+        lines.push(settings_section(
+            "AUTH ACCOUNT",
+            "Left/Right selects; Enter applies and restarts",
+            width,
+        ));
+        if let Some(option) = view.auth_options.get(view.auth_cursor) {
+            let account = option.account_label.as_deref().unwrap_or("no account");
+            let current = if option.current { " current" } else { "" };
+            let status = if option.ready {
+                "ready"
+            } else {
+                "login needed"
+            };
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled("< ", Style::default().fg(Color::Yellow)),
+                Span::styled(
+                    truncate_text(
+                        &format!("{} | {} | {}{}", option.name, account, status, current),
+                        width.saturating_sub(8) as usize,
+                    ),
+                    Style::default()
+                        .fg(kind_color(kind))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" >", Style::default().fg(Color::Yellow)),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!(
+                        "No {} auth profiles. Open global Auth settings.",
+                        kind.as_str()
+                    ),
+                    Style::default().fg(SETTINGS_MUTED),
+                ),
+            ]));
+        }
+    } else {
+        lines.push(Line::from(""));
+    }
     lines.push(settings_section(
         "HISTORY",
         "visible conversation snapshot",
@@ -783,11 +839,15 @@ fn pane_settings_lines(
             Style::default().fg(SETTINGS_TEXT),
         ),
     ]));
-    lines.push(Line::from(""));
+    if view.auth_kind.is_none() {
+        lines.push(Line::from(""));
+    }
     lines.push(pane_settings_rename_line(width, palette));
     lines.push(pane_settings_reload_line(width, palette));
-    lines.push(Line::from(""));
-    lines.push(pane_settings_command_bar(width));
+    if view.auth_kind.is_none() {
+        lines.push(Line::from(""));
+    }
+    lines.push(pane_settings_command_bar(width, view.auth_kind.is_some()));
 
     lines
 }
@@ -818,7 +878,31 @@ fn pane_settings_action_line(label: &str, width: u16, background: Color) -> Line
     ))
 }
 
-fn pane_settings_command_bar(width: u16) -> Line<'static> {
+fn pane_settings_command_bar(width: u16, has_auth: bool) -> Line<'static> {
+    if has_auth {
+        if width < 50 {
+            return Line::from(vec![
+                Span::raw("  "),
+                command_key("Left/Right"),
+                Span::styled(" auth  ", Style::default().fg(Color::Gray)),
+                command_key("Enter"),
+                Span::styled(" apply", Style::default().fg(Color::Gray)),
+            ]);
+        }
+
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Left/Right"),
+            Span::styled(" account  ", Style::default().fg(Color::Gray)),
+            command_key("Enter"),
+            Span::styled(" apply + restart  ", Style::default().fg(Color::Gray)),
+            command_key("r"),
+            Span::styled(" history  ", Style::default().fg(Color::Gray)),
+            command_key("Esc"),
+            Span::styled(" close", Style::default().fg(Color::Gray)),
+        ]);
+    }
+
     if width < 50 {
         return Line::from(vec![
             Span::raw("  "),
@@ -844,12 +928,26 @@ fn pane_settings_command_bar(width: u16) -> Line<'static> {
     ])
 }
 
-fn pane_settings_rename_rect(area: Rect) -> Option<Rect> {
-    pane_settings_action_rect(area, if area.width < 36 { 1 } else { 6 })
+fn pane_settings_rename_rect(area: Rect, has_auth: bool) -> Option<Rect> {
+    let row = if area.width < 36 && has_auth {
+        2
+    } else if area.width < 36 {
+        1
+    } else {
+        6
+    };
+    pane_settings_action_rect(area, row)
 }
 
-fn pane_settings_reload_rect(area: Rect) -> Option<Rect> {
-    pane_settings_action_rect(area, if area.width < 36 { 2 } else { 7 })
+fn pane_settings_reload_rect(area: Rect, has_auth: bool) -> Option<Rect> {
+    let row = if area.width < 36 && has_auth {
+        3
+    } else if area.width < 36 {
+        2
+    } else {
+        7
+    };
+    pane_settings_action_rect(area, row)
 }
 
 fn pane_settings_action_rect(area: Rect, row: u16) -> Option<Rect> {
@@ -1352,7 +1450,7 @@ fn settings_content_row_count(app: &App) -> usize {
     match app.settings_tab() {
         SettingsTab::General => app.settings_rows().len(),
         SettingsTab::Auth => {
-            app.auth_profiles().len().max(1) + usize::from(app.auth_create().is_some()) * 3
+            app.auth_profiles().len().max(1) + usize::from(app.auth_create().is_some()) * 3 + 3
         }
     }
 }
@@ -1636,6 +1734,40 @@ fn auth_settings_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     let mut lines = vec![
         settings_tabs(SettingsTab::Auth),
         Line::from(""),
+        settings_section("LAUNCH POLICY", "applies to new compatible panes", width),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled("Auth assignment", Style::default().fg(SETTINGS_TEXT)),
+            Span::raw("  "),
+            Span::styled(
+                if app.auth_auto_cycle() {
+                    "[ auto-cycle ]"
+                } else {
+                    "[ manual ]"
+                },
+                if app.auth_auto_cycle() {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(SETTINGS_BORDER)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                        .fg(Color::LightCyan)
+                        .bg(SETTINGS_SURFACE)
+                        .add_modifier(Modifier::BOLD)
+                },
+            ),
+            Span::raw("  "),
+            Span::styled(
+                if app.auth_auto_cycle() {
+                    "round-robin across ready accounts"
+                } else {
+                    "pane choices stay explicit"
+                },
+                Style::default().fg(SETTINGS_MUTED),
+            ),
+        ]),
+        Line::from(""),
         settings_section(
             "AUTH PROFILES",
             if app.auth_refreshing() {
@@ -1743,6 +1875,8 @@ fn auth_command_bar(width: u16) -> Line<'static> {
             Span::styled(" move  ", Style::default().fg(Color::Gray)),
             command_key("d"),
             Span::styled(" default  ", Style::default().fg(Color::Gray)),
+            command_key("c"),
+            Span::styled(" cycle  ", Style::default().fg(Color::Gray)),
             command_key("Esc"),
             Span::styled(" close", Style::default().fg(Color::Gray)),
         ]);
@@ -1754,6 +1888,8 @@ fn auth_command_bar(width: u16) -> Line<'static> {
         Span::styled(" move  ", Style::default().fg(Color::Gray)),
         command_key("d"),
         Span::styled(" default  ", Style::default().fg(Color::Gray)),
+        command_key("c"),
+        Span::styled(" cycle  ", Style::default().fg(Color::Gray)),
         command_key("n"),
         Span::styled(" new  ", Style::default().fg(Color::Gray)),
         command_key("l"),
@@ -2563,23 +2699,29 @@ mod tests {
     #[test]
     fn pane_settings_action_buttons_use_expected_rows() {
         assert_eq!(
-            pane_settings_rename_rect(Rect::new(5, 10, 40, 12)),
+            pane_settings_rename_rect(Rect::new(5, 10, 40, 12), false),
             Some(Rect::new(5, 16, 40, 1))
         );
         assert_eq!(
-            pane_settings_reload_rect(Rect::new(5, 10, 40, 12)),
+            pane_settings_reload_rect(Rect::new(5, 10, 40, 12), false),
             Some(Rect::new(5, 17, 40, 1))
         );
         assert_eq!(
-            pane_settings_rename_rect(Rect::new(5, 10, 20, 4)),
-            Some(Rect::new(5, 11, 20, 1))
-        );
-        assert_eq!(
-            pane_settings_reload_rect(Rect::new(5, 10, 20, 4)),
+            pane_settings_rename_rect(Rect::new(5, 10, 20, 5), true),
             Some(Rect::new(5, 12, 20, 1))
         );
-        assert_eq!(pane_settings_rename_rect(Rect::new(5, 10, 40, 6)), None);
-        assert_eq!(pane_settings_reload_rect(Rect::new(5, 10, 40, 6)), None);
+        assert_eq!(
+            pane_settings_reload_rect(Rect::new(5, 10, 20, 5), true),
+            Some(Rect::new(5, 13, 20, 1))
+        );
+        assert_eq!(
+            pane_settings_rename_rect(Rect::new(5, 10, 40, 6), false),
+            None
+        );
+        assert_eq!(
+            pane_settings_reload_rect(Rect::new(5, 10, 40, 6), false),
+            None
+        );
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -29,7 +29,7 @@ pub struct UsageTarget {
 #[derive(Debug, Clone, PartialEq)]
 pub enum UsageEvent {
     Profile {
-        profile_name: String,
+        usage_key: String,
         label: Option<String>,
     },
     ApiSpend {
@@ -54,7 +54,7 @@ impl From<AgentKind> for AuthKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct UsageSource {
-    profile_name: String,
+    usage_key: String,
     dir: PathBuf,
     kind: AuthKind,
 }
@@ -74,7 +74,7 @@ pub fn spawn_usage_monitor(targets: Vec<UsageTarget>, tx: Sender<UsageEvent>) {
                 let label = profile_usage_label(source);
                 if tx
                     .send(UsageEvent::Profile {
-                        profile_name: source.profile_name.clone(),
+                        usage_key: source.usage_key.clone(),
                         label,
                     })
                     .is_err()
@@ -106,7 +106,7 @@ fn resolve_usage_sources(targets: &[UsageTarget]) -> Vec<UsageSource> {
     let mut sources = BTreeMap::new();
     for target in targets {
         if let Some(source) = resolve_usage_source(target) {
-            sources.entry(source.profile_name.clone()).or_insert(source);
+            sources.entry(source.usage_key.clone()).or_insert(source);
         }
     }
     sources.into_values().collect()
@@ -117,7 +117,7 @@ fn resolve_usage_source(target: &UsageTarget) -> Option<UsageSource> {
         && dir.is_dir()
     {
         return Some(UsageSource {
-            profile_name: target.profile_name.clone(),
+            usage_key: usage_key(target),
             dir: dir.clone(),
             kind: kind.into(),
         });
@@ -129,7 +129,7 @@ fn resolve_usage_source(target: &UsageTarget) -> Option<UsageSource> {
             .or_else(|| infer_kind(&target.profile_name))
             .unwrap_or(AuthKind::Claude);
         return Some(UsageSource {
-            profile_name: target.profile_name.clone(),
+            usage_key: usage_key(target),
             dir: vibe_dir,
             kind,
         });
@@ -142,10 +142,18 @@ fn resolve_usage_source(target: &UsageTarget) -> Option<UsageSource> {
     };
 
     dir.is_dir().then(|| UsageSource {
-        profile_name: target.profile_name.clone(),
+        usage_key: usage_key(target),
         dir,
         kind: command_kind,
     })
+}
+
+fn usage_key(target: &UsageTarget) -> String {
+    target
+        .auth_dir
+        .as_ref()
+        .map(|dir| dir.display().to_string())
+        .unwrap_or_else(|| target.profile_name.clone())
 }
 
 fn profile_kind(dir: &Path) -> Option<AuthKind> {
@@ -524,9 +532,10 @@ struct CostAmount {
 }
 
 fn profiles_home() -> PathBuf {
-    env::var_os("CLAUDE_PROFILES_HOME")
+    env::var_os("GRIDBASH_AUTH_HOME")
         .map(PathBuf::from)
-        .or_else(|| home_dir().map(|home| home.join(".claude-profiles")))
+        .or_else(|| env::var_os("CLAUDE_PROFILES_HOME").map(PathBuf::from))
+        .or_else(|| home_dir().map(|home| home.join(".gridbash-auth")))
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
@@ -648,5 +657,34 @@ mod tests {
 
         assert_eq!(source.dir, temp);
         assert_eq!(source.kind, AuthKind::Codex);
+        assert_eq!(source.usage_key, temp.display().to_string());
+    }
+
+    #[test]
+    fn keeps_usage_sources_separate_for_different_auth_accounts() {
+        let root = env::temp_dir().join(format!(
+            "gridbash-usage-accounts-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ));
+        let first = root.join("codex-1");
+        let second = root.join("codex-2");
+        fs::create_dir_all(&first).expect("first auth dir");
+        fs::create_dir(&second).expect("second auth dir");
+        let targets = [first.clone(), second.clone()].map(|auth_dir| UsageTarget {
+            profile_name: "codex".into(),
+            command: "codex".into(),
+            auth_kind: Some(AgentKind::Codex),
+            auth_dir: Some(auth_dir),
+        });
+
+        let sources = resolve_usage_sources(&targets);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(sources.len(), 2);
+        assert!(sources.iter().any(|source| source.dir == first));
+        assert!(sources.iter().any(|source| source.dir == second));
     }
 }


### PR DESCRIPTION
## Summary
- move GridBash's default auth profile home to %USERPROFILE%\\.gridbash-auth with documented legacy override/migration options
- add a compact per-pane Claude/Codex auth account picker that restarts only the changed pane and persists the selection in session metadata
- add a manual-by-default global launch policy with optional round-robin assignment across ready matching auth profiles
- keep usage labels distinct when identical launch profiles use different auth accounts

## Validation
- cargo test (98 passed, 1 ignored interactive ConPTY smoke test)
- cargo clippy --all-targets -- -D warnings
- 
pm test (98 passed, 1 ignored)
- git diff --check

Closes #118