### PR TITLE
fix: treat usage utilization as percent

### DIFF
--- a/docs/devlogs/2026-07-12-fix-low-usage-percentage-scaling.md
+++ b/docs/devlogs/2026-07-12-fix-low-usage-percentage-scaling.md
@@ -1,0 +1,29 @@
+# Fix low usage percentage scaling
+
+Date: 2026-07-12
+Release target: unreleased
+
+## Summary
+
+- Corrected auth-profile quota displays for usage values at or below 1%.
+
+## What Changed
+
+- Treat Anthropic usage `utilization` values consistently as percentages on the documented 0–100 scale.
+- Added regression coverage for 0.5%, 1%, and 73% utilization values.
+
+## Why It Matters
+
+- Freshly reset accounts no longer appear nearly exhausted when they have consumed less than 1% of a usage window.
+
+## Validation
+
+- `cargo test auth::tests::treats_low_usage_utilization_as_a_percentage`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo fmt -- --check`
+- `git diff --check`
+
+## Release Notes
+
+- Fixed incorrect quota percentages for auth profiles with very low utilization.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -559,12 +559,7 @@ fn parse_usage_response(value: &Value) -> Option<UsageInfo> {
 
 fn parse_usage_window(value: Option<&Value>) -> Option<UsageWindow> {
     let value = value?;
-    let utilization = value.get("utilization").and_then(Value::as_f64)?;
-    let used_percent = if utilization <= 1.0 {
-        utilization * 100.0
-    } else {
-        utilization
-    };
+    let used_percent = value.get("utilization").and_then(Value::as_f64)?;
     let available_percent = (100.0 - used_percent).round().clamp(0.0, 100.0) as u8;
     let resets_at = value
         .get("resets_at")
@@ -756,13 +751,21 @@ mod tests {
     #[test]
     fn formats_usage_response_as_available_percent() {
         let value = serde_json::json!({
-            "five_hour": {"utilization": 25.0, "resets_at": "2026-07-07T12:00:00Z"},
-            "seven_day": {"utilization": 0.5}
+            "five_hour": {"utilization": 73.0, "resets_at": "2026-07-07T12:00:00Z"}
         });
 
         let usage = parse_usage_response(&value).expect("usage");
 
-        assert_eq!(usage.five_hour.unwrap().available_percent, 75);
-        assert_eq!(usage.seven_day.unwrap().available_percent, 50);
+        assert_eq!(usage.five_hour.unwrap().available_percent, 27);
+    }
+
+    #[test]
+    fn treats_low_usage_utilization_as_a_percentage() {
+        for (utilization, available_percent) in [(0.5, 100), (1.0, 99)] {
+            let value = serde_json::json!({"utilization": utilization});
+            let usage = parse_usage_window(Some(&value)).expect("usage window");
+
+            assert_eq!(usage.available_percent, available_percent);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- remove magnitude-based fraction detection from auth usage parsing
- treat Anthropic `utilization` as its API-defined 0–100 percentage
- cover 0.5%, 1%, and 73% utilization and add an unreleased devlog

## Diagnosis
The previous `utilization <= 1.0` branch conflated low percentages with fractions. That made 0.5% used render as 50% used and 1% used render as 100% used. GridBash's other usage path already consumes Anthropic `utilization` directly as percent.

## Validation
- `cargo test auth::tests::treats_low_usage_utilization_as_a_percentage`
- `cargo test` (117 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

Refs #154