### PR TITLE
fix: restore Alt+v image paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
 | Alt+c | Focus or unfocus the command bar |
-| Alt+v | Listen for one dictated utterance; press again to cancel |
+| Alt+Shift+V | Listen for one dictated utterance; press again to cancel |
 | Alt+p | Open settings for the focused pane; use Reload past history to refresh its visible conversation snapshot |
 | Alt+Shift+p | Open the previous panes list |
 | Alt+r | Rename the focused pane |
@@ -302,10 +302,10 @@ shown in blue. Shrinking removes live panes outside the retained upper-left
 rectangle. For example, changing 3x3 to 3x2 deactivates the full rightmost column.
 
 Voice mode uses modern Windows online dictation and the default microphone. Press
-`Alt+v` to listen for one utterance; GridBash waits up to 15 seconds for speech.
+`Alt+Shift+V` to listen for one utterance; GridBash waits up to 15 seconds for speech.
 The transcript is inserted into the command bar or the panes that were targeted
 when listening started. GridBash never presses Enter for dictated text, so you can
-review or edit it before submitting. Press `Alt+v` while listening to cancel.
+review or edit it before submitting. Press `Alt+Shift+V` while listening to cancel.
 
 Voice audio is processed by Microsoft's online speech service. Enable **Online
 speech recognition** in Windows Settings under **Privacy & security > Speech**,

--- a/docs/devlogs/2026-07-09-add-voice-mode.md
+++ b/docs/devlogs/2026-07-09-add-voice-mode.md
@@ -9,7 +9,7 @@ Release target: unreleased
 
 ## What Changed
 
-- Added `Alt+v` to listen for one utterance with the installed Windows speech recognizer.
+- Added `Alt+Shift+V` to listen for one utterance with the installed Windows speech recognizer.
 - Preserved the command bar or pane targets selected when listening starts and never auto-submitted dictated text.
 - Added cancellation, no-speech, unavailable-recognizer, microphone-error, and changed-tab status handling.
 - Added a visible `MIC` state plus shortcut and setup documentation.
@@ -28,4 +28,4 @@ Release target: unreleased
 
 ## Release Notes
 
-- Press `Alt+v` to dictate into the current command bar or pane targets. Press it again to cancel; review the inserted text and submit it normally when ready.
+- Press `Alt+Shift+V` to dictate into the current command bar or pane targets. Press it again to cancel; review the inserted text and submit it normally when ready.

--- a/docs/devlogs/2026-07-10-improve-voice-transcription-accuracy.md
+++ b/docs/devlogs/2026-07-10-improve-voice-transcription-accuracy.md
@@ -29,4 +29,4 @@ Issue: #130
 
 ## Release Notes
 
-- Voice mode now uses modern Windows online dictation for more accurate prompt transcription. Enable Online speech recognition in Windows Settings before using `Alt+v`.
+- Voice mode now uses modern Windows online dictation for more accurate prompt transcription. Enable Online speech recognition in Windows Settings before using `Alt+Shift+V`.

--- a/docs/devlogs/2026-07-10-restore-alt-v-image-paste.md
+++ b/docs/devlogs/2026-07-10-restore-alt-v-image-paste.md
@@ -1,0 +1,31 @@
+# Restore Alt+v image paste
+
+Date: 2026-07-10
+Release target: unreleased
+Issue: #138
+
+## Summary
+
+- Moved voice mode to `Alt+Shift+V` so agent panes can receive plain `Alt+v` for clipboard-image paste.
+
+## What Changed
+
+- Restricted voice start and cancellation to `Alt+Shift+V`.
+- Allowed plain `Alt+v` to pass through to the focused terminal pane.
+- Updated runtime hints and voice documentation to show the new shortcut.
+- Added regression coverage for both shortcut paths.
+
+## Why It Matters
+
+- Codex and Claude users can paste clipboard images without losing GridBash voice input.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `cargo build --release`
+
+## Release Notes
+
+- Voice mode now uses `Alt+Shift+V`; plain `Alt+v` once again reaches focused agent panes for clipboard-image paste.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1622,10 +1622,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+v voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings"
+        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings"
             .into()
     }
 }
@@ -2445,7 +2445,7 @@ impl App {
                 }
             },
             VoiceOutcome::NoSpeech => {
-                self.status = "voice heard no speech; press Alt+v to try again".into();
+                self.status = "voice heard no speech; press Alt+Shift+V to try again".into();
             }
             VoiceOutcome::Error(error) => {
                 self.status = format!("voice unavailable: {error}");
@@ -2792,7 +2792,7 @@ impl App {
                 self.status = self.focus_status();
                 Ok(Some(false))
             }
-            'v' => {
+            'v' if is_voice_shortcut(ch, modifiers) => {
                 self.toggle_voice_input();
                 Ok(Some(false))
             }
@@ -4707,7 +4707,7 @@ impl App {
         self.voice_destination = Some(destination);
         self.voice.start();
         self.status = format!(
-            "voice listening for {} (Alt+v cancels; speech is not submitted)",
+            "voice listening for {} (Alt+Shift+V cancels; speech is not submitted)",
             self.input_scope_label()
         );
     }
@@ -6399,6 +6399,13 @@ fn pane_number_list(indices: &[usize]) -> String {
         .join(", ")
 }
 
+fn is_voice_shortcut(ch: char, modifiers: KeyModifiers) -> bool {
+    ch.eq_ignore_ascii_case(&'v')
+        && modifiers.contains(KeyModifiers::ALT)
+        && modifiers.contains(KeyModifiers::SHIFT)
+        && !modifiers.contains(KeyModifiers::CONTROL)
+}
+
 fn control_byte(ch: char) -> Option<u8> {
     let lower = ch.to_ascii_lowercase();
     if lower.is_ascii_lowercase() {
@@ -7123,6 +7130,16 @@ mod tests {
         assert_eq!(command.cursor_chars(), 3);
         assert!(command.backspace());
         assert_eq!(command.input, "abc");
+    }
+
+    #[test]
+    fn voice_shortcut_preserves_plain_alt_v_for_agent_image_paste() {
+        let image_paste = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT);
+        assert!(!is_voice_shortcut('v', KeyModifiers::ALT));
+        assert_eq!(terminal_key_bytes(image_paste), Some(b"\x1bv".to_vec()));
+
+        let voice_modifiers = KeyModifiers::ALT | KeyModifiers::SHIFT;
+        assert!(is_voice_shortcut('V', voice_modifiers));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -228,7 +228,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+v voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(


### PR DESCRIPTION
## Summary

- move voice start/cancel from `Alt+v` to `Alt+Shift+V`
- pass plain `Alt+v` through to focused panes for Codex/Claude clipboard-image paste
- update runtime hints and voice documentation
- add regression coverage for shortcut recognition and terminal encoding

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (113 passed, 1 expected interactive ConPTY test ignored)
- `cargo build --release --jobs 1 --quiet`

Refs #138
