### PR TITLE
fix: inherit invoking shell for panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Open the startup grid picker:
 gridbash
 ```
 
-On first launch, if no default profile is configured, GridBash opens an animated setup screen and asks you to choose from the detected terminal profiles. The choice is saved to:
+When launched through the npm command, GridBash inherits the invoking shell for new panes: PowerShell launches PowerShell, PowerShell 7 launches `pwsh`, cmd launches cmd, and Git Bash launches Git Bash. Use `--profile` or `GRIDBASH_PROFILE` to override shell inheritance.
+
+If the invoking shell cannot be detected and no default profile is configured, GridBash opens an animated setup screen and asks you to choose from the detected terminal profiles. The choice is saved to:
 
 ```text
 %APPDATA%\GridBash\config.toml
@@ -154,7 +156,7 @@ On first launch, if no default profile is configured, GridBash opens an animated
 
 The startup picker asks for rows and columns, updates the preview grid as you change them, and launches every pane in the directory where you started `gridbash`.
 
-Set the default terminal profile:
+Set the fallback terminal profile used when shell inheritance is unavailable:
 
 ```powershell
 gridbash --set-default powershell

--- a/docs/devlogs/2026-07-10-inherit.md
+++ b/docs/devlogs/2026-07-10-inherit.md
@@ -1,0 +1,31 @@
+# Inherit Invoking Shell
+
+Date: 2026-07-10
+Release target: unreleased
+
+## Summary
+
+- GridBash now uses the shell that invoked the npm command as the default pane profile.
+
+## What Changed
+
+- Detect PowerShell, PowerShell 7, cmd, and Git Bash from the npm launcher's parent process.
+- Pass the detected profile to the Rust application without overriding `--profile` or `GRIDBASH_PROFILE`.
+- Prefer the inherited shell over a saved fallback and skip first-run terminal selection when detection succeeds.
+
+## Why It Matters
+
+- Running `gridbash` feels native to the current terminal instead of unexpectedly opening a different shell.
+
+## Validation
+
+- `npm run test:launcher`
+- `node --check npm/bin/gridbash.js`
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+
+## Release Notes
+
+- Fixed default pane startup so GridBash inherits PowerShell, pwsh, cmd, or Git Bash from the invoking terminal.

--- a/npm/bin/gridbash.js
+++ b/npm/bin/gridbash.js
@@ -27,6 +27,70 @@ function readPackageVersion(root = packageRoot()) {
   }
 }
 
+function tasklistImageName(output) {
+  const match = /^\s*"([^"]+)"/m.exec(String(output || ""));
+  return match?.[1];
+}
+
+function profileForProcessName(processName) {
+  const name = path.win32.basename(String(processName || "").trim()).toLowerCase();
+  switch (name) {
+    case "powershell.exe":
+      return "powershell";
+    case "pwsh.exe":
+      return "pwsh";
+    case "cmd.exe":
+      return "cmd";
+    case "bash.exe":
+    case "sh.exe":
+    case "git-bash.exe":
+      return "git-bash";
+    default:
+      return undefined;
+  }
+}
+
+function detectInvokingProfile({
+  platform = process.platform,
+  parentPid = process.ppid,
+  run = spawnSync,
+} = {}) {
+  if (platform !== "win32") {
+    return undefined;
+  }
+
+  let result;
+  try {
+    result = run(
+      "tasklist.exe",
+      ["/FI", `PID eq ${parentPid}`, "/FO", "CSV", "/NH"],
+      {
+        encoding: "utf8",
+        windowsHide: true,
+      },
+    );
+  } catch {
+    return undefined;
+  }
+  if (result.error || result.status !== 0) {
+    return undefined;
+  }
+
+  return profileForProcessName(tasklistImageName(result.stdout));
+}
+
+function environmentForLaunch(env = process.env, invokingProfile = detectInvokingProfile()) {
+  const childEnv = { ...env };
+  if (
+    invokingProfile &&
+    !childEnv.GRIDBASH_PROFILE &&
+    !childEnv.GRIDBASH_INVOKING_PROFILE
+  ) {
+    childEnv.GRIDBASH_INVOKING_PROFILE = invokingProfile;
+  }
+  return childEnv;
+}
+
 function parseVersion(value) {
   const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(value || "");
   if (!match) {
@@ -266,6 +330,7 @@ async function main() {
 
   const result = spawnSync(exe, args, {
     cwd: process.cwd(),
+    env: environmentForLaunch(),
     stdio: "inherit",
     windowsHide: false,
   });
@@ -287,9 +352,13 @@ if (require.main === module) {
   module.exports = {
     checkForUpdate,
     compareVersions,
+    detectInvokingProfile,
+    environmentForLaunch,
     fetchLatestRelease,
     formatUpdateNotice,
+    profileForProcessName,
     shouldSkipUpdateCheck,
+    tasklistImageName,
     updateCheckTimeoutMs,
   };
 }

--- a/npm/scripts/gridbash-launcher.test.js
+++ b/npm/scripts/gridbash-launcher.test.js
@@ -5,8 +5,12 @@ const { test } = require("node:test");
 const {
   checkForUpdate,
   compareVersions,
+  detectInvokingProfile,
+  environmentForLaunch,
   formatUpdateNotice,
+  profileForProcessName,
   shouldSkipUpdateCheck,
+  tasklistImageName,
   updateCheckTimeoutMs,
 } = require("../bin/gridbash.js");
 
@@ -46,6 +50,50 @@ test("shouldSkipUpdateCheck preserves help, version, MCP, and non-TTY paths", ()
 test("updateCheckTimeoutMs clamps overrides", () => {
   assert.equal(updateCheckTimeoutMs({ GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "25" }), 25);
   assert.equal(updateCheckTimeoutMs({ GRIDBASH_UPDATE_CHECK_TIMEOUT_MS: "10000" }), 5000);
+});
+
+test("profileForProcessName maps supported Windows shells", () => {
+  assert.equal(profileForProcessName("powershell.exe"), "powershell");
+  assert.equal(profileForProcessName("C:\\Program Files\\PowerShell\\7\\pwsh.exe"), "pwsh");
+  assert.equal(profileForProcessName("cmd.exe"), "cmd");
+  assert.equal(profileForProcessName("bash.exe"), "git-bash");
+  assert.equal(profileForProcessName("node.exe"), undefined);
+});
+
+test("detectInvokingProfile reads the parent process from tasklist", () => {
+  const run = (command, args, options) => {
+    assert.equal(command, "tasklist.exe");
+    assert.deepEqual(args, ["/FI", "PID eq 4242", "/FO", "CSV", "/NH"]);
+    assert.equal(options.encoding, "utf8");
+    return {
+      status: 0,
+      stdout: '"powershell.exe","4242","Console","1","75,000 K"\r\n',
+    };
+  };
+
+  assert.equal(detectInvokingProfile({ parentPid: 4242, platform: "win32", run }), "powershell");
+  assert.equal(detectInvokingProfile({ platform: "darwin", run }), undefined);
+  assert.equal(
+    detectInvokingProfile({
+      platform: "win32",
+      run: () => {
+        throw new Error("tasklist unavailable");
+      },
+    }),
+    undefined,
+  );
+  assert.equal(tasklistImageName("INFO: No tasks are running"), undefined);
+});
+
+test("environmentForLaunch preserves explicit profile overrides", () => {
+  assert.deepEqual(environmentForLaunch({ HOME: "home" }, "powershell"), {
+    HOME: "home",
+    GRIDBASH_INVOKING_PROFILE: "powershell",
+  });
+  assert.deepEqual(
+    environmentForLaunch({ GRIDBASH_PROFILE: "codex" }, "powershell"),
+    { GRIDBASH_PROFILE: "codex" },
+  );
 });
 
 test("checkForUpdate returns latest release only when it is newer", async () => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -5727,9 +5727,24 @@ fn uses_direct_launch(cli: &Cli) -> bool {
 }
 
 fn resolve_profile_name(cli: &Cli, config: &Config) -> String {
+    resolve_profile_name_from(
+        cli,
+        config,
+        env::var("GRIDBASH_PROFILE").ok(),
+        env::var("GRIDBASH_INVOKING_PROFILE").ok(),
+    )
+}
+
+fn resolve_profile_name_from(
+    cli: &Cli,
+    config: &Config,
+    environment_profile: Option<String>,
+    invoking_profile: Option<String>,
+) -> String {
     cli.profile
         .clone()
-        .or_else(|| env::var("GRIDBASH_PROFILE").ok())
+        .or(environment_profile)
+        .or(invoking_profile)
         .or_else(|| config.defaults.profile.clone())
         .unwrap_or_else(|| "git-bash".into())
 }
@@ -6466,6 +6481,8 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    use clap::Parser as ClapParser;
+
     use super::*;
     use crate::profiles::Profile;
     use vt100::Parser;
@@ -6494,6 +6511,44 @@ mod tests {
 
     fn selected(indices: &[usize]) -> BTreeSet<usize> {
         indices.iter().copied().collect()
+    }
+
+    #[test]
+    fn invoking_profile_precedes_saved_fallback() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let mut config = Config::default();
+        config.set_default_profile("git-bash");
+
+        assert_eq!(
+            resolve_profile_name_from(&cli, &config, None, Some("powershell".into())),
+            "powershell"
+        );
+    }
+
+    #[test]
+    fn explicit_profiles_precede_invoking_profile() {
+        let cli = Cli::parse_from(["gridbash", "--profile", "cmd"]);
+        let config = Config::default();
+        assert_eq!(
+            resolve_profile_name_from(
+                &cli,
+                &config,
+                Some("codex".into()),
+                Some("powershell".into()),
+            ),
+            "cmd"
+        );
+
+        let cli = Cli::parse_from(["gridbash"]);
+        assert_eq!(
+            resolve_profile_name_from(
+                &cli,
+                &config,
+                Some("codex".into()),
+                Some("powershell".into()),
+            ),
+            "codex"
+        );
     }
 
     fn mouse_event(kind: MouseEventKind, modifiers: KeyModifiers) -> MouseEvent {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ pub struct Cli {
     #[arg(long)]
     pub count: Option<usize>,
 
-    /// Profile to launch in every pane. Overrides GRIDBASH_PROFILE and config defaults.
+    /// Profile to launch in every pane. Overrides GRIDBASH_PROFILE, shell inheritance, and config defaults.
     #[arg(long)]
     pub profile: Option<String>,
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -59,6 +59,7 @@ pub fn should_run(cli: &Cli, config: &Config) -> bool {
     cli.command.is_none()
         && cli.profile.is_none()
         && env::var_os("GRIDBASH_PROFILE").is_none()
+        && env::var_os("GRIDBASH_INVOKING_PROFILE").is_none()
         && config.defaults.profile.is_none()
 }
 


### PR DESCRIPTION
## Summary
- detect the invoking Windows shell in the npm launcher
- prefer inherited shell profiles over saved fallbacks while preserving explicit overrides
- skip first-run shell selection when inheritance succeeds
- document and test PowerShell, pwsh, cmd, and Git Bash mappings

Closes #135

## Validation
- npm run test:launcher
- node --check npm/bin/gridbash.js
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- cargo build --release
- git diff --check
