### PR TITLE
fix: improve voice transcription accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,12 +291,17 @@ exited target panes directly.
 
 Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. When the one-line command bar is focused, typing stays in that bar; Enter runs the command from the cwd shown in the prompt and keeps output hidden until expanded.
 
-Voice mode uses the installed Windows speech recognizer and the default microphone.
-Press `Alt+v` to listen for one utterance (up to 15 seconds). The transcript is
-inserted into the command bar or the panes that were targeted when listening
-started. GridBash never presses Enter for dictated text, so you can review or edit
-it before submitting. Press `Alt+v` while listening to cancel. A Windows speech
-language pack matching the desired dictation language must be installed.
+Voice mode uses modern Windows online dictation and the default microphone. Press
+`Alt+v` to listen for one utterance; GridBash waits up to 15 seconds for speech.
+The transcript is inserted into the command bar or the panes that were targeted
+when listening started. GridBash never presses Enter for dictated text, so you can
+review or edit it before submitting. Press `Alt+v` while listening to cancel.
+
+Voice audio is processed by Microsoft's online speech service. Enable **Online
+speech recognition** in Windows Settings under **Privacy & security > Speech**,
+allow desktop apps to access the microphone, and install the Windows speech
+language pack matching the desired dictation language. If any requirement is
+missing, GridBash reports the Windows dictation error instead of inserting text.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
 

--- a/docs/devlogs/2026-07-10-improve-voice-transcription-accuracy.md
+++ b/docs/devlogs/2026-07-10-improve-voice-transcription-accuracy.md
@@ -1,0 +1,32 @@
+# Improve voice transcription accuracy
+
+Date: 2026-07-10
+Release target: unreleased
+Issue: #130
+
+## Summary
+
+- Replaced legacy Windows speech recognition with modern Windows online dictation.
+
+## What Changed
+
+- Voice mode now uses `Windows.Media.SpeechRecognition` instead of `.NET System.Speech`.
+- Increased the end-of-speech pause to make dictated prompts feel less abrupt.
+- Added actionable errors for disabled online speech, unsupported languages, and unavailable microphones.
+- Updated the voice setup and privacy documentation.
+
+## Why It Matters
+
+- Free-form coding prompts receive substantially better recognition than the legacy desktop engine could provide.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+- Confirmed the modern `en-US` dictation grammar compiles on Windows 11.
+
+## Release Notes
+
+- Voice mode now uses modern Windows online dictation for more accurate prompt transcription. Enable Online speech recognition in Windows Settings before using `Alt+v`.

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -18,19 +18,68 @@ const RECOGNIZE_SCRIPT: &str = r#"
 $ErrorActionPreference = 'Stop'
 $recognizer = $null
 try {
-    Add-Type -AssemblyName System.Speech
-    $recognizer = New-Object System.Speech.Recognition.SpeechRecognitionEngine
-    $recognizer.LoadGrammar((New-Object System.Speech.Recognition.DictationGrammar))
-    $recognizer.SetInputToDefaultAudioDevice()
-    $result = $recognizer.Recognize([TimeSpan]::FromSeconds(15))
-    if ($null -eq $result) { exit 2 }
+    Add-Type -AssemblyName System.Runtime.WindowsRuntime
+    $null = [Windows.Media.SpeechRecognition.SpeechRecognizer, Windows.Media.SpeechRecognition, ContentType=WindowsRuntime]
+
+    $asTaskMethod = [System.WindowsRuntimeSystemExtensions].GetMethods() |
+        Where-Object {
+            $_.Name -eq 'AsTask' -and
+            $_.IsGenericMethod -and
+            $_.GetParameters().Count -eq 1 -and
+            $_.GetParameters()[0].ParameterType.Name -eq 'IAsyncOperation`1'
+        } |
+        Select-Object -First 1
+    if ($null -eq $asTaskMethod) {
+        throw 'could not access the Windows Runtime async bridge'
+    }
+
+    function Wait-WindowsRuntimeOperation($operation, [Type] $resultType) {
+        $task = $asTaskMethod.MakeGenericMethod($resultType).Invoke($null, @($operation))
+        $task.GetAwaiter().GetResult()
+    }
+
+    $recognizer = [Windows.Media.SpeechRecognition.SpeechRecognizer]::new()
+    $recognizer.Timeouts.InitialSilenceTimeout = [TimeSpan]::FromSeconds(15)
+    $recognizer.Timeouts.EndSilenceTimeout = [TimeSpan]::FromMilliseconds(1500)
+    $recognizer.Timeouts.BabbleTimeout = [TimeSpan]::FromSeconds(15)
+
+    $compileResult = Wait-WindowsRuntimeOperation `
+        $recognizer.CompileConstraintsAsync() `
+        ([Windows.Media.SpeechRecognition.SpeechRecognitionCompilationResult])
+    if ($compileResult.Status -ne 'Success') {
+        throw "Windows dictation grammar failed to compile: $($compileResult.Status)"
+    }
+
+    $result = Wait-WindowsRuntimeOperation `
+        $recognizer.RecognizeAsync() `
+        ([Windows.Media.SpeechRecognition.SpeechRecognitionResult])
+    if ($result.Status -eq 'UserCanceled' -or [string]::IsNullOrWhiteSpace($result.Text)) {
+        exit 2
+    }
+    if ($result.Status -ne 'Success') {
+        throw "Windows dictation failed: $($result.Status)"
+    }
+
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     [Console]::Out.Write($result.Text)
 } catch {
-    [Console]::Error.Write($_.Exception.Message)
+    $exception = $_.Exception
+    if ($null -ne $exception.InnerException) {
+        $exception = $exception.InnerException
+    }
+    $errorCode = '{0:X8}' -f ($exception.HResult -band 0xffffffffL)
+    $message = switch ($errorCode) {
+        '80045509' { 'online speech recognition is off; enable Windows Settings > Privacy & security > Speech > Online speech recognition' }
+        '80070005' { 'microphone access is denied; allow desktop apps under Windows Settings > Privacy & security > Microphone' }
+        'C00DABE0' { 'no microphone is available' }
+        default { "modern Windows dictation failed: $($exception.Message)" }
+    }
+    [Console]::Error.Write($message)
     exit 1
 } finally {
-    if ($null -ne $recognizer) { $recognizer.Dispose() }
+    if ($null -ne $recognizer) {
+        try { $recognizer.Dispose() } catch {}
+    }
 }
 "#;
 
@@ -149,7 +198,7 @@ fn recognize(cancel_rx: Receiver<()>) -> Option<VoiceOutcome> {
         Ok(child) => child,
         Err(error) => {
             return Some(VoiceOutcome::Error(format!(
-                "could not start Windows speech recognition: {error}"
+                "could not start modern Windows dictation: {error}"
             )));
         }
     };
@@ -169,7 +218,7 @@ fn recognize(cancel_rx: Receiver<()>) -> Option<VoiceOutcome> {
             Err(error) => {
                 terminate(&mut child);
                 return Some(VoiceOutcome::Error(format!(
-                    "speech recognition failed: {error}"
+                    "modern Windows dictation failed: {error}"
                 )));
             }
         }
@@ -200,7 +249,7 @@ fn read_outcome(child: &mut Child, status: ExitStatus) -> VoiceOutcome {
 
     let detail = normalize_transcript(&stderr);
     if detail.is_empty() {
-        VoiceOutcome::Error(format!("Windows speech recognition exited with {status}"))
+        VoiceOutcome::Error(format!("modern Windows dictation exited with {status}"))
     } else {
         VoiceOutcome::Error(detail)
     }


### PR DESCRIPTION
## Summary

- replace legacy `System.Speech` dictation with modern Windows online dictation
- preserve cancellable push-to-talk and review-before-submit behavior
- report actionable speech privacy and microphone errors
- document the online processing and Windows setup requirements

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (104 passed, 1 expected interactive ConPTY test ignored)
- `cargo build --release --jobs 1 --quiet`
- modern `en-US` Windows dictation grammar compiled successfully
- exact voice script reached and correctly identified the Windows online-speech privacy gate

Refs #130
