### PR TITLE
feat: add unified grid resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Right-click pane | Toggle that pane in or out of the selected set |
 | Alt+Left / Alt+Right | Focus previous / next pane in the row, wrapping at row edges |
 | Alt+Up / Alt+Down | Focus pane above / below in the column, wrapping at column edges |
-| Alt+Shift+Up / Alt+Shift+Down | Remove / add a row when safe |
-| Alt+Shift+Left / Alt+Shift+Right | Remove / add a column when safe |
+| Alt+l | Open the grid resizer; Enter applies the chosen dimensions and Esc cancels |
 | Alt+n | Open the startup picker and launch a new tab |
 | Alt+t | Switch to the next tab |
 | Alt+s | Toggle focused pane selection |
@@ -290,6 +289,10 @@ When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter
 exited target panes directly.
 
 Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. When the one-line command bar is focused, typing stays in that bar; Enter runs the command from the cwd shown in the prompt and keeps output hidden until expanded.
+
+The grid resizer uses the same row-and-column picker as startup, with active cells
+shown in blue. Shrinking removes live panes outside the retained upper-left
+rectangle. For example, changing 3x3 to 3x2 deactivates the full rightmost column.
 
 Voice mode uses the installed Windows speech recognizer and the default microphone.
 Press `Alt+v` to listen for one utterance (up to 15 seconds). The transcript is

--- a/docs/devlogs/2026-07-10-unified-grid-resizer.md
+++ b/docs/devlogs/2026-07-10-unified-grid-resizer.md
@@ -1,0 +1,35 @@
+# Unified grid resizer
+
+Date: 2026-07-10
+Release target: unreleased
+
+## Summary
+
+- Replaced four incremental resize shortcuts with one full-screen grid resizer.
+- Preserved pane coordinates across both expansion and contraction.
+
+## What Changed
+
+- `Alt+l` now opens the same row-and-column picker used during startup, initialized to the active tab's current dimensions.
+- The live-grid picker renders active cells in blue and applies changes with Enter.
+- Shrinking now terminates panes outside the retained upper-left rectangle, including an entire rightmost column when changing 3x3 to 3x2.
+- Expanding inserts newly spawned panes into new coordinates without shifting existing rows or columns.
+- Focus, selection, sleeping state, pane names, follow-ups, group membership, and launch specs follow retained panes to their new indices.
+- Removed the Alt+Shift+Arrow resize handlers and documentation.
+
+## Why It Matters
+
+- Resizing is now visible, reversible until confirmation, and consistent with onboarding.
+- Coordinate-aware remapping avoids surprising pane movement when one dimension changes or when the total cell count stays the same.
+
+## Validation
+
+- `cargo check --tests`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo fmt -- --check`
+- `git diff --check`
+
+## Release Notes
+
+- Open the unified blue grid resizer with `Alt+l`; shrinking can now deactivate live panes outside the chosen dimensions.

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 use crate::{
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
-    composer::Composer,
+    composer::{Composer, GridPicker, GridPickerAction},
     config::Config,
     control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
     image_preview::{self, ImagePreview},
@@ -97,6 +97,7 @@ pub struct App {
     control_handle: Option<ControlHandle>,
     control_rx: Option<std_mpsc::Receiver<ControlEnvelope>>,
     image_overlay: Option<ImagePreview>,
+    grid_resizer: Option<GridPicker>,
     settings: SettingsState,
     rename: RenamePaneState,
     tab_rename: RenameTabState,
@@ -246,12 +247,6 @@ impl PaneSelection {
         }
         true
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GridAxis {
-    Rows,
-    Columns,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1482,10 +1477,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
+        "Drag copies within pane | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
             .into()
     } else {
-        "Alt+arrows move | Alt+Shift+arrows resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
+        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g group | Alt+u ungroup | Alt+o settings"
             .into()
     }
 }
@@ -1618,6 +1613,7 @@ impl App {
             control_handle: init.control_handle,
             control_rx: init.control_rx,
             image_overlay: None,
+            grid_resizer: None,
             settings: init.settings,
             rename: RenamePaneState::default(),
             tab_rename: RenameTabState::default(),
@@ -1778,6 +1774,7 @@ impl App {
         self.prompt = None;
         self.text_selection = None;
         self.command_line.focused = false;
+        self.grid_resizer = None;
     }
 
     fn activate_plan_as_tab(&mut self, title: String, mut plan: LaunchPlan) -> Result<()> {
@@ -1946,6 +1943,7 @@ impl App {
                     }
                     Event::Paste(text)
                         if !self.settings.open
+                            && self.grid_resizer.is_none()
                             && !self.rename.open
                             && !self.previous_panes.open
                             && !self.pane_settings.open
@@ -1963,6 +1961,7 @@ impl App {
                     Event::Mouse(mouse)
                         if (self.mouse_enabled || !self.sleeping.is_empty())
                             && !self.settings.open
+                            && self.grid_resizer.is_none()
                             && self.follow_up.is_none()
                             && self.prompt.is_none() =>
                     {
@@ -2571,6 +2570,10 @@ impl App {
     }
 
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
+        if self.grid_resizer.is_some() {
+            return self.handle_grid_resizer_key(key);
+        }
+
         if self.image_overlay.is_some() {
             return Ok(self.handle_image_overlay_key(key));
         }
@@ -2668,22 +2671,6 @@ impl App {
     fn handle_app_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<Option<bool>> {
         match key.code {
             KeyCode::Char(ch) => self.handle_alt_char(terminal, ch, key.modifiers),
-            KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.adjust_grid(GridAxis::Columns, -1)?;
-                Ok(Some(false))
-            }
-            KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.adjust_grid(GridAxis::Columns, 1)?;
-                Ok(Some(false))
-            }
-            KeyCode::Up if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.adjust_grid(GridAxis::Rows, -1)?;
-                Ok(Some(false))
-            }
-            KeyCode::Down if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                self.adjust_grid(GridAxis::Rows, 1)?;
-                Ok(Some(false))
-            }
             KeyCode::Left => {
                 self.focus_previous();
                 self.status = self.focus_status();
@@ -2748,6 +2735,10 @@ impl App {
             }
             'n' => {
                 self.open_new_tab(terminal)?;
+                Ok(Some(false))
+            }
+            'l' => {
+                self.open_grid_resizer();
                 Ok(Some(false))
             }
             'x' => {
@@ -2823,6 +2814,38 @@ impl App {
                 Some(KeyOutcome::Render)
             }
             ExitedRecoveryAction::HoldAltPrefix => Some(KeyOutcome::Render),
+        }
+    }
+
+    fn open_grid_resizer(&mut self) {
+        self.close_tab_modals();
+        self.grid_resizer = Some(GridPicker::new(self.layout.size()));
+        self.status = "grid resizer open".into();
+    }
+
+    fn handle_grid_resizer_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return Ok(KeyOutcome::Quit);
+        }
+
+        let action = self
+            .grid_resizer
+            .as_mut()
+            .map(|picker| picker.handle_key(key))
+            .unwrap_or(GridPickerAction::Cancel);
+        match action {
+            GridPickerAction::Continue => Ok(KeyOutcome::Render),
+            GridPickerAction::Cancel => {
+                self.grid_resizer = None;
+                self.status = "grid resize canceled".into();
+                Ok(KeyOutcome::Render)
+            }
+            GridPickerAction::Confirm(next) => {
+                self.apply_grid_resize(next)?;
+                self.grid_resizer = None;
+                self.save_session_snapshot()?;
+                Ok(KeyOutcome::Render)
+            }
         }
     }
 
@@ -4172,157 +4195,160 @@ impl App {
         );
     }
 
-    fn adjust_grid(&mut self, axis: GridAxis, delta: isize) -> Result<()> {
+    fn apply_grid_resize(&mut self, next: GridSize) -> Result<()> {
         let current = self.layout.size();
-        let Some(rows) =
-            adjust_dimension(current.rows, if axis == GridAxis::Rows { delta } else { 0 })
-        else {
-            self.status = "grid is capped at 100 cells".into();
-            return Ok(());
-        };
-        let Some(columns) = adjust_dimension(
-            current.columns,
-            if axis == GridAxis::Columns { delta } else { 0 },
-        ) else {
-            self.status = "grid is capped at 100 cells".into();
-            return Ok(());
-        };
-        let Some(next) = GridSize::new(rows, columns) else {
-            self.status = invalid_grid_status(rows, columns);
-            return Ok(());
-        };
-
-        if next == current {
+        if next == current && self.panes.len() == next.count() {
+            self.status = format!("grid remains {}x{}", next.rows, next.columns);
             return Ok(());
         }
 
         let before = self.panes.len();
-        if next.count() > self.panes.len() {
-            self.spawn_panes_to_fill(next.count())?;
-        } else if next.count() < self.panes.len() && !self.remove_overflow_panes(next.count(), next)
-        {
-            return Ok(());
+        let slots = grid_resize_slots(current, next, before);
+        let old_to_new = slots
+            .iter()
+            .enumerate()
+            .filter_map(|(new, old)| old.map(|old| (old, new)))
+            .collect::<BTreeMap<_, _>>();
+        let retained = old_to_new.len();
+        let removed = before.saturating_sub(retained);
+        let added = slots.iter().filter(|slot| slot.is_none()).count();
+
+        let plan = self
+            .launch_plan
+            .as_ref()
+            .ok_or_else(|| anyhow!("no launch plan selected"))?;
+        let templates = plan.panes.clone();
+        if templates.is_empty() {
+            return Err(anyhow!("no pane template available"));
         }
+
+        let mut next_plan = LaunchPlan {
+            panes: slots
+                .iter()
+                .enumerate()
+                .map(|(new_index, old_index)| {
+                    let mut spec = old_index
+                        .and_then(|old_index| plan.panes.get(old_index))
+                        .cloned()
+                        .unwrap_or_else(|| templates[new_index % templates.len()].clone());
+                    if old_index.is_none() && self.config.auth.auto_cycle {
+                        clear_spec_auth(&mut spec);
+                    }
+                    spec
+                })
+                .collect(),
+            grid: next,
+        };
+        apply_auth_defaults(&mut next_plan, &self.config)?;
+
+        // Spawn every new cell before touching the live vectors. If a launch fails,
+        // the current grid remains intact.
+        let mut spawned = BTreeMap::new();
+        for (new_index, old_index) in slots.iter().enumerate() {
+            if old_index.is_none() {
+                let pane = self.spawn_pane_instance(&next_plan.panes[new_index], new_index)?;
+                spawned.insert(new_index, pane);
+            }
+        }
+
+        let mut old_panes = mem::take(&mut self.panes)
+            .into_iter()
+            .map(Some)
+            .collect::<Vec<_>>();
+        let mut old_idle = mem::take(&mut self.pane_idle)
+            .into_iter()
+            .map(Some)
+            .collect::<Vec<_>>();
+        let mut old_names = mem::take(&mut self.pane_names)
+            .into_iter()
+            .map(Some)
+            .collect::<Vec<_>>();
+
+        self.panes = Vec::with_capacity(next.count());
+        self.pane_idle = Vec::with_capacity(next.count());
+        self.pane_names = Vec::with_capacity(next.count());
+        for (new_index, old_index) in slots.iter().copied().enumerate() {
+            if let Some(old_index) = old_index {
+                self.panes.push(
+                    old_panes
+                        .get_mut(old_index)
+                        .and_then(Option::take)
+                        .expect("retained pane index"),
+                );
+                self.pane_idle.push(
+                    old_idle
+                        .get_mut(old_index)
+                        .and_then(Option::take)
+                        .unwrap_or_else(|| PaneIdleState::new(Instant::now())),
+                );
+                self.pane_names.push(
+                    old_names
+                        .get_mut(old_index)
+                        .and_then(Option::take)
+                        .unwrap_or(None),
+                );
+            } else {
+                self.panes
+                    .push(spawned.remove(&new_index).expect("spawned resize pane"));
+                self.pane_idle.push(PaneIdleState::new(Instant::now()));
+                self.pane_names.push(None);
+            }
+        }
+
+        let old_focus = self.focus;
+        self.focus = resized_focus_index(old_focus, current, next, &old_to_new);
+        self.selected = remap_index_set(&self.selected, &old_to_new);
+        self.sleeping = remap_index_set(&self.sleeping, &old_to_new);
+        self.text_selection = self.text_selection.and_then(|selection| {
+            old_to_new
+                .get(&selection.pane)
+                .copied()
+                .map(|pane| MouseSelection { pane, ..selection })
+        });
+        self.follow_up = self.follow_up.and_then(|prompt| {
+            old_to_new
+                .get(&prompt.pane_index)
+                .copied()
+                .map(|pane_index| FollowUpPromptState {
+                    pane_index,
+                    ..prompt
+                })
+        });
+        self.remap_groups(&old_to_new);
 
         self.layout.set_size(next);
-        if let Some(plan) = &mut self.launch_plan {
-            plan.grid = next;
-        }
+        self.launch_plan = Some(next_plan.clone());
+        self.start_usage_monitor(&next_plan);
 
-        let added = self.panes.len().saturating_sub(before);
-        let removed = before.saturating_sub(self.panes.len());
-        self.status = if added > 0 {
+        self.status = if added > 0 && removed > 0 {
+            format!(
+                "grid resized to {}x{}; deactivated {removed} and spawned {added} pane(s)",
+                next.rows, next.columns
+            )
+        } else if added > 0 {
             format!(
                 "grid resized to {}x{}; spawned {added} pane(s)",
                 next.rows, next.columns
             )
         } else if removed > 0 {
             format!(
-                "grid resized to {}x{}; removed {removed} exited pane(s)",
+                "grid resized to {}x{}; deactivated {removed} pane(s)",
                 next.rows, next.columns
             )
         } else {
-            format!(
-                "grid resized to {}x{}; {} pane(s)",
-                next.rows,
-                next.columns,
-                self.panes.len()
-            )
+            format!("grid resized to {}x{}", next.rows, next.columns)
         };
 
         Ok(())
     }
 
-    fn spawn_panes_to_fill(&mut self, target_count: usize) -> Result<()> {
-        let specs = self.pane_specs_to_fill(target_count)?;
-        for spec in specs {
-            let index = self.panes.len();
-            self.spawn_pane_spec(index, &spec)?;
-        }
-        self.pane_names.resize(self.panes.len(), None);
-        Ok(())
-    }
-
-    fn pane_specs_to_fill(&mut self, target_count: usize) -> Result<Vec<PaneLaunchSpec>> {
-        let plan = self
-            .launch_plan
-            .as_mut()
-            .ok_or_else(|| anyhow!("no launch plan selected"))?;
-        if plan.panes.is_empty() {
-            return Err(anyhow!("no pane template available"));
-        }
-
-        let templates = plan.panes.clone();
-        while plan.panes.len() < target_count {
-            let mut spec = templates[plan.panes.len() % templates.len()].clone();
-            if self.config.auth.auto_cycle {
-                clear_spec_auth(&mut spec);
-            }
-            plan.panes.push(spec);
-        }
-        apply_auth_defaults(plan, &self.config)?;
-
-        Ok(plan.panes[self.panes.len()..target_count].to_vec())
-    }
-
-    fn remove_overflow_panes(&mut self, target_count: usize, next: GridSize) -> bool {
-        let running = self
-            .panes
-            .iter()
-            .skip(target_count)
-            .filter(|pane| !pane.exited)
-            .count();
-        if running > 0 {
-            self.status = format!(
-                "cannot shrink to {}x{}; {running} running pane(s) would be removed",
-                next.rows, next.columns
-            );
-            return false;
-        }
-
-        self.panes.truncate(target_count);
-        if let Some(plan) = &mut self.launch_plan {
-            plan.panes.truncate(target_count);
-        }
-        self.selected = self
-            .selected
-            .iter()
-            .copied()
-            .filter(|index| *index < target_count)
-            .collect();
-        if self.focus >= target_count {
-            self.focus = target_count.saturating_sub(1);
-        }
-        self.pane_names.truncate(target_count);
-        self.pane_idle.truncate(target_count);
-        if self
-            .follow_up
-            .is_some_and(|prompt| prompt.pane_index >= target_count)
-        {
-            self.follow_up = None;
-        }
-        self.sleeping = self
-            .sleeping
-            .iter()
-            .copied()
-            .filter(|index| *index < target_count)
-            .collect();
-        if self
-            .text_selection
-            .is_some_and(|selection| selection.pane >= target_count)
-        {
-            self.text_selection = None;
-        }
-        self.truncate_groups(target_count);
-        true
-    }
-
-    fn truncate_groups(&mut self, target_count: usize) {
+    fn remap_groups(&mut self, old_to_new: &BTreeMap<usize, usize>) {
         self.groups.retain_mut(|group| {
-            group.workers.retain(|index| *index < target_count);
-            group
-                .relay_buffers
-                .retain(|pane_index, _| *pane_index < target_count);
+            group.workers = remap_index_set(&group.workers, old_to_new);
+            group.relay_buffers = mem::take(&mut group.relay_buffers)
+                .into_iter()
+                .filter_map(|(old, buffer)| old_to_new.get(&old).copied().map(|new| (new, buffer)))
+                .collect();
             !group.workers.is_empty()
         });
 
@@ -4971,6 +4997,10 @@ impl App {
 
     pub fn status(&self) -> &str {
         &self.status
+    }
+
+    pub fn grid_resizer(&self) -> Option<&GridPicker> {
+        self.grid_resizer.as_ref()
     }
 
     pub fn settings_open(&self) -> bool {
@@ -6257,20 +6287,44 @@ fn base64_encode(bytes: &[u8]) -> String {
     output
 }
 
-fn adjust_dimension(value: usize, delta: isize) -> Option<usize> {
-    if delta < 0 {
-        value.checked_sub((-delta) as usize)
-    } else {
-        value.checked_add(delta as usize)
+fn grid_resize_slots(current: GridSize, next: GridSize, pane_count: usize) -> Vec<Option<usize>> {
+    let mut slots = Vec::with_capacity(next.count());
+    for row in 0..next.rows {
+        for column in 0..next.columns {
+            let old_index = (row < current.rows && column < current.columns)
+                .then_some(row * current.columns + column)
+                .filter(|index| *index < pane_count);
+            slots.push(old_index);
+        }
     }
+    slots
 }
 
-fn invalid_grid_status(rows: usize, columns: usize) -> String {
-    if rows == 0 || columns == 0 {
-        "grid needs at least 1 row and 1 column".into()
-    } else {
-        "grid is capped at 100 cells".into()
+fn remap_index_set(
+    indices: &BTreeSet<usize>,
+    old_to_new: &BTreeMap<usize, usize>,
+) -> BTreeSet<usize> {
+    indices
+        .iter()
+        .filter_map(|old| old_to_new.get(old).copied())
+        .collect()
+}
+
+fn resized_focus_index(
+    old_focus: usize,
+    current: GridSize,
+    next: GridSize,
+    old_to_new: &BTreeMap<usize, usize>,
+) -> usize {
+    if let Some(new_focus) = old_to_new.get(&old_focus) {
+        return *new_focus;
     }
+
+    let old_row = old_focus / current.columns;
+    let old_column = old_focus % current.columns;
+    let row = old_row.min(next.rows.saturating_sub(1));
+    let column = old_column.min(next.columns.saturating_sub(1));
+    row * next.columns + column
 }
 
 fn awake_input_targets_for(
@@ -6503,6 +6557,92 @@ mod tests {
             row: 0,
             modifiers,
         }
+    }
+
+    #[test]
+    fn shrinking_columns_deactivates_the_rightmost_column() {
+        let slots = grid_resize_slots(
+            GridSize {
+                rows: 3,
+                columns: 3,
+            },
+            GridSize {
+                rows: 3,
+                columns: 2,
+            },
+            9,
+        );
+
+        assert_eq!(
+            slots,
+            vec![Some(0), Some(1), Some(3), Some(4), Some(6), Some(7)]
+        );
+    }
+
+    #[test]
+    fn expanding_columns_preserves_rows_and_inserts_new_cells() {
+        let slots = grid_resize_slots(
+            GridSize {
+                rows: 3,
+                columns: 2,
+            },
+            GridSize {
+                rows: 3,
+                columns: 3,
+            },
+            6,
+        );
+
+        assert_eq!(
+            slots,
+            vec![
+                Some(0),
+                Some(1),
+                None,
+                Some(2),
+                Some(3),
+                None,
+                Some(4),
+                Some(5),
+                None,
+            ]
+        );
+    }
+
+    #[test]
+    fn equal_count_reshape_removes_and_adds_by_coordinate() {
+        let slots = grid_resize_slots(
+            GridSize {
+                rows: 2,
+                columns: 3,
+            },
+            GridSize {
+                rows: 3,
+                columns: 2,
+            },
+            6,
+        );
+
+        assert_eq!(slots, vec![Some(0), Some(1), Some(3), Some(4), None, None]);
+    }
+
+    #[test]
+    fn focus_moves_to_nearest_retained_cell_when_its_column_is_removed() {
+        let current = GridSize {
+            rows: 3,
+            columns: 3,
+        };
+        let next = GridSize {
+            rows: 3,
+            columns: 2,
+        };
+        let old_to_new = grid_resize_slots(current, next, 9)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(new, old)| old.map(|old| (old, new)))
+            .collect();
+
+        assert_eq!(resized_focus_index(5, current, next, &old_to_new), 3);
     }
 
     #[test]

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
     Frame, Terminal,
@@ -24,17 +24,52 @@ type ComposerTerminal = Terminal<CrosstermBackend<Stdout>>;
 const DEFAULT_ROWS: usize = 2;
 const DEFAULT_COLUMNS: usize = 3;
 const MAX_DIMENSION: usize = 10;
-const PREVIEW_BORDER: Color = Color::Rgb(95, 214, 150);
-const PREVIEW_LIGHT: Color = Color::Rgb(43, 128, 84);
-const PREVIEW_MID: Color = Color::Rgb(28, 96, 65);
-const PREVIEW_DARK: Color = Color::Rgb(15, 65, 49);
+const STARTUP_PREVIEW: PreviewPalette = PreviewPalette {
+    border: Color::Rgb(95, 214, 150),
+    light: Color::Rgb(43, 128, 84),
+    mid: Color::Rgb(28, 96, 65),
+    dark: Color::Rgb(15, 65, 49),
+};
+const RESIZE_PREVIEW: PreviewPalette = PreviewPalette {
+    border: Color::Rgb(88, 166, 255),
+    light: Color::Rgb(47, 129, 247),
+    mid: Color::Rgb(31, 91, 191),
+    dark: Color::Rgb(15, 50, 110),
+};
 
 pub struct Composer {
     current_dir: PathBuf,
     worktrees: Option<ManagedWorktreeOptions>,
+    picker: GridPicker,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridPickerMode {
+    Startup,
+    Resize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridPickerAction {
+    Continue,
+    Confirm(GridSize),
+    Cancel,
+}
+
+#[derive(Debug, Clone)]
+pub struct GridPicker {
+    initial: GridSize,
     rows: usize,
     columns: usize,
     active_field: DimensionField,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PreviewPalette {
+    border: Color,
+    light: Color,
+    mid: Color,
+    dark: Color,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,12 +86,14 @@ enum ComposerEvent {
 
 impl Composer {
     pub fn new(current_dir: PathBuf, worktrees: Option<ManagedWorktreeOptions>) -> Self {
+        let grid = GridSize {
+            rows: DEFAULT_ROWS,
+            columns: DEFAULT_COLUMNS,
+        };
         Self {
             current_dir,
             worktrees,
-            rows: DEFAULT_ROWS,
-            columns: DEFAULT_COLUMNS,
-            active_field: DimensionField::Rows,
+            picker: GridPicker::new(grid),
         }
     }
 
@@ -66,7 +103,10 @@ impl Composer {
         config: &Config,
     ) -> Result<Option<LaunchPlan>> {
         loop {
-            terminal.draw(|frame| self.draw(frame))?;
+            terminal.draw(|frame| {
+                self.picker
+                    .draw(frame, GridPickerMode::Startup, Some(&self.current_dir))
+            })?;
 
             if !event::poll(Duration::from_millis(50))? {
                 continue;
@@ -74,7 +114,13 @@ impl Composer {
 
             let result = match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    self.handle_key(key, config)?
+                    match self.picker.handle_key(key) {
+                        GridPickerAction::Continue => ComposerEvent::Continue,
+                        GridPickerAction::Confirm(grid) => {
+                            self.launch_plan(config, grid).map(ComposerEvent::Launch)?
+                        }
+                        GridPickerAction::Cancel => ComposerEvent::Quit,
+                    }
                 }
                 _ => ComposerEvent::Continue,
             };
@@ -87,39 +133,71 @@ impl Composer {
         }
     }
 
-    fn handle_key(&mut self, key: KeyEvent, config: &Config) -> Result<ComposerEvent> {
+    fn launch_plan(&self, config: &Config, grid: GridSize) -> Result<LaunchPlan> {
+        let profile_name = startup_profile_name(config);
+        let profile = find_profile(config, &profile_name)?;
+
+        LaunchPlan::from_launch_options(
+            profile_name,
+            profile,
+            self.current_dir.clone(),
+            grid.count(),
+            grid,
+            self.worktrees.as_ref(),
+        )
+    }
+}
+
+impl GridPicker {
+    pub fn new(grid: GridSize) -> Self {
+        Self {
+            initial: grid,
+            rows: grid.rows,
+            columns: grid.columns,
+            active_field: DimensionField::Rows,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> GridPickerAction {
         match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => Ok(ComposerEvent::Quit),
-            KeyCode::Enter => self.launch_plan(config).map(ComposerEvent::Launch),
+            KeyCode::Esc | KeyCode::Char('q') => GridPickerAction::Cancel,
+            KeyCode::Enter => GridPickerAction::Confirm(self.grid()),
             KeyCode::Left | KeyCode::Char('h') | KeyCode::BackTab => {
                 self.active_field = DimensionField::Rows;
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => {
                 self.active_field = DimensionField::Columns;
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Up | KeyCode::Char('+') | KeyCode::Char('=') | KeyCode::Char('k') => {
                 self.adjust_active(1);
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Down | KeyCode::Char('-') | KeyCode::Char('j') => {
                 self.adjust_active(-1);
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Char('r') => {
                 self.active_field = DimensionField::Rows;
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Char('c') => {
                 self.active_field = DimensionField::Columns;
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
             KeyCode::Char(ch) if ch.is_ascii_digit() => {
                 self.set_active_from_digit(ch);
-                Ok(ComposerEvent::Continue)
+                GridPickerAction::Continue
             }
-            _ => Ok(ComposerEvent::Continue),
+            _ => GridPickerAction::Continue,
+        }
+    }
+
+    pub fn grid(&self) -> GridSize {
+        GridSize {
+            rows: self.rows,
+            columns: self.columns,
         }
     }
 
@@ -145,22 +223,7 @@ impl Composer {
         }
     }
 
-    fn launch_plan(&self, config: &Config) -> Result<LaunchPlan> {
-        let grid = GridSize::new(self.rows, self.columns).context("invalid grid dimensions")?;
-        let profile_name = startup_profile_name(config);
-        let profile = find_profile(config, &profile_name)?;
-
-        LaunchPlan::from_launch_options(
-            profile_name,
-            profile,
-            self.current_dir.clone(),
-            grid.count(),
-            grid,
-            self.worktrees.as_ref(),
-        )
-    }
-
-    fn draw(&self, frame: &mut Frame<'_>) {
+    pub fn draw(&self, frame: &mut Frame<'_>, mode: GridPickerMode, cwd: Option<&Path>) {
         let area = frame.area();
         frame.render_widget(background(), area);
 
@@ -168,7 +231,10 @@ impl Composer {
         frame.render_widget(Clear, panel);
         let block = Block::default()
             .borders(Borders::ALL)
-            .title(" GridBash Startup ")
+            .title(match mode {
+                GridPickerMode::Startup => " GridBash Startup ",
+                GridPickerMode::Resize => " GridBash Resize ",
+            })
             .border_style(Style::default().fg(Color::Cyan))
             .style(panel_style());
         let inner = block.inner(panel);
@@ -183,17 +249,35 @@ impl Composer {
             ])
             .split(inner);
 
-        self.draw_header(frame, chunks[0]);
-        self.draw_preview(frame, chunks[1]);
-        self.draw_controls(frame, chunks[2]);
+        self.draw_header(frame, chunks[0], mode, cwd);
+        self.draw_preview(frame, chunks[1], mode);
+        self.draw_controls(frame, chunks[2], mode);
     }
 
-    fn draw_header(&self, frame: &mut Frame<'_>, area: Rect) {
-        let cwd = display_path(&self.current_dir);
+    fn draw_header(
+        &self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        mode: GridPickerMode,
+        cwd: Option<&Path>,
+    ) {
+        let context = match mode {
+            GridPickerMode::Startup => cwd
+                .map(display_path)
+                .map(|cwd| ("cwd ", cwd))
+                .unwrap_or_else(|| ("", String::new())),
+            GridPickerMode::Resize => (
+                "current ",
+                format!("{}x{}", self.initial.rows, self.initial.columns),
+            ),
+        };
         let lines = vec![
             Line::from(vec![
                 Span::styled(
-                    "Choose grid dimensions",
+                    match mode {
+                        GridPickerMode::Startup => "Choose grid dimensions",
+                        GridPickerMode::Resize => "Resize active grid",
+                    },
                     Style::default()
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
@@ -205,21 +289,21 @@ impl Composer {
                 ),
             ]),
             Line::from(vec![
-                Span::styled("cwd ", Style::default().fg(Color::DarkGray)),
-                Span::styled(cwd, Style::default().fg(Color::Gray)),
+                Span::styled(context.0, Style::default().fg(Color::DarkGray)),
+                Span::styled(context.1, Style::default().fg(Color::Gray)),
             ]),
         ];
 
         frame.render_widget(Paragraph::new(lines).style(panel_style()), area);
     }
 
-    fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect) {
+    fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect, mode: GridPickerMode) {
         let preview_area = inset(area, 1, 0);
-        let grid = GridSize {
-            rows: self.rows,
-            columns: self.columns,
+        let palette = match mode {
+            GridPickerMode::Startup => STARTUP_PREVIEW,
+            GridPickerMode::Resize => RESIZE_PREVIEW,
         };
-        let rects = square_preview_rects(preview_area, grid);
+        let rects = square_preview_rects(preview_area, self.grid());
 
         for (index, rect) in rects.into_iter().enumerate() {
             if rect.width == 0 || rect.height == 0 {
@@ -228,15 +312,15 @@ impl Composer {
 
             let block = Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(PREVIEW_BORDER))
-                .style(Style::default().bg(PREVIEW_DARK));
+                .border_style(Style::default().fg(palette.border))
+                .style(Style::default().bg(palette.dark));
             let inner = block.inner(rect);
             frame.render_widget(block, rect);
-            frame.render_widget(dithered_fill(index, inner), inner);
+            frame.render_widget(dithered_fill(index, inner, palette), inner);
         }
     }
 
-    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect) {
+    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect, mode: GridPickerMode) {
         let lines = vec![
             Line::from(""),
             Line::from(vec![
@@ -255,7 +339,20 @@ impl Composer {
                 Span::styled("Left/Right", Style::default().fg(Color::Yellow)),
                 Span::raw(" switch  "),
                 Span::styled("Enter", Style::default().fg(Color::Yellow)),
-                Span::raw(" launch"),
+                Span::raw(match mode {
+                    GridPickerMode::Startup => " launch",
+                    GridPickerMode::Resize => " apply  ",
+                }),
+                if mode == GridPickerMode::Resize {
+                    Span::styled("Esc", Style::default().fg(Color::Yellow))
+                } else {
+                    Span::raw("")
+                },
+                if mode == GridPickerMode::Resize {
+                    Span::raw(" cancel")
+                } else {
+                    Span::raw("")
+                },
             ]),
         ];
 
@@ -366,15 +463,15 @@ fn square_preview_rects(area: Rect, grid: GridSize) -> Vec<Rect> {
     rects
 }
 
-fn dithered_fill(index: usize, rect: Rect) -> Paragraph<'static> {
+fn dithered_fill(index: usize, rect: Rect, palette: PreviewPalette) -> Paragraph<'static> {
     let lines = (0..rect.height)
         .map(|y| {
             let mut spans = Vec::with_capacity(rect.width as usize);
             for x in 0..rect.width {
                 let bg = match (x.saturating_mul(3) + y.saturating_mul(5) + index as u16) % 6 {
-                    0 | 3 => PREVIEW_LIGHT,
-                    1 | 4 => PREVIEW_MID,
-                    _ => PREVIEW_DARK,
+                    0 | 3 => palette.light,
+                    1 | 4 => palette.mid,
+                    _ => palette.dark,
                 };
                 spans.push(Span::styled(" ", Style::default().bg(bg)));
             }
@@ -382,12 +479,15 @@ fn dithered_fill(index: usize, rect: Rect) -> Paragraph<'static> {
         })
         .collect::<Vec<_>>();
 
-    Paragraph::new(lines).style(Style::default().bg(PREVIEW_DARK))
+    Paragraph::new(lines).style(Style::default().bg(palette.dark))
 }
 
 #[cfg(test)]
 mod tests {
     use std::env;
+
+    use crossterm::event::KeyModifiers;
+    use ratatui::backend::TestBackend;
 
     use super::*;
 
@@ -402,7 +502,9 @@ mod tests {
         let current_dir = env::current_dir().expect("current dir");
 
         let composer = Composer::new(current_dir.clone(), None);
-        let plan = composer.launch_plan(&config).expect("launch plan");
+        let plan = composer
+            .launch_plan(&config, composer.picker.grid())
+            .expect("launch plan");
 
         assert_eq!(plan.grid.rows, DEFAULT_ROWS);
         assert_eq!(plan.grid.columns, DEFAULT_COLUMNS);
@@ -411,6 +513,53 @@ mod tests {
             plan.panes
                 .iter()
                 .all(|pane| { pane.profile_name == "powershell" && pane.cwd == current_dir })
+        );
+    }
+
+    #[test]
+    fn resize_picker_starts_from_the_live_grid_and_confirms_changes() {
+        let mut picker = GridPicker::new(GridSize {
+            rows: 3,
+            columns: 3,
+        });
+
+        picker.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        picker.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            GridPickerAction::Confirm(GridSize {
+                rows: 3,
+                columns: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn resize_picker_renders_active_cells_in_blue() {
+        let picker = GridPicker::new(GridSize {
+            rows: 2,
+            columns: 3,
+        });
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame, GridPickerMode::Resize, None))
+            .expect("draw picker");
+
+        let buffer = terminal.backend().buffer();
+        assert!(buffer.content().iter().any(|cell| {
+            matches!(
+                cell.bg,
+                Color::Rgb(47, 129, 247) | Color::Rgb(31, 91, 191) | Color::Rgb(15, 50, 110)
+            )
+        }));
+        assert!(
+            !buffer
+                .content()
+                .iter()
+                .any(|cell| cell.bg == STARTUP_PREVIEW.light)
         );
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ use crate::{
         RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind, TabLabel,
     },
     auth::{AgentKind, AuthProfile},
+    composer::GridPickerMode,
     image_preview::ImagePreview,
 };
 
@@ -73,6 +74,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let follow_up_dialog = app.follow_up_dialog();
     let prompt_view = app.prompt_view();
     let pane_settings_open = app.pane_settings_open();
+    let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let exited_recovery = if app.settings_open()
         || previous_panes_view.is_some()
@@ -81,6 +83,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || tab_rename_view.is_some()
         || follow_up_dialog.is_some()
         || prompt_view.is_some()
+        || grid_resizer.is_some()
         || image_overlay.is_some()
     {
         None
@@ -94,6 +97,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || tab_rename_view.is_some()
         || follow_up_dialog.is_some()
         || prompt_view.is_some()
+        || grid_resizer.is_some()
         || image_overlay.is_some()
         || exited_recovery.is_some();
     let mut pane_settings_rename_button = None;
@@ -219,7 +223,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -251,6 +255,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
     if let Some(recovery) = exited_recovery.as_ref() {
         render_exited_recovery(frame, area, recovery, palette);
+    }
+    if let Some(picker) = grid_resizer {
+        picker.draw(frame, GridPickerMode::Resize, None);
     }
 
     DrawState {


### PR DESCRIPTION
Closes #128

## Summary
- replace Alt+Shift+Arrow resizing with an Alt+l full-screen grid picker
- render active resize cells in blue using the shared onboarding picker
- preserve pane coordinates and terminate cells outside the selected rows/columns
- remap focus, selection, sleeping state, names, follow-ups, groups, and launch specs

## Validation
- cargo check --tests
- cargo test (110 passed, 1 ignored)
- cargo clippy --all-targets -- -D warnings
- cargo fmt -- --check
- git diff --check
