### PR TITLE
refactor: add cross-platform target discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules/
 npm-debug.log*
 npm/bin/win32-x64/gridbash.exe
+npm/bin/linux-x64/gridbash
+npm/bin/linux-arm64/gridbash

--- a/docs/devlogs/2026-07-10-add-linux-platform-support.md
+++ b/docs/devlogs/2026-07-10-add-linux-platform-support.md
@@ -1,0 +1,29 @@
+# Add Linux platform support
+
+Date: 2026-07-10
+Release target: unreleased
+Issue: #141
+
+## Summary
+
+- Add native Linux x64 and arm64 support without forking the Windows codebase or release line.
+
+## What Changed
+
+- Added a shared target manifest for Windows x64 and glibc Linux on x64 and arm64.
+- Updated the npm launcher to select the packaged executable from the current platform and architecture.
+- Generalized native package preparation and local installation for supported targets.
+- Expanded npm metadata and binary ignore rules for the Linux artifacts.
+
+## Why It Matters
+
+- Linux developers can run the same PTY-backed GridBash workflow locally, through tmux, or over SSH.
+
+## Validation
+
+- `npm run test:launcher` (8 passing tests)
+- `npm pack --dry-run --ignore-scripts`
+
+## Release Notes
+
+- GridBash now supports Windows x64 plus glibc Linux on x64 and arm64.

--- a/npm/bin/gridbash.js
+++ b/npm/bin/gridbash.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const http = require("node:http");
 const https = require("node:https");
 const path = require("node:path");
+const { targetFor, targetKey } = require("./platforms.js");
 
 const DEFAULT_UPDATE_CHECK_TIMEOUT_MS = 900;
 const DEFAULT_UPDATE_CHECK_URL =
@@ -299,16 +300,12 @@ async function maybePrintUpdateNotice(args, env = process.env, stderr = process.
 
 async function main() {
   const args = process.argv.slice(2);
-
-  if (process.platform !== "win32") {
-    fail("this npm package currently ships the Windows x64 build only");
+  const target = targetFor();
+  if (!target) {
+    fail(`unsupported platform: ${targetKey(process.platform, process.arch)}`);
   }
 
-  if (process.arch !== "x64") {
-    fail(`unsupported architecture: ${process.arch}`);
-  }
-
-  const exe = path.join(__dirname, "win32-x64", "gridbash.exe");
+  const exe = path.join(__dirname, target.directory, target.executable);
   const normalizedBinDir = path.resolve(__dirname).toLowerCase();
   const sourceManifest = path.resolve(__dirname, "..", "..", "Cargo.toml");
 

--- a/npm/bin/platforms.js
+++ b/npm/bin/platforms.js
@@ -1,0 +1,41 @@
+const TARGETS = Object.freeze({
+  "win32-x64": Object.freeze({
+    platform: "win32",
+    arch: "x64",
+    directory: "win32-x64",
+    executable: "gridbash.exe",
+    cargoTarget: "x86_64-pc-windows-msvc",
+  }),
+  "linux-x64": Object.freeze({
+    platform: "linux",
+    arch: "x64",
+    directory: "linux-x64",
+    executable: "gridbash",
+    cargoTarget: "x86_64-unknown-linux-gnu",
+  }),
+  "linux-arm64": Object.freeze({
+    platform: "linux",
+    arch: "arm64",
+    directory: "linux-arm64",
+    executable: "gridbash",
+    cargoTarget: "aarch64-unknown-linux-gnu",
+  }),
+});
+
+function targetKey(platform, arch) {
+  return `${platform}-${arch}`;
+}
+
+function targetFor(platform = process.platform, arch = process.arch) {
+  return TARGETS[targetKey(platform, arch)];
+}
+
+function supportedTargets() {
+  return Object.values(TARGETS);
+}
+
+module.exports = {
+  supportedTargets,
+  targetFor,
+  targetKey,
+};

--- a/npm/scripts/gridbash-launcher.test.js
+++ b/npm/scripts/gridbash-launcher.test.js
@@ -1,6 +1,7 @@
 const assert = require("node:assert/strict");
 const http = require("node:http");
 const { test } = require("node:test");
+const { supportedTargets, targetFor, targetKey } = require("../bin/platforms.js");
 
 const {
   checkForUpdate,
@@ -37,6 +38,22 @@ test("compareVersions handles newer, older, and prerelease versions", () => {
   assert.equal(compareVersions("0.1.4", "0.1.5"), -1);
   assert.equal(compareVersions("0.2.0", "0.1.99"), 1);
   assert.equal(compareVersions("1.0.0", "1.0.0-beta.1"), 1);
+});
+
+test("platform target selection covers shipped Windows and Linux builds", () => {
+  assert.equal(targetKey("linux", "arm64"), "linux-arm64");
+  assert.deepEqual(targetFor("win32", "x64"), {
+    platform: "win32",
+    arch: "x64",
+    directory: "win32-x64",
+    executable: "gridbash.exe",
+    cargoTarget: "x86_64-pc-windows-msvc",
+  });
+  assert.equal(targetFor("linux", "ia32"), undefined);
+  assert.deepEqual(
+    supportedTargets().map((target) => `${target.platform}-${target.arch}`),
+    ["win32-x64", "linux-x64", "linux-arm64"],
+  );
 });
 
 test("shouldSkipUpdateCheck preserves help, version, MCP, and non-TTY paths", () => {

--- a/npm/scripts/install-local.js
+++ b/npm/scripts/install-local.js
@@ -1,6 +1,7 @@
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
+const { targetFor, targetKey } = require("../bin/platforms.js");
 
 const root = path.resolve(__dirname, "..", "..");
 const packageJson = require(path.join(root, "package.json"));
@@ -73,8 +74,8 @@ function assertNotLinked() {
   console.log(`install-local: installed copy at ${packagePath}`);
 }
 
-if (process.platform !== "win32" || process.arch !== "x64") {
-  fail("local packaged install currently supports win32-x64 only");
+if (!targetFor()) {
+  fail(`unsupported platform: ${targetKey(process.platform, process.arch)}`);
 }
 
 run("node", ["npm/scripts/prepare.js"]);

--- a/npm/scripts/prepare.js
+++ b/npm/scripts/prepare.js
@@ -1,11 +1,9 @@
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
+const { targetFor, targetKey } = require("../bin/platforms.js");
 
 const root = path.resolve(__dirname, "..", "..");
-const source = path.join(root, "target", "release", "gridbash.exe");
-const outDir = path.join(root, "npm", "bin", "win32-x64");
-const target = path.join(outDir, "gridbash.exe");
 
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -22,12 +20,28 @@ function run(command, args) {
   }
 }
 
-if (process.platform !== "win32" || process.arch !== "x64") {
-  console.log("gridbash prepare: skipping binary build for non-win32-x64 platform");
+const platformTarget = targetFor();
+if (!platformTarget) {
+  console.log(
+    `gridbash prepare: skipping unsupported platform ${targetKey(process.platform, process.arch)}`,
+  );
   process.exit(0);
 }
 
-run(process.platform === "win32" ? "cargo.exe" : "cargo", ["build", "--release"]);
+const executable = process.platform === "win32" ? "gridbash.exe" : "gridbash";
+const source = path.join(root, "target", "release", executable);
+const outDir = path.join(root, "npm", "bin", platformTarget.directory);
+const packagedBinary = path.join(outDir, platformTarget.executable);
+
+run(process.platform === "win32" ? "cargo.exe" : "cargo", [
+  "build",
+  "--release",
+  "--bin",
+  "gridbash",
+]);
 fs.mkdirSync(outDir, { recursive: true });
-fs.copyFileSync(source, target);
-console.log(`gridbash prepare: copied ${path.relative(root, target)}`);
+fs.copyFileSync(source, packagedBinary);
+if (process.platform !== "win32") {
+  fs.chmodSync(packagedBinary, 0o755);
+}
+console.log(`gridbash prepare: copied ${path.relative(root, packagedBinary)}`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gridbash",
   "version": "0.1.6",
-  "description": "Windows-native terminal grid for running Codex, Claude, Gemini, and other CLI agents side by side.",
+  "description": "Cross-platform terminal grid for running Codex, Claude, Gemini, and other CLI agents side by side.",
   "license": "MIT",
   "homepage": "https://jasonsuhari.github.io/gridbash/",
   "repository": {
@@ -55,6 +55,7 @@
     "pty",
     "conpty",
     "windows",
+    "linux",
     "powershell",
     "git-bash",
     "developer-tools"
@@ -63,9 +64,11 @@
     "node": ">=18"
   },
   "os": [
-    "win32"
+    "win32",
+    "linux"
   ],
   "cpu": [
-    "x64"
+    "x64",
+    "arm64"
   ]
 }


### PR DESCRIPTION
## Summary

- centralize supported npm target tuples in one published manifest
- select packaged executables by platform and architecture
- generalize native prepare and local packaged install for Linux x64/arm64
- add target-selection tests and Linux package metadata

## Validation

- `npm run test:launcher` (8 passing)
- `npm pack --dry-run --ignore-scripts`
- `node --check` for all changed launcher/install scripts

Refs #141
