### PR TITLE
fix: protect desktop from pane workload contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "tokio",
  "toml",
  "vt100",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ shell-words = "1.1"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync", "time"] }
 toml = "0.9"
 vt100 = "0.16"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Example:
 ```toml
 [defaults]
 profile = "powershell"
+# Use "normal" to opt out of GridBash's desktop-responsiveness safeguard.
+pane_priority = "below-normal"
 
 [manager]
 endpoint = "https://api.openai.com/v1/chat/completions"
@@ -406,6 +408,11 @@ Default profile resolution order:
 ```text
 --profile > GRIDBASH_PROFILE > [defaults].profile > git-bash
 ```
+
+GridBash keeps its own interface at normal Windows process priority, while pane
+processes default to `below-normal`. Child workloads such as parallel compilers
+normally inherit that priority, which keeps input and other desktop apps responsive
+when many panes are busy. Set `[defaults].pane_priority = "normal"` to opt out.
 
 Pane managers use the OpenAI-compatible chat-completions endpoint, model, and API
 key under `[manager]`. These values can also be edited from the Manager tab in

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,7 @@
 [defaults]
 profile = "git-bash"
+# Keeps compilers and other pane workloads from starving interactive desktop apps.
+pane_priority = "below-normal"
 
 [manager]
 endpoint = "https://api.openai.com/v1/chat/completions"

--- a/docs/devlogs/2026-07-10-pane-workload-priority.md
+++ b/docs/devlogs/2026-07-10-pane-workload-priority.md
@@ -1,0 +1,33 @@
+# Keep Pane Workloads From Starving the Desktop
+
+Date: 2026-07-10
+Release target: unreleased
+
+## Summary
+
+- Run pane process trees below normal Windows priority by default.
+- Keep the GridBash interface itself at normal priority.
+- Allow users to restore normal pane priority through configuration.
+
+## What Changed
+
+- Added `[defaults].pane_priority` with `below-normal` and `normal` values.
+- Applied the configured priority to each ConPTY root process after launch.
+- Added Windows process-priority and config coverage.
+
+## Why It Matters
+
+Multiple agent panes can launch several parallel compilers at once. Giving those
+workloads the same priority as interactive apps can make terminal input, browsers,
+and the rest of Windows feel unresponsive even when GridBash itself is lightweight.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test`
+
+## Release Notes
+
+Pane workloads now run below normal Windows priority by default to protect desktop
+responsiveness under heavy multi-pane CPU load. Set
+`[defaults].pane_priority = "normal"` to retain the previous behavior.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1998,6 +1998,7 @@ impl App {
             &spec.env,
             &spec.cwd,
             &extra_env,
+            self.config.defaults.pane_priority,
             self.event_tx.clone(),
         )
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,16 @@ impl ManagerConfig {
 pub struct Defaults {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "PaneProcessPriority::is_default")]
+    pub pane_priority: PaneProcessPriority,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneProcessPriority {
+    Normal,
+    #[default]
+    BelowNormal,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -158,7 +168,13 @@ impl Config {
 
 impl Defaults {
     fn is_empty(&self) -> bool {
-        self.profile.is_none()
+        self.profile.is_none() && self.pane_priority.is_default()
+    }
+}
+
+impl PaneProcessPriority {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
     }
 }
 
@@ -210,6 +226,32 @@ mod tests {
         .expect("parse config");
 
         assert_eq!(config.defaults.profile.as_deref(), Some("powershell"));
+        assert_eq!(
+            config.defaults.pane_priority,
+            PaneProcessPriority::BelowNormal
+        );
+    }
+
+    #[test]
+    fn parses_normal_pane_process_priority() {
+        let config: Config = toml::from_str(
+            r#"
+            [defaults]
+            pane_priority = "normal"
+            "#,
+        )
+        .expect("parse config");
+
+        assert_eq!(config.defaults.pane_priority, PaneProcessPriority::Normal);
+        let serialized = toml::to_string(&config).expect("serialize config");
+        assert!(serialized.contains("pane_priority = \"normal\""));
+    }
+
+    #[test]
+    fn omits_default_pane_process_priority_from_saved_config() {
+        let serialized = toml::to_string(&Config::default()).expect("serialize config");
+
+        assert!(!serialized.contains("pane_priority"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod image_preview;
 mod layout;
 mod manager;
 mod onboarding;
+mod process_priority;
 mod profiles;
 mod pty;
 mod session;

--- a/src/process_priority.rs
+++ b/src/process_priority.rs
@@ -1,0 +1,81 @@
+use std::io;
+
+use crate::config::PaneProcessPriority;
+
+#[cfg(windows)]
+pub fn set_process_priority(process_id: u32, priority: PaneProcessPriority) -> io::Result<()> {
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{
+            BELOW_NORMAL_PRIORITY_CLASS, NORMAL_PRIORITY_CLASS, OpenProcess,
+            PROCESS_SET_INFORMATION, SetPriorityClass,
+        },
+    };
+
+    let priority_class = match priority {
+        PaneProcessPriority::Normal => NORMAL_PRIORITY_CLASS,
+        PaneProcessPriority::BelowNormal => BELOW_NORMAL_PRIORITY_CLASS,
+    };
+
+    // SAFETY: OpenProcess returns either a valid owned handle or null. The handle
+    // is used only with SetPriorityClass and is closed before this function returns.
+    let process = unsafe { OpenProcess(PROCESS_SET_INFORMATION, 0, process_id) };
+    if process.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    // SAFETY: process is a valid process handle with PROCESS_SET_INFORMATION.
+    let changed = unsafe { SetPriorityClass(process, priority_class) };
+    let error = (changed == 0).then(io::Error::last_os_error);
+    // SAFETY: process is an owned handle returned by OpenProcess above.
+    unsafe { CloseHandle(process) };
+
+    match error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+#[cfg(not(windows))]
+pub fn set_process_priority(_process_id: u32, _priority: PaneProcessPriority) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use std::process::Command;
+
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{
+            BELOW_NORMAL_PRIORITY_CLASS, GetPriorityClass, OpenProcess,
+            PROCESS_QUERY_LIMITED_INFORMATION,
+        },
+    };
+
+    use super::*;
+
+    #[test]
+    fn sets_a_child_process_to_below_normal_priority() {
+        let mut child = Command::new("cmd.exe")
+            .args(["/d", "/c", "ping 127.0.0.1 -n 10 > nul"])
+            .spawn()
+            .expect("spawn test child");
+
+        set_process_priority(child.id(), PaneProcessPriority::BelowNormal)
+            .expect("lower child priority");
+
+        // SAFETY: the child is still owned by this test and the returned handle is
+        // checked for null, queried, then closed.
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, child.id()) };
+        assert!(!process.is_null(), "open child for priority query");
+        // SAFETY: process is a valid query handle.
+        let priority = unsafe { GetPriorityClass(process) };
+        // SAFETY: process is an owned handle returned by OpenProcess above.
+        unsafe { CloseHandle(process) };
+
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(priority, BELOW_NORMAL_PRIORITY_CLASS);
+    }
+}

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -13,7 +13,7 @@ use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system}
 use tokio::sync::mpsc;
 use vt100::{Parser, Screen};
 
-use crate::layout::PaneId;
+use crate::{config::PaneProcessPriority, layout::PaneId, process_priority::set_process_priority};
 
 const DEVICE_STATUS_QUERY: &[u8] = b"\x1b[5n";
 const CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
@@ -105,6 +105,7 @@ impl PtyPane {
         env: &BTreeMap<String, String>,
         cwd: &Path,
         extra_env: &[(String, String)],
+        process_priority: PaneProcessPriority,
         event_tx: mpsc::UnboundedSender<PtyEvent>,
     ) -> Result<Self> {
         let pty_system = native_pty_system();
@@ -137,6 +138,11 @@ impl PtyPane {
             .slave
             .spawn_command(command_builder)
             .with_context(|| format!("failed to spawn {}", command.display()))?;
+        if let Some(process_id) = child.process_id() {
+            // A pane should still launch if Windows refuses a priority change.
+            // The root process normally passes this priority to its descendants.
+            let _ = set_process_priority(process_id, process_priority);
+        }
         drop(pair.slave);
 
         let reader = pair
@@ -953,6 +959,7 @@ mod tests {
             &BTreeMap::new(),
             &cwd,
             &[],
+            PaneProcessPriority::BelowNormal,
             event_tx,
         )
         .expect("spawn cmd pty");


### PR DESCRIPTION
## Summary
- default pane process trees to below-normal Windows priority
- keep the GridBash UI at normal priority and allow a config opt-out
- document the behavior and add Windows API/config tests

## Investigation
On the affected 12-thread laptop, three GridBash processes used about 84 MB total and roughly 0.125 of one CPU core during sampling. Pane workloads simultaneously spawned 9?14 normal-priority rustc processes plus multiple Cargo builds, with system CPU around 57?65% and paging spikes up to about 605 pages/sec.

## Validation
- `cargo fmt -- --check`
- `cargo test` (115 passed, 1 intentionally ignored)
- focused Windows process-priority test confirmed `BELOW_NORMAL_PRIORITY_CLASS`

Refs #142
