### PR TITLE
fix: center pane work summaries

### DIFF
--- a/docs/devlogs/2026-07-09-center-pane-work-summaries.md
+++ b/docs/devlogs/2026-07-09-center-pane-work-summaries.md
@@ -1,0 +1,25 @@
+# Center pane work summaries
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Centered the automatic agent work summary in each pane's bottom border.
+
+## What Changed
+
+- Kept the existing visible-terminal summarizer, which extracts the latest meaningful conversation line without calling a separate LLM endpoint.
+- Applied center alignment to the pane footer title.
+
+## Why It Matters
+
+- The concise status reads as a pane-level caption and is easier to scan across a grid.
+
+## Validation
+
+- TODO
+
+## Release Notes
+
+- Agent-pane work summaries are centered in their footer borders.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
@@ -1935,6 +1935,7 @@ fn conversation_footer(summary: String, emphasized: bool) -> Line<'static> {
         Span::styled(summary, summary_style),
         Span::raw(" "),
     ])
+    .alignment(Alignment::Center)
 }
 
 fn settings_summary(width: u16) -> String {
@@ -2693,6 +2694,14 @@ mod tests {
         assert_eq!(
             pane_title("api", QUIET_MARKER, "gridbash/", None, None, None, None, ""),
             " api * | gridbash/ "
+        );
+    }
+
+    #[test]
+    fn conversation_footer_is_centered() {
+        assert_eq!(
+            conversation_footer("reviewing changes".into(), false).alignment,
+            Some(Alignment::Center)
         );
     }
 


### PR DESCRIPTION
Closes #123\n\n## Summary\n- center automatic agent work summaries in each pane's bottom border\n- retain the existing endpoint-free terminal-output summarizer\n- cover footer alignment with a unit test\n\n## Validation\n- cargo fmt --check\n- cargo test\n- cargo clippy -- -D warnings