### PR TITLE
fix: enable pane-local scrollback

### DIFF
--- a/docs/devlogs/2026-07-09-enable-pane-scrollback.md
+++ b/docs/devlogs/2026-07-09-enable-pane-scrollback.md
@@ -1,0 +1,33 @@
+# Enable pane scrollback
+
+Date: 2026-07-09
+Release target: unreleased
+
+## Summary
+
+- Added direct mouse-wheel scrollback inside individual GridBash panes.
+
+## What Changed
+
+- Routed vertical wheel events over plain shells into each pane's existing terminal scrollback buffer.
+- Preserved mouse-wheel forwarding for child applications that enable terminal mouse reporting.
+- Hid the live cursor while reviewing history and returned targeted panes to live output when keyboard input is sent.
+
+## Why It Matters
+
+- Earlier pane output can be reviewed in place without switching to Ctrl+T transcript mode.
+- Each pane keeps an independent scroll position, so reviewing one does not disturb the others.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+- `npm run test:launcher`
+
+## Release Notes
+
+- Mouse wheel and trackpad scrolling now review scrollback directly inside the pane under the pointer.
+
+Tracks #124.

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,7 @@ const TODO_IDLE_STEP_SECONDS: u64 = 15;
 const COMMAND_OUTPUT_MAX_LINES: usize = 2000;
 const ACTIVITY_DECAY_INTERVAL: Duration = Duration::from_millis(250);
 const OUTPUT_QUIET_AFTER: Duration = Duration::from_secs(3);
+const PANE_SCROLL_ROWS: isize = 3;
 
 pub struct App {
     config: Config,
@@ -3954,20 +3955,35 @@ impl App {
 
         let bytes = mouse_scroll_bytes(mouse, point, pane.screen());
         let exited = pane.exited;
-        let changed = self.focus != index || self.clear_text_selection();
+        let mut changed = self.focus != index || self.clear_text_selection();
         self.focus = index;
-        if changed {
-            self.status = format!("focused pane {}", index + 1);
-        }
-
-        if exited {
-            return Ok(changed);
-        }
 
         if let Some(bytes) = bytes
+            && !exited
             && let Some(pane) = self.panes.get(index)
         {
             pane.write(&bytes)?;
+            if changed {
+                self.status = format!("focused pane {}", index + 1);
+            }
+            return Ok(changed);
+        }
+
+        if let Some(rows) = pane_scroll_rows(mouse.kind)
+            && let Some(pane) = self.panes.get_mut(index)
+        {
+            changed |= pane.scroll_view(rows);
+            self.status = if pane.screen().scrollback() == 0 {
+                format!("pane {} at live output", index + 1)
+            } else {
+                format!(
+                    "pane {} scrollback: {} rows",
+                    index + 1,
+                    pane.screen().scrollback()
+                )
+            };
+        } else if changed {
+            self.status = format!("focused pane {}", index + 1);
         }
 
         Ok(changed)
@@ -4716,6 +4732,7 @@ impl App {
 
     fn route_input_to_targets(&mut self, bytes: &[u8], targets: Vec<usize>) -> Result<bool> {
         let mut skipped_exited = 0;
+        let mut changed = false;
 
         for index in targets {
             let pane = self
@@ -4726,6 +4743,7 @@ impl App {
                 skipped_exited += 1;
                 continue;
             }
+            changed |= pane.reset_view();
             pane.record_input(bytes);
             pane.write(bytes)
                 .with_context(|| format!("failed to route input to pane {}", index + 1))?;
@@ -4744,7 +4762,7 @@ impl App {
             return Ok(true);
         }
 
-        Ok(false)
+        Ok(changed)
     }
 
     fn input_targets(&self) -> Vec<usize> {
@@ -6363,6 +6381,14 @@ fn is_mouse_scroll(kind: MouseEventKind) -> bool {
     )
 }
 
+fn pane_scroll_rows(kind: MouseEventKind) -> Option<isize> {
+    match kind {
+        MouseEventKind::ScrollUp => Some(PANE_SCROLL_ROWS),
+        MouseEventKind::ScrollDown => Some(-PANE_SCROLL_ROWS),
+        _ => None,
+    }
+}
+
 fn mouse_scroll_bytes(mouse: MouseEvent, point: CellPoint, screen: &Screen) -> Option<Vec<u8>> {
     if screen.mouse_protocol_mode() == MouseProtocolMode::None {
         return None;
@@ -6491,6 +6517,19 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn plain_pane_scroll_uses_vertical_wheel_steps() {
+        assert_eq!(
+            pane_scroll_rows(MouseEventKind::ScrollUp),
+            Some(PANE_SCROLL_ROWS)
+        );
+        assert_eq!(
+            pane_scroll_rows(MouseEventKind::ScrollDown),
+            Some(-PANE_SCROLL_ROWS)
+        );
+        assert_eq!(pane_scroll_rows(MouseEventKind::ScrollLeft), None);
     }
 
     #[test]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -187,6 +187,17 @@ impl PtyPane {
         self.parser.screen()
     }
 
+    pub fn scroll_view(&mut self, rows: isize) -> bool {
+        scroll_screen(self.parser.screen_mut(), rows)
+    }
+
+    pub fn reset_view(&mut self) -> bool {
+        let screen = self.parser.screen_mut();
+        let changed = screen.scrollback() > 0;
+        screen.set_scrollback(0);
+        changed
+    }
+
     pub fn process_output(&mut self, bytes: &[u8]) {
         self.update_cwd_from_osc7(bytes);
         self.parser.process(bytes);
@@ -340,6 +351,17 @@ impl PtyPane {
         self.output_tail.push_str(&plain);
         trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
     }
+}
+
+fn scroll_screen(screen: &mut Screen, rows: isize) -> bool {
+    let before = screen.scrollback();
+    let next = if rows.is_negative() {
+        before.saturating_sub(rows.unsigned_abs())
+    } else {
+        before.saturating_add(rows as usize)
+    };
+    screen.set_scrollback(next);
+    screen.scrollback() != before
 }
 
 impl Drop for PtyPane {
@@ -871,6 +893,24 @@ mod tests {
 
         activity.record_output(start + quiet_after + Duration::from_secs(2));
         assert!(!activity.is_quiet());
+    }
+
+    #[test]
+    fn scroll_screen_moves_through_scrollback_and_back_to_live_output() {
+        let mut parser = Parser::new(3, 20, 100);
+        let mut other_parser = Parser::new(3, 20, 100);
+        parser.process(b"one\r\ntwo\r\nthree\r\nfour\r\nfive");
+        other_parser.process(b"alpha\r\nbeta\r\ngamma\r\ndelta");
+
+        assert_eq!(parser.screen().scrollback(), 0);
+        assert!(scroll_screen(parser.screen_mut(), 3));
+        assert!(parser.screen().scrollback() > 0);
+        assert!(parser.screen().contents().contains("one"));
+        assert_eq!(other_parser.screen().scrollback(), 0);
+
+        assert!(scroll_screen(parser.screen_mut(), -3));
+        assert_eq!(parser.screen().scrollback(), 0);
+        assert!(parser.screen().contents().contains("five"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -161,7 +161,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             render_group_badge(frame, rect, group);
         }
 
-        if focused && !sleeping && !modal_open {
+        if focused && !sleeping && !modal_open && pane.screen().scrollback() == 0 {
             set_terminal_cursor(frame, inner, pane.screen());
         }
     }


### PR DESCRIPTION
## Summary
- scroll plain pane history with the wheel/trackpad over that pane
- preserve mouse reporting for interactive child applications
- snap targeted panes back to live output on keyboard input and hide the cursor while reviewing history

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (103 passed, 1 existing interactive Windows smoke test ignored)
- cargo build --release
- npm run test:launcher

Closes #124