### PR TITLE
perf: optimize runtime hot paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ sha2 = "0.10"
 whisper-rs = "0.16"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ Example:
 profile = "powershell"
 # Use "normal" to opt out of GridBash's desktop-responsiveness safeguard.
 pane_priority = "below-normal"
+# Use "unrestricted" to disable adaptive CPU sharing between pane workloads.
+pane_workload = "adaptive"
 
 [manager]
 endpoint = "https://api.openai.com/v1/chat/completions"
@@ -468,7 +470,11 @@ so GridBash's Alt shortcuts reach the TUI.
 GridBash keeps its own interface at normal Windows process priority, while pane
 processes default to `below-normal`. Child workloads such as parallel compilers
 normally inherit that priority, which keeps input and other desktop apps responsive
-when many panes are busy. Set `[defaults].pane_priority = "normal"` to opt out.
+when many panes are busy. On Windows, the default `adaptive` pane workload policy
+also gives focused and selected panes more CPU time than hidden or sleeping panes
+when the system is contested; every pane continues running. Set
+`[defaults].pane_workload = "unrestricted"` to disable adaptive sharing, or change
+the Workload policy under Performance settings while GridBash is running.
 
 Pane managers use the OpenAI-compatible chat-completions endpoint, model, and API
 key under `[manager]`. These values can also be edited from the Manager tab in

--- a/config.example.toml
+++ b/config.example.toml
@@ -2,6 +2,8 @@
 profile = "git-bash"
 # Keeps compilers and other pane workloads from starving interactive desktop apps.
 pane_priority = "below-normal"
+# Shares CPU fairly under contention while keeping every pane process running.
+pane_workload = "adaptive"
 
 [manager]
 endpoint = "https://api.openai.com/v1/chat/completions"

--- a/docs/devlogs/2026-07-11-optimize-runtime-responsiveness.md
+++ b/docs/devlogs/2026-07-11-optimize-runtime-responsiveness.md
@@ -1,0 +1,40 @@
+# Optimize Runtime Responsiveness
+
+Date: 2026-07-11
+Release target: unreleased
+
+## Summary
+
+- Made terminal input and the desktop remain responsive under large, busy grids.
+
+## What Changed
+
+- Bounded PTY output buffering and limited each event-loop drain by event count,
+  byte count, and elapsed time so output cannot starve keyboard handling.
+- Moved pane writes onto ordered background workers so a blocked child cannot
+  freeze the GridBash interface.
+- Added revision-based screen and conversation-summary caches, a 30 FPS output
+  cap for large grids, and suppression of redundant redraws from sleeping and
+  inactive panes.
+- Added adaptive Windows Job Object scheduling. Focused and selected panes receive
+  more CPU time under contention while all background panes keep running.
+- Reduced output allocations and made history trimming amortized instead of
+  rescanning a full tail after every chunk.
+
+## Why It Matters
+
+- Twenty or more active panes can generate output faster than a terminal UI can
+  parse and repaint it. Bounded work and adaptive scheduling keep that load from
+  turning into input latency or an unusable desktop.
+
+## Validation
+
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `npm run test:launcher`
+- `cargo build --release`
+
+## Release Notes
+
+- Strongly improved input latency and system responsiveness for large grids while
+  preserving pane output, appearance, and background progress.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashMap},
     env,
     ffi::OsString,
     io::{self, Stdout, Write},
@@ -17,14 +18,14 @@ use std::process::Stdio;
 use anyhow::{Context, Result, anyhow};
 use crossterm::{
     event::{
-        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
-        MouseEventKind,
+        self, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+        KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect, style::Color};
+use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect, style::Color, text::Line};
 use tokio::sync::mpsc;
 use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 
@@ -32,13 +33,14 @@ use crate::{
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
     composer::{Composer, GridPicker, GridPickerAction},
-    config::Config,
+    config::{Config, PaneWorkloadPolicy},
     control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerDecision},
+    process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile},
-    pty::{PtyEvent, PtyPane, plain_terminal_text},
+    pty::{PtyEvent, PtyPane},
     session::{SavedPaneHistory, SessionRecord, SessionRecorder},
     setup::{LaunchPlan, PaneLaunchSpec},
     ui,
@@ -50,6 +52,11 @@ use crate::{
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
 const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(16);
+const LARGE_GRID_FRAME_INTERVAL: Duration = Duration::from_millis(33);
+const PTY_EVENT_CHANNEL_CAPACITY: usize = 256;
+const PTY_DRAIN_MAX_EVENTS: usize = 64;
+const PTY_DRAIN_MAX_BYTES: usize = 512 * 1024;
+const PTY_DRAIN_MAX_TIME: Duration = Duration::from_millis(4);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const PANE_GOAL_OUTPUT_MAX_BYTES: usize = 12_000;
 const PANE_GOAL_REVIEW_IDLE: Duration = Duration::from_secs(2);
@@ -121,8 +128,13 @@ pub struct App {
     pane_settings_sleep_button: Option<Rect>,
     pane_settings_goal_button: Option<Rect>,
     pane_settings_stop_goal_button: Option<Rect>,
-    event_tx: mpsc::UnboundedSender<PtyEvent>,
-    event_rx: mpsc::UnboundedReceiver<PtyEvent>,
+    event_tx: mpsc::Sender<PtyEvent>,
+    event_rx: mpsc::Receiver<PtyEvent>,
+    pane_render_cache: RefCell<HashMap<PaneId, ui::PaneRenderCache>>,
+    conversation_cache: RefCell<HashMap<PaneId, ConversationCache>>,
+    applied_workloads: HashMap<PaneId, (PaneWorkloadPolicy, PaneWorkloadClass)>,
+    terminal_focused: bool,
+    workload_warning_shown: bool,
     usage_tx: std_mpsc::Sender<UsageEvent>,
     usage_rx: std_mpsc::Receiver<UsageEvent>,
     profile_usage: BTreeMap<String, String>,
@@ -211,6 +223,47 @@ pub struct PaneSelection {
     pub start_column: u16,
     pub end_row: u16,
     pub end_column: u16,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ConversationCache {
+    revision: u64,
+    summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaneRoute {
+    Visible(usize),
+    Inactive { tab: usize, pane: usize },
+}
+
+struct PtyDrainBudget {
+    started: Instant,
+    events: usize,
+    bytes: usize,
+}
+
+impl PtyDrainBudget {
+    fn new() -> Self {
+        Self {
+            started: Instant::now(),
+            events: 0,
+            bytes: 0,
+        }
+    }
+
+    fn allows_more(&self) -> bool {
+        self.within_size_limits() && self.started.elapsed() < PTY_DRAIN_MAX_TIME
+    }
+
+    fn within_size_limits(&self) -> bool {
+        self.events < PTY_DRAIN_MAX_EVENTS && self.bytes < PTY_DRAIN_MAX_BYTES
+    }
+
+    fn record(&mut self, bytes: usize) {
+        self.events += 1;
+        self.bytes += bytes;
+    }
 }
 
 impl MouseSelection {
@@ -540,6 +593,7 @@ enum SettingsTarget {
     PaneDensity,
     Scrollback,
     RefreshMs,
+    PaneWorkload,
     Palette(PaletteRole),
 }
 
@@ -560,6 +614,7 @@ enum SettingsChange {
     None,
     Render,
     SaveTodos,
+    SaveWorkload,
 }
 
 #[derive(Debug, Clone)]
@@ -893,6 +948,7 @@ struct SettingsState {
     pane_density: i32,
     scrollback: i32,
     refresh_ms: i32,
+    pane_workload: PaneWorkloadPolicy,
     palette: GridPalette,
     manager_cursor: usize,
     manager_edit: Option<ManagerSettingEdit>,
@@ -1054,6 +1110,7 @@ impl Default for SettingsState {
             pane_density: 2,
             scrollback: 10_000,
             refresh_ms: 16,
+            pane_workload: PaneWorkloadPolicy::Adaptive,
             palette: GridPalette::default(),
             manager_cursor: 0,
             manager_edit: None,
@@ -1070,6 +1127,7 @@ impl SettingsState {
                 .idle_seconds
                 .clamp(MIN_TODO_IDLE_SECONDS, MAX_TODO_IDLE_SECONDS),
             todo_prompts: config.todos.normalized_prompts(),
+            pane_workload: config.defaults.pane_workload,
             ..Self::default()
         }
     }
@@ -1163,6 +1221,15 @@ impl SettingsState {
             Some(SettingsTarget::RefreshMs) => {
                 self.refresh_ms = (self.refresh_ms + delta * 4).clamp(8, 100);
                 SettingsChange::Render
+            }
+            Some(SettingsTarget::PaneWorkload) => {
+                if delta != 0 {
+                    self.pane_workload = match self.pane_workload {
+                        PaneWorkloadPolicy::Adaptive => PaneWorkloadPolicy::Unrestricted,
+                        PaneWorkloadPolicy::Unrestricted => PaneWorkloadPolicy::Adaptive,
+                    };
+                }
+                SettingsChange::SaveWorkload
             }
             Some(SettingsTarget::Palette(role)) => {
                 self.palette.adjust(role, delta as isize);
@@ -1404,6 +1471,7 @@ impl SettingsState {
             SettingsTarget::PaneDensity,
             SettingsTarget::Scrollback,
             SettingsTarget::RefreshMs,
+            SettingsTarget::PaneWorkload,
         ]);
         targets.extend(
             PaletteRole::ALL
@@ -1550,10 +1618,24 @@ impl SettingsState {
             SettingsTarget::RefreshMs,
             SettingsGroup::Performance,
             SettingsValueKind::Stepper,
-            "Refresh delay",
+            "Minimum refresh delay",
             format!("{} ms", self.refresh_ms),
-            "render loop throttle",
+            "output frame throttle",
         ));
+        rows.push(
+            self.row(
+                SettingsTarget::PaneWorkload,
+                SettingsGroup::Performance,
+                SettingsValueKind::Choice,
+                "Workload policy",
+                match self.pane_workload {
+                    PaneWorkloadPolicy::Adaptive => "adaptive",
+                    PaneWorkloadPolicy::Unrestricted => "unrestricted",
+                }
+                .into(),
+                "keep the desktop responsive under load",
+            ),
+        );
         rows.extend(
             PaletteRole::ALL
                 .iter()
@@ -1607,6 +1689,10 @@ impl SettingsChange {
 
     fn save_todos(self) -> bool {
         matches!(self, Self::SaveTodos)
+    }
+
+    fn save_workload(self) -> bool {
+        matches!(self, Self::SaveWorkload)
     }
 }
 
@@ -1722,7 +1808,7 @@ impl App {
     }
 
     fn from_parts(init: AppInit) -> Self {
-        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (event_tx, event_rx) = mpsc::channel(PTY_EVENT_CHANNEL_CAPACITY);
         let (usage_tx, usage_rx) = std_mpsc::channel();
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let (goal_tx, goal_rx) = std_mpsc::channel();
@@ -1783,6 +1869,11 @@ impl App {
             pane_settings_stop_goal_button: None,
             event_tx,
             event_rx,
+            pane_render_cache: RefCell::new(HashMap::new()),
+            conversation_cache: RefCell::new(HashMap::new()),
+            applied_workloads: HashMap::new(),
+            terminal_focused: true,
+            workload_warning_shown: false,
             usage_tx,
             usage_rx,
             profile_usage: BTreeMap::new(),
@@ -2002,6 +2093,7 @@ impl App {
             &spec.cwd,
             &extra_env,
             self.config.defaults.pane_priority,
+            self.config.defaults.pane_workload,
             self.event_tx.clone(),
         )
     }
@@ -2022,22 +2114,47 @@ impl App {
     }
 
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
-        let mut needs_render = true;
+        let mut immediate_render = true;
+        let mut output_render = false;
+        let mut last_render = Instant::now();
         let mut mouse_capture_enabled = self.mouse_enabled;
 
         loop {
-            needs_render |= self.drain_pty_events();
-            needs_render |= self.drain_usage_events();
-            needs_render |= self.drain_auth_refresh();
-            needs_render |= self.drain_command_events();
-            needs_render |= self.drain_goal_reviews();
-            needs_render |= self.drain_voice_events()?;
-            needs_render |= self.drain_control_events();
-            needs_render |= self.decay_activity();
-            needs_render |= self.update_follow_up_prompt();
-            needs_render |= self.schedule_goal_reviews();
+            let frame_interval = self.output_frame_interval();
+            let until_frame = frame_interval.saturating_sub(last_render.elapsed());
+            let wait = if immediate_render || !self.event_rx.is_empty() {
+                Duration::ZERO
+            } else if output_render {
+                until_frame.min(INPUT_POLL_INTERVAL)
+            } else {
+                INPUT_POLL_INTERVAL
+            };
 
-            if needs_render {
+            if event::poll(wait)? {
+                let event = event::read()?;
+                if self.handle_terminal_event(
+                    terminal,
+                    event,
+                    &mut immediate_render,
+                    &mut mouse_capture_enabled,
+                )? {
+                    break;
+                }
+            }
+
+            output_render |= self.drain_pty_events();
+            immediate_render |= self.drain_usage_events();
+            immediate_render |= self.drain_auth_refresh();
+            immediate_render |= self.drain_command_events();
+            immediate_render |= self.drain_goal_reviews();
+            immediate_render |= self.drain_voice_events()?;
+            immediate_render |= self.drain_control_events();
+            immediate_render |= self.decay_activity();
+            immediate_render |= self.update_follow_up_prompt();
+            immediate_render |= self.schedule_goal_reviews();
+            immediate_render |= self.refresh_workload_classes();
+
+            if immediate_render || (output_render && last_render.elapsed() >= frame_interval) {
                 terminal.draw(|frame| {
                     let draw_state = ui::draw(frame, self);
                     self.grid_area = draw_state.grid_area;
@@ -2052,80 +2169,11 @@ impl App {
                     self.pane_settings_stop_goal_button = draw_state.pane_settings_stop_goal_button;
                 })?;
                 self.sync_pane_sizes();
-                needs_render = false;
+                immediate_render = false;
+                output_render = false;
+                last_render = Instant::now();
             }
             self.sync_mouse_capture(terminal, &mut mouse_capture_enabled)?;
-
-            if event::poll(INPUT_POLL_INTERVAL)? {
-                match event::read()? {
-                    Event::Key(key) if key.kind == KeyEventKind::Press => {
-                        match self.handle_key(terminal, key)? {
-                            KeyOutcome::Continue => {}
-                            KeyOutcome::Render => needs_render = true,
-                            KeyOutcome::AuthLogin(profile) => {
-                                self.run_auth_login(terminal, profile)?;
-                                mouse_capture_enabled = false;
-                                needs_render = true;
-                            }
-                            KeyOutcome::Quit => break,
-                        }
-                    }
-                    Event::Resize(_, _) => needs_render = true,
-                    Event::Paste(text) if self.tab_rename.open => {
-                        self.tab_rename.insert_text(&text);
-                        needs_render = true;
-                    }
-                    Event::Paste(text) if self.rename.open => {
-                        self.rename.insert_text(&text);
-                        needs_render = true;
-                    }
-                    Event::Paste(text) if self.settings.editing_manager() => {
-                        if self.settings.insert_manager_text(&text) {
-                            needs_render = true;
-                        }
-                    }
-                    Event::Paste(text) if self.settings.editing_todo() => {
-                        if self.settings.insert_todo_text(&text) {
-                            needs_render = true;
-                        }
-                    }
-                    Event::Paste(text) if self.goal_editor.is_some() => {
-                        if let Some(editor) = &mut self.goal_editor {
-                            let remaining =
-                                TODO_INPUT_LIMIT.saturating_sub(editor.input.chars().count());
-                            editor.input.extend(text.chars().take(remaining));
-                            needs_render = true;
-                        }
-                    }
-                    Event::Paste(text)
-                        if !self.settings.open
-                            && self.grid_resizer.is_none()
-                            && !self.rename.open
-                            && !self.previous_panes.open
-                            && !self.pane_settings.open
-                            && self.image_overlay.is_none()
-                            && self.follow_up.is_none()
-                            && self.goal_editor.is_none() =>
-                    {
-                        if self.command_line.focused {
-                            self.command_line.insert_text(&text);
-                            needs_render = true;
-                        } else {
-                            self.route_input(text.as_bytes())?;
-                        }
-                    }
-                    Event::Mouse(mouse)
-                        if (self.mouse_enabled || !self.sleeping.is_empty())
-                            && !self.settings.open
-                            && self.grid_resizer.is_none()
-                            && self.follow_up.is_none()
-                            && self.goal_editor.is_none() =>
-                    {
-                        needs_render |= self.handle_mouse(mouse, terminal)?;
-                    }
-                    _ => {}
-                }
-            }
         }
 
         if mouse_capture_enabled {
@@ -2133,6 +2181,136 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn handle_terminal_event(
+        &mut self,
+        terminal: &mut Tui,
+        event: Event,
+        needs_render: &mut bool,
+        mouse_capture_enabled: &mut bool,
+    ) -> Result<bool> {
+        match event {
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                match self.handle_key(terminal, key)? {
+                    KeyOutcome::Continue => {}
+                    KeyOutcome::Render => *needs_render = true,
+                    KeyOutcome::AuthLogin(profile) => {
+                        self.run_auth_login(terminal, profile)?;
+                        *mouse_capture_enabled = false;
+                        *needs_render = true;
+                    }
+                    KeyOutcome::Quit => return Ok(true),
+                }
+            }
+            Event::Resize(_, _) => *needs_render = true,
+            Event::FocusGained => {
+                self.terminal_focused = true;
+                *needs_render = true;
+            }
+            Event::FocusLost => self.terminal_focused = false,
+            Event::Paste(text) if self.tab_rename.open => {
+                self.tab_rename.insert_text(&text);
+                *needs_render = true;
+            }
+            Event::Paste(text) if self.rename.open => {
+                self.rename.insert_text(&text);
+                *needs_render = true;
+            }
+            Event::Paste(text) if self.settings.editing_manager() => {
+                *needs_render |= self.settings.insert_manager_text(&text);
+            }
+            Event::Paste(text) if self.settings.editing_todo() => {
+                *needs_render |= self.settings.insert_todo_text(&text);
+            }
+            Event::Paste(text) if self.goal_editor.is_some() => {
+                if let Some(editor) = &mut self.goal_editor {
+                    let remaining = TODO_INPUT_LIMIT.saturating_sub(editor.input.chars().count());
+                    editor.input.extend(text.chars().take(remaining));
+                    *needs_render = true;
+                }
+            }
+            Event::Paste(text)
+                if !self.settings.open
+                    && self.grid_resizer.is_none()
+                    && !self.rename.open
+                    && !self.previous_panes.open
+                    && !self.pane_settings.open
+                    && self.image_overlay.is_none()
+                    && self.follow_up.is_none()
+                    && self.goal_editor.is_none() =>
+            {
+                if self.command_line.focused {
+                    self.command_line.insert_text(&text);
+                    *needs_render = true;
+                } else {
+                    self.route_input(text.as_bytes())?;
+                }
+            }
+            Event::Mouse(mouse)
+                if (self.mouse_enabled || !self.sleeping.is_empty())
+                    && !self.settings.open
+                    && self.grid_resizer.is_none()
+                    && self.follow_up.is_none()
+                    && self.goal_editor.is_none() =>
+            {
+                *needs_render |= self.handle_mouse(mouse, terminal)?;
+            }
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn output_frame_interval(&self) -> Duration {
+        adaptive_output_frame_interval(self.settings.refresh_ms, self.panes.len())
+    }
+
+    fn refresh_workload_classes(&mut self) -> bool {
+        let policy = self.config.defaults.pane_workload;
+        let mut seen = BTreeSet::new();
+        let mut failure = None;
+
+        for (index, pane) in self.panes.iter().enumerate() {
+            let class = if !self.terminal_focused || self.sleeping.contains(&index) {
+                PaneWorkloadClass::Background
+            } else if index == self.focus {
+                PaneWorkloadClass::Focused
+            } else if self.selected.contains(&index) {
+                PaneWorkloadClass::Selected
+            } else {
+                PaneWorkloadClass::Visible
+            };
+            seen.insert(pane.id());
+            if self.applied_workloads.get(&pane.id()) != Some(&(policy, class)) {
+                if let Err(error) = pane.apply_workload(policy, class) {
+                    failure.get_or_insert(error);
+                }
+                self.applied_workloads.insert(pane.id(), (policy, class));
+            }
+        }
+
+        for tab in self.tabs.iter().filter_map(Option::as_ref) {
+            for pane in &tab.panes {
+                let class = PaneWorkloadClass::Background;
+                seen.insert(pane.id());
+                if self.applied_workloads.get(&pane.id()) != Some(&(policy, class)) {
+                    if let Err(error) = pane.apply_workload(policy, class) {
+                        failure.get_or_insert(error);
+                    }
+                    self.applied_workloads.insert(pane.id(), (policy, class));
+                }
+            }
+        }
+
+        self.applied_workloads.retain(|id, _| seen.contains(id));
+        if let Some(error) = failure
+            && !self.workload_warning_shown
+        {
+            self.status = format!("adaptive workload fallback: {error:#}");
+            self.workload_warning_shown = true;
+            return true;
+        }
+        false
     }
 
     fn sync_mouse_capture(&self, terminal: &mut Tui, enabled: &mut bool) -> Result<()> {
@@ -2152,54 +2330,96 @@ impl App {
 
     fn drain_pty_events(&mut self) -> bool {
         let mut changed = false;
+        let routes = self.pane_routes();
         let mut pending_output = BTreeMap::<(PaneId, u64), Vec<u8>>::new();
         let mut exited = Vec::new();
+        let mut budget = PtyDrainBudget::new();
 
-        while let Ok(event) = self.event_rx.try_recv() {
+        while budget.allows_more() {
+            let Ok(event) = self.event_rx.try_recv() else {
+                break;
+            };
             match event {
                 PtyEvent::Output {
                     pane,
                     generation,
                     bytes,
                 } => {
+                    budget.record(bytes.len());
                     pending_output
                         .entry((pane, generation))
                         .or_default()
                         .extend(bytes);
                 }
                 PtyEvent::Exited { pane, generation } => {
+                    budget.record(0);
                     exited.push((pane, generation));
+                }
+                PtyEvent::WriteFailed {
+                    pane,
+                    generation,
+                    error,
+                } => {
+                    budget.record(0);
+                    if let Some(PaneRoute::Visible(index)) =
+                        routes.get(&(pane, generation)).copied()
+                    {
+                        self.status = format!("pane {} input failed: {error}", index + 1);
+                        changed = true;
+                    }
                 }
             }
         }
 
         for ((pane, generation), bytes) in pending_output {
-            if let Some(index) = self.visible_pane_index(pane, generation) {
-                let target = &mut self.panes[index];
-                target.process_output(&bytes);
-                self.capture_goal_output(index, &bytes);
-                self.mark_pane_touched(index);
-                changed = true;
-            } else if self.process_inactive_output(pane, generation, &bytes) {
-                changed = true;
+            match routes.get(&(pane, generation)).copied() {
+                Some(PaneRoute::Visible(index)) => {
+                    let target = &mut self.panes[index];
+                    let plain = target.process_output(&bytes);
+                    self.capture_goal_output(index, &plain);
+                    self.mark_pane_touched(index);
+                    changed |= !self.sleeping.contains(&index);
+                }
+                Some(PaneRoute::Inactive { tab, pane }) => {
+                    if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
+                        let was_active = tab.panes[pane].active;
+                        let plain = tab.panes[pane].process_output(&bytes);
+                        capture_goal_text(&mut tab.pane_goals, &tab.sleeping, pane, &plain);
+                        changed |= !was_active;
+                    }
+                }
+                None => {}
             }
         }
 
         for (pane, generation) in exited {
-            if let Some(index) = self.visible_pane_index(pane, generation) {
-                let target = &mut self.panes[index];
-                if !target.exited {
-                    target.exited = true;
-                    changed = true;
+            match routes.get(&(pane, generation)).copied() {
+                Some(PaneRoute::Visible(index)) => {
+                    let target = &mut self.panes[index];
+                    if !target.exited {
+                        target.exited = true;
+                        changed = true;
+                    }
+                    if self
+                        .follow_up
+                        .is_some_and(|prompt| prompt.pane_index == index)
+                    {
+                        self.follow_up = None;
+                    }
                 }
-                if self
-                    .follow_up
-                    .is_some_and(|prompt| prompt.pane_index == index)
-                {
-                    self.follow_up = None;
+                Some(PaneRoute::Inactive { tab, pane }) => {
+                    if let Some(target) = self
+                        .tabs
+                        .get_mut(tab)
+                        .and_then(Option::as_mut)
+                        .and_then(|tab| tab.panes.get_mut(pane))
+                        && !target.exited
+                    {
+                        target.exited = true;
+                        changed = true;
+                    }
                 }
-            } else if self.process_inactive_exit(pane, generation) {
-                changed = true;
+                None => {}
             }
         }
 
@@ -2226,48 +2446,30 @@ impl App {
         changed
     }
 
-    fn visible_pane_index(&self, pane: PaneId, generation: u64) -> Option<usize> {
-        self.panes
-            .iter()
-            .position(|target| target.id() == pane && target.generation() == generation)
-    }
-
-    fn process_inactive_output(&mut self, pane: PaneId, generation: u64, bytes: &[u8]) -> bool {
-        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
-            if let Some(index) = tab
-                .panes
-                .iter()
-                .position(|target| target.id() == pane && target.generation() == generation)
-            {
-                tab.panes[index].process_output(bytes);
-                capture_goal_bytes(&mut tab.pane_goals, &tab.sleeping, index, bytes);
-                return true;
+    fn pane_routes(&self) -> HashMap<(PaneId, u64), PaneRoute> {
+        let mut routes = HashMap::new();
+        for (index, pane) in self.panes.iter().enumerate() {
+            routes.insert((pane.id(), pane.generation()), PaneRoute::Visible(index));
+        }
+        for (tab_index, tab) in self.tabs.iter().enumerate() {
+            let Some(tab) = tab else {
+                continue;
+            };
+            for (pane_index, pane) in tab.panes.iter().enumerate() {
+                routes.insert(
+                    (pane.id(), pane.generation()),
+                    PaneRoute::Inactive {
+                        tab: tab_index,
+                        pane: pane_index,
+                    },
+                );
             }
         }
-
-        false
+        routes
     }
 
-    fn process_inactive_exit(&mut self, pane: PaneId, generation: u64) -> bool {
-        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
-            if let Some(target) = tab
-                .panes
-                .iter_mut()
-                .find(|target| target.id() == pane && target.generation() == generation)
-            {
-                if target.exited {
-                    return false;
-                }
-                target.exited = true;
-                return true;
-            }
-        }
-
-        false
-    }
-
-    fn capture_goal_output(&mut self, pane_index: usize, bytes: &[u8]) {
-        capture_goal_bytes(&mut self.pane_goals, &self.sleeping, pane_index, bytes);
+    fn capture_goal_output(&mut self, pane_index: usize, output: &str) {
+        capture_goal_text(&mut self.pane_goals, &self.sleeping, pane_index, output);
     }
 
     fn schedule_goal_reviews(&mut self) -> bool {
@@ -2595,20 +2797,19 @@ impl App {
 
         let now = Instant::now();
         let mut changed = false;
-        for pane in &mut self.panes {
-            if pane.active {
+        for (index, pane) in self.panes.iter_mut().enumerate() {
+            let became_quiet = pane.refresh_output_activity(now, OUTPUT_QUIET_AFTER);
+            if became_quiet {
                 pane.active = false;
-                changed = true;
+                changed |= !self.sleeping.contains(&index);
             }
-            changed |= pane.refresh_output_activity(now, OUTPUT_QUIET_AFTER);
         }
         for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
             for pane in &mut tab.panes {
-                if pane.active {
+                if pane.refresh_output_activity(now, OUTPUT_QUIET_AFTER) {
                     pane.active = false;
                     changed = true;
                 }
-                changed |= pane.refresh_output_activity(now, OUTPUT_QUIET_AFTER);
             }
         }
         self.last_activity_decay = now;
@@ -4514,6 +4715,9 @@ impl App {
         if change.save_todos() {
             self.save_todo_settings();
         }
+        if change.save_workload() {
+            self.save_workload_setting();
+        }
     }
 
     fn save_todo_settings(&mut self) -> bool {
@@ -4747,9 +4951,9 @@ impl App {
                 continue;
             }
             changed |= pane.reset_view();
-            pane.record_input(bytes);
             pane.write(bytes)
                 .with_context(|| format!("failed to route input to pane {}", index + 1))?;
+            pane.record_input(bytes);
             self.mark_pane_touched(index);
         }
 
@@ -4952,6 +5156,44 @@ impl App {
 
     pub fn panes(&self) -> &[PtyPane] {
         &self.panes
+    }
+
+    fn save_workload_setting(&mut self) -> bool {
+        let previous = self.config.defaults.pane_workload;
+        self.config.defaults.pane_workload = self.settings.pane_workload;
+        match self.config.save(self.config_path.as_deref()) {
+            Ok(_) => {
+                self.applied_workloads.clear();
+                true
+            }
+            Err(error) => {
+                self.config.defaults.pane_workload = previous;
+                self.settings.pane_workload = previous;
+                self.status = format!("failed to save workload policy: {error:#}");
+                false
+            }
+        }
+    }
+
+    pub fn pane_screen_lines(
+        &self,
+        index: usize,
+        width: u16,
+        height: u16,
+        selection: Option<PaneSelection>,
+    ) -> Vec<Line<'static>> {
+        let Some(pane) = self.panes.get(index) else {
+            return Vec::new();
+        };
+        let mut caches = self.pane_render_cache.borrow_mut();
+        ui::cached_screen_lines(
+            caches.entry(pane.id()).or_default(),
+            pane.screen_revision(),
+            pane.screen(),
+            width,
+            height,
+            selection,
+        )
     }
 
     pub fn focused_pane(&self) -> Option<usize> {
@@ -5311,7 +5553,15 @@ impl App {
             .and_then(|plan| plan.panes.get(index))
             .and_then(|pane| pane.agent_label())?;
         let pane = self.panes.get(index)?;
-        let summary = conversation_summary(pane.screen())
+        let mut caches = self.conversation_cache.borrow_mut();
+        let cache = caches.entry(pane.id()).or_default();
+        if cache.revision != pane.screen_revision() {
+            cache.revision = pane.screen_revision();
+            cache.summary = conversation_summary(pane.screen());
+        }
+        let summary = cache
+            .summary
+            .clone()
             .unwrap_or_else(|| "waiting for conversation".into());
         Some(truncate_chars(&format!("{label} | {summary}"), max_chars))
     }
@@ -5605,6 +5855,15 @@ impl App {
     }
 }
 
+fn adaptive_output_frame_interval(refresh_ms: i32, pane_count: usize) -> Duration {
+    let configured = Duration::from_millis(refresh_ms.max(1) as u64);
+    if pane_count > 8 {
+        configured.max(LARGE_GRID_FRAME_INTERVAL)
+    } else {
+        configured
+    }
+}
+
 fn resolve_grid(cli: &Cli) -> Result<GridSize> {
     if let Some(grid) = &cli.grid {
         return GridSize::parse(grid).with_context(|| format!("invalid grid '{grid}'"));
@@ -5756,11 +6015,11 @@ fn resolved_current_dir() -> Result<std::path::PathBuf> {
     let current = env::current_dir().context("failed to resolve current directory")?;
     Ok(current.canonicalize().unwrap_or(current))
 }
-fn capture_goal_bytes(
+fn capture_goal_text(
     goals: &mut [Option<PaneGoal>],
     sleeping: &BTreeSet<usize>,
     pane_index: usize,
-    bytes: &[u8],
+    output: &str,
 ) {
     if sleeping.contains(&pane_index) {
         return;
@@ -5772,11 +6031,10 @@ fn capture_goal_bytes(
     if !goal.active {
         return;
     }
-    let output = plain_terminal_text(bytes);
     if output.trim().is_empty() {
         return;
     }
-    goal.output_buffer.push_str(&output);
+    goal.output_buffer.push_str(output);
     trim_goal_buffer(&mut goal.output_buffer);
     goal.last_output_at = Some(Instant::now());
     if !goal.in_flight {
@@ -7292,7 +7550,12 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
 fn setup_terminal(enable_mouse: bool) -> Result<Tui> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableBracketedPaste,
+        EnableFocusChange
+    )?;
     if enable_mouse {
         execute!(stdout, EnableMouseCapture)?;
     }
@@ -7308,6 +7571,7 @@ fn teardown_terminal(terminal: &mut Tui, enable_mouse: bool) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         DisableBracketedPaste,
+        DisableFocusChange,
         DisableMouseCapture,
         LeaveAlternateScreen
     )?;
@@ -7320,6 +7584,7 @@ fn suspend_terminal(terminal: &mut Tui) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         DisableBracketedPaste,
+        DisableFocusChange,
         DisableMouseCapture,
         LeaveAlternateScreen
     )?;
@@ -7332,7 +7597,8 @@ fn resume_terminal(terminal: &mut Tui) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         EnterAlternateScreen,
-        EnableBracketedPaste
+        EnableBracketedPaste,
+        EnableFocusChange
     )?;
     Ok(())
 }
@@ -7341,6 +7607,39 @@ fn resume_terminal(terminal: &mut Tui) -> Result<()> {
 mod selection_tests {
     use super::*;
     use vt100::Parser;
+
+    #[test]
+    fn pty_drain_budget_bounds_event_and_byte_work() {
+        let mut event_budget = PtyDrainBudget::new();
+        for _ in 0..PTY_DRAIN_MAX_EVENTS {
+            assert!(event_budget.within_size_limits());
+            event_budget.record(0);
+        }
+        assert!(!event_budget.within_size_limits());
+
+        let mut byte_budget = PtyDrainBudget::new();
+        while byte_budget.bytes < PTY_DRAIN_MAX_BYTES {
+            assert!(byte_budget.within_size_limits());
+            byte_budget.record(32 * 1024);
+        }
+        assert!(!byte_budget.within_size_limits());
+    }
+
+    #[test]
+    fn large_grids_use_a_thirty_fps_output_floor() {
+        assert_eq!(
+            adaptive_output_frame_interval(8, 20),
+            LARGE_GRID_FRAME_INTERVAL
+        );
+        assert_eq!(
+            adaptive_output_frame_interval(16, 4),
+            Duration::from_millis(16)
+        );
+        assert_eq!(
+            adaptive_output_frame_interval(48, 20),
+            Duration::from_millis(48)
+        );
+    }
 
     #[test]
     fn pane_selection_contains_single_and_multi_line_ranges() {
@@ -7461,7 +7760,7 @@ mod selection_tests {
         };
         let mut goals = vec![goal(1), goal(2)];
 
-        capture_goal_bytes(&mut goals, &BTreeSet::new(), 1, b"pane two only\r\n");
+        capture_goal_text(&mut goals, &BTreeSet::new(), 1, "pane two only\n");
 
         assert!(goals[0].as_ref().unwrap().output_buffer.is_empty());
         assert_eq!(goals[1].as_ref().unwrap().output_buffer, "pane two only\n");

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,8 @@ pub struct Defaults {
     pub profile: Option<String>,
     #[serde(default, skip_serializing_if = "PaneProcessPriority::is_default")]
     pub pane_priority: PaneProcessPriority,
+    #[serde(default, skip_serializing_if = "PaneWorkloadPolicy::is_default")]
+    pub pane_workload: PaneWorkloadPolicy,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -93,6 +95,14 @@ pub enum PaneProcessPriority {
     Normal,
     #[default]
     BelowNormal,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PaneWorkloadPolicy {
+    #[default]
+    Adaptive,
+    Unrestricted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -168,11 +178,17 @@ impl Config {
 
 impl Defaults {
     fn is_empty(&self) -> bool {
-        self.profile.is_none() && self.pane_priority.is_default()
+        self.profile.is_none() && self.pane_priority.is_default() && self.pane_workload.is_default()
     }
 }
 
 impl PaneProcessPriority {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+impl PaneWorkloadPolicy {
     fn is_default(&self) -> bool {
         *self == Self::default()
     }
@@ -230,6 +246,7 @@ mod tests {
             config.defaults.pane_priority,
             PaneProcessPriority::BelowNormal
         );
+        assert_eq!(config.defaults.pane_workload, PaneWorkloadPolicy::Adaptive);
     }
 
     #[test]
@@ -252,6 +269,25 @@ mod tests {
         let serialized = toml::to_string(&Config::default()).expect("serialize config");
 
         assert!(!serialized.contains("pane_priority"));
+        assert!(!serialized.contains("pane_workload"));
+    }
+
+    #[test]
+    fn parses_unrestricted_pane_workload_policy() {
+        let config: Config = toml::from_str(
+            r#"
+            [defaults]
+            pane_workload = "unrestricted"
+            "#,
+        )
+        .expect("parse config");
+
+        assert_eq!(
+            config.defaults.pane_workload,
+            PaneWorkloadPolicy::Unrestricted
+        );
+        let serialized = toml::to_string(&config).expect("serialize config");
+        assert!(serialized.contains("pane_workload = \"unrestricted\""));
     }
 
     #[test]

--- a/src/process_priority.rs
+++ b/src/process_priority.rs
@@ -10,6 +10,7 @@ pub enum PaneWorkloadClass {
     Background,
 }
 
+#[cfg(windows)]
 impl PaneWorkloadClass {
     fn weight(self) -> u32 {
         match self {

--- a/src/process_priority.rs
+++ b/src/process_priority.rs
@@ -1,9 +1,164 @@
 use std::io;
 
-use crate::config::PaneProcessPriority;
+use crate::config::{PaneProcessPriority, PaneWorkloadPolicy};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneWorkloadClass {
+    Focused,
+    Selected,
+    Visible,
+    Background,
+}
+
+impl PaneWorkloadClass {
+    fn weight(self) -> u32 {
+        match self {
+            Self::Focused => 9,
+            Self::Selected => 7,
+            Self::Visible => 3,
+            Self::Background => 1,
+        }
+    }
+}
+
+pub struct PaneWorkloadController {
+    #[cfg(windows)]
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+impl PaneWorkloadController {
+    pub fn attach(
+        process_id: u32,
+        priority: PaneProcessPriority,
+        policy: PaneWorkloadPolicy,
+    ) -> io::Result<Self> {
+        set_process_priority(process_id, priority)?;
+        Self::attach_platform(process_id, policy)
+    }
+
+    pub fn unmanaged() -> Self {
+        Self {
+            #[cfg(windows)]
+            job: std::ptr::null_mut(),
+        }
+    }
+
+    pub fn apply(&self, policy: PaneWorkloadPolicy, class: PaneWorkloadClass) -> io::Result<()> {
+        self.apply_platform(policy, class)
+    }
+}
 
 #[cfg(windows)]
-pub fn set_process_priority(process_id: u32, priority: PaneProcessPriority) -> io::Result<()> {
+impl PaneWorkloadController {
+    fn attach_platform(process_id: u32, policy: PaneWorkloadPolicy) -> io::Result<Self> {
+        use windows_sys::Win32::{
+            Foundation::CloseHandle,
+            System::{
+                JobObjects::{AssignProcessToJobObject, CreateJobObjectW},
+                Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE},
+            },
+        };
+
+        // SAFETY: null security attributes and name create an unnamed job owned
+        // by the returned handle.
+        let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if job.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        // AssignProcessToJobObject requires quota and terminate access. The
+        // process remains owned by portable-pty; this handle is query-only here.
+        let process = unsafe { OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, process_id) };
+        if process.is_null() {
+            let error = io::Error::last_os_error();
+            unsafe { CloseHandle(job) };
+            return Err(error);
+        }
+
+        let assigned = unsafe { AssignProcessToJobObject(job, process) };
+        let error = (assigned == 0).then(io::Error::last_os_error);
+        unsafe { CloseHandle(process) };
+        if let Some(error) = error {
+            unsafe { CloseHandle(job) };
+            return Err(error);
+        }
+
+        let controller = Self { job };
+        controller.apply(policy, PaneWorkloadClass::Visible)?;
+        Ok(controller)
+    }
+
+    fn apply_platform(
+        &self,
+        policy: PaneWorkloadPolicy,
+        class: PaneWorkloadClass,
+    ) -> io::Result<()> {
+        use windows_sys::Win32::System::JobObjects::{
+            JOB_OBJECT_CPU_RATE_CONTROL_ENABLE, JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED,
+            JOBOBJECT_CPU_RATE_CONTROL_INFORMATION, JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0,
+            JobObjectCpuRateControlInformation, SetInformationJobObject,
+        };
+
+        if self.job.is_null() {
+            return Ok(());
+        }
+
+        let info = match policy {
+            PaneWorkloadPolicy::Adaptive => JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
+                ControlFlags: JOB_OBJECT_CPU_RATE_CONTROL_ENABLE
+                    | JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED,
+                Anonymous: JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
+                    Weight: class.weight(),
+                },
+            },
+            PaneWorkloadPolicy::Unrestricted => JOBOBJECT_CPU_RATE_CONTROL_INFORMATION::default(),
+        };
+
+        let changed = unsafe {
+            SetInformationJobObject(
+                self.job,
+                JobObjectCpuRateControlInformation,
+                std::ptr::from_ref(&info).cast(),
+                std::mem::size_of_val(&info) as u32,
+            )
+        };
+        if changed == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+impl PaneWorkloadController {
+    fn attach_platform(_process_id: u32, _policy: PaneWorkloadPolicy) -> io::Result<Self> {
+        Ok(Self {})
+    }
+
+    fn apply_platform(
+        &self,
+        _policy: PaneWorkloadPolicy,
+        _class: PaneWorkloadClass,
+    ) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for PaneWorkloadController {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+
+        if !self.job.is_null() {
+            // No kill-on-close limit is set; closing only releases GridBash's job
+            // handle and preserves the existing child termination semantics.
+            unsafe { CloseHandle(self.job) };
+        }
+    }
+}
+
+#[cfg(windows)]
+fn set_process_priority(process_id: u32, priority: PaneProcessPriority) -> io::Result<()> {
     use windows_sys::Win32::{
         Foundation::CloseHandle,
         System::Threading::{
@@ -16,28 +171,18 @@ pub fn set_process_priority(process_id: u32, priority: PaneProcessPriority) -> i
         PaneProcessPriority::Normal => NORMAL_PRIORITY_CLASS,
         PaneProcessPriority::BelowNormal => BELOW_NORMAL_PRIORITY_CLASS,
     };
-
-    // SAFETY: OpenProcess returns either a valid owned handle or null. The handle
-    // is used only with SetPriorityClass and is closed before this function returns.
     let process = unsafe { OpenProcess(PROCESS_SET_INFORMATION, 0, process_id) };
     if process.is_null() {
         return Err(io::Error::last_os_error());
     }
-
-    // SAFETY: process is a valid process handle with PROCESS_SET_INFORMATION.
     let changed = unsafe { SetPriorityClass(process, priority_class) };
     let error = (changed == 0).then(io::Error::last_os_error);
-    // SAFETY: process is an owned handle returned by OpenProcess above.
     unsafe { CloseHandle(process) };
-
-    match error {
-        Some(error) => Err(error),
-        None => Ok(()),
-    }
+    error.map_or(Ok(()), Err)
 }
 
 #[cfg(not(windows))]
-pub fn set_process_priority(_process_id: u32, _priority: PaneProcessPriority) -> io::Result<()> {
+fn set_process_priority(_process_id: u32, _priority: PaneProcessPriority) -> io::Result<()> {
     Ok(())
 }
 
@@ -47,35 +192,84 @@ mod tests {
 
     use windows_sys::Win32::{
         Foundation::CloseHandle,
-        System::Threading::{
-            BELOW_NORMAL_PRIORITY_CLASS, GetPriorityClass, OpenProcess,
-            PROCESS_QUERY_LIMITED_INFORMATION,
+        System::{
+            JobObjects::{
+                IsProcessInJob, JOBOBJECT_CPU_RATE_CONTROL_INFORMATION,
+                JobObjectCpuRateControlInformation, QueryInformationJobObject,
+            },
+            Threading::{
+                BELOW_NORMAL_PRIORITY_CLASS, GetPriorityClass, OpenProcess,
+                PROCESS_QUERY_LIMITED_INFORMATION,
+            },
         },
     };
 
     use super::*;
 
     #[test]
-    fn sets_a_child_process_to_below_normal_priority() {
+    fn attaches_child_and_updates_adaptive_weight() {
         let mut child = Command::new("cmd.exe")
             .args(["/d", "/c", "ping 127.0.0.1 -n 10 > nul"])
             .spawn()
             .expect("spawn test child");
+        let controller = PaneWorkloadController::attach(
+            child.id(),
+            PaneProcessPriority::BelowNormal,
+            PaneWorkloadPolicy::Adaptive,
+        )
+        .expect("attach workload controller");
+        controller
+            .apply(PaneWorkloadPolicy::Adaptive, PaneWorkloadClass::Focused)
+            .expect("set focused weight");
 
-        set_process_priority(child.id(), PaneProcessPriority::BelowNormal)
-            .expect("lower child priority");
-
-        // SAFETY: the child is still owned by this test and the returned handle is
-        // checked for null, queried, then closed.
         let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, child.id()) };
-        assert!(!process.is_null(), "open child for priority query");
-        // SAFETY: process is a valid query handle.
-        let priority = unsafe { GetPriorityClass(process) };
-        // SAFETY: process is an owned handle returned by OpenProcess above.
-        unsafe { CloseHandle(process) };
+        assert!(!process.is_null(), "open child for query");
+        let mut in_job = 0;
+        assert_ne!(
+            unsafe { IsProcessInJob(process, controller.job, &mut in_job) },
+            0
+        );
+        assert_ne!(in_job, 0);
+        assert_eq!(
+            unsafe { GetPriorityClass(process) },
+            BELOW_NORMAL_PRIORITY_CLASS
+        );
 
+        let mut info = JOBOBJECT_CPU_RATE_CONTROL_INFORMATION::default();
+        assert_ne!(
+            unsafe {
+                QueryInformationJobObject(
+                    controller.job,
+                    JobObjectCpuRateControlInformation,
+                    std::ptr::from_mut(&mut info).cast(),
+                    std::mem::size_of_val(&info) as u32,
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        assert_eq!(unsafe { info.Anonymous.Weight }, 9);
+
+        controller
+            .apply(PaneWorkloadPolicy::Unrestricted, PaneWorkloadClass::Visible)
+            .expect("disable adaptive scheduling");
+        let mut unrestricted = JOBOBJECT_CPU_RATE_CONTROL_INFORMATION::default();
+        assert_ne!(
+            unsafe {
+                QueryInformationJobObject(
+                    controller.job,
+                    JobObjectCpuRateControlInformation,
+                    std::ptr::from_mut(&mut unrestricted).cast(),
+                    std::mem::size_of_val(&unrestricted) as u32,
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        assert_eq!(unrestricted.ControlFlags, 0);
+
+        unsafe { CloseHandle(process) };
         let _ = child.kill();
         let _ = child.wait();
-        assert_eq!(priority, BELOW_NORMAL_PRIORITY_CLASS);
     }
 }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -3,17 +3,21 @@ use std::{
     env, fs,
     io::{Read, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::mpsc::{SyncSender, TrySendError, sync_channel},
     thread,
     time::{Duration, Instant},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use tokio::sync::mpsc;
 use vt100::{Parser, Screen};
 
-use crate::{config::PaneProcessPriority, layout::PaneId, process_priority::set_process_priority};
+use crate::{
+    config::{PaneProcessPriority, PaneWorkloadPolicy},
+    layout::PaneId,
+    process_priority::{PaneWorkloadClass, PaneWorkloadController},
+};
 
 const DEVICE_STATUS_QUERY: &[u8] = b"\x1b[5n";
 const CURSOR_POSITION_QUERY: &[u8] = b"\x1b[6n";
@@ -23,9 +27,11 @@ const MAX_TERMINAL_QUERY_LEN: usize = 4;
 const MAX_INPUT_HISTORY: usize = 200;
 const MAX_INPUT_LINE_CHARS: usize = 4096;
 const MAX_OUTPUT_TAIL_CHARS: usize = 40_000;
+const OUTPUT_TAIL_TRIM_AT_CHARS: usize = 48_000;
 const MAX_REPLAY_OUTPUT_CHARS: usize = 18_000;
 const MAX_OSC_SCAN: usize = 4096;
 const PTY_READ_BUFFER_BYTES: usize = 32 * 1024;
+const PTY_WRITE_QUEUE_MESSAGES: usize = 256;
 
 #[derive(Debug, Clone)]
 pub enum PtyEvent {
@@ -37,6 +43,11 @@ pub enum PtyEvent {
     Exited {
         pane: PaneId,
         generation: u64,
+    },
+    WriteFailed {
+        pane: PaneId,
+        generation: u64,
+        error: String,
     },
 }
 
@@ -79,8 +90,11 @@ pub struct PtyPane {
     generation: u64,
     master: Box<dyn MasterPty + Send>,
     child: Box<dyn Child + Send>,
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    writer: SyncSender<Vec<u8>>,
+    workload: PaneWorkloadController,
+    workload_error: Option<String>,
     parser: Parser,
+    screen_revision: u64,
     cwd: PathBuf,
     rows: u16,
     cols: u16,
@@ -90,6 +104,7 @@ pub struct PtyPane {
     input_history: Vec<String>,
     pending_input: String,
     output_tail: String,
+    output_tail_chars: usize,
     pub active: bool,
     pub exited: bool,
 }
@@ -106,7 +121,8 @@ impl PtyPane {
         cwd: &Path,
         extra_env: &[(String, String)],
         process_priority: PaneProcessPriority,
-        event_tx: mpsc::UnboundedSender<PtyEvent>,
+        workload_policy: PaneWorkloadPolicy,
+        event_tx: mpsc::Sender<PtyEvent>,
     ) -> Result<Self> {
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -138,22 +154,30 @@ impl PtyPane {
             .slave
             .spawn_command(command_builder)
             .with_context(|| format!("failed to spawn {}", command.display()))?;
-        if let Some(process_id) = child.process_id() {
-            // A pane should still launch if Windows refuses a priority change.
-            // The root process normally passes this priority to its descendants.
-            let _ = set_process_priority(process_id, process_priority);
-        }
+        let (workload, workload_error) = match child.process_id() {
+            Some(process_id) => {
+                match PaneWorkloadController::attach(process_id, process_priority, workload_policy)
+                {
+                    Ok(controller) => (controller, None),
+                    Err(error) => (PaneWorkloadController::unmanaged(), Some(error.to_string())),
+                }
+            }
+            None => (
+                PaneWorkloadController::unmanaged(),
+                Some("child process ID is unavailable".into()),
+            ),
+        };
         drop(pair.slave);
 
         let reader = pair
             .master
             .try_clone_reader()
             .context("failed to clone PTY reader")?;
-        let writer = Arc::new(Mutex::new(
-            pair.master
-                .take_writer()
-                .context("failed to open PTY writer")?,
-        ));
+        let writer = pair
+            .master
+            .take_writer()
+            .context("failed to open PTY writer")?;
+        let writer = spawn_writer(id, generation, event_tx.clone(), writer);
         spawn_reader(id, generation, event_tx, reader);
 
         Ok(Self {
@@ -162,7 +186,10 @@ impl PtyPane {
             master: pair.master,
             child,
             writer,
+            workload,
+            workload_error,
             parser: Parser::new(24, 80, 10_000),
+            screen_revision: 0,
             cwd: cwd.to_path_buf(),
             rows: 24,
             cols: 80,
@@ -172,6 +199,7 @@ impl PtyPane {
             input_history: Vec::new(),
             pending_input: String::new(),
             output_tail: String::new(),
+            output_tail_chars: 0,
             active: false,
             exited: false,
         })
@@ -193,24 +221,38 @@ impl PtyPane {
         self.parser.screen()
     }
 
+    pub fn screen_revision(&self) -> u64 {
+        self.screen_revision
+    }
+
     pub fn scroll_view(&mut self, rows: isize) -> bool {
-        scroll_screen(self.parser.screen_mut(), rows)
+        let changed = scroll_screen(self.parser.screen_mut(), rows);
+        if changed {
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
+        changed
     }
 
     pub fn reset_view(&mut self) -> bool {
         let screen = self.parser.screen_mut();
         let changed = screen.scrollback() > 0;
         screen.set_scrollback(0);
+        if changed {
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
         changed
     }
 
-    pub fn process_output(&mut self, bytes: &[u8]) {
+    pub fn process_output(&mut self, bytes: &[u8]) -> String {
         self.update_cwd_from_osc7(bytes);
         self.parser.process(bytes);
-        self.append_plain_output(bytes);
+        let plain = plain_terminal_text(bytes);
+        self.append_plain_output(&plain);
         self.active = true;
+        self.screen_revision = self.screen_revision.wrapping_add(1);
         self.output_activity.record_output(Instant::now());
         self.answer_terminal_queries(bytes);
+        plain
     }
 
     pub fn output_quiet(&self) -> bool {
@@ -240,6 +282,7 @@ impl PtyPane {
     pub fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
         self.output_tail = output_tail.to_string();
         trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
+        self.output_tail_chars = self.output_tail.chars().count();
         self.input_history = input_history
             .iter()
             .filter(|line| !line.trim().is_empty())
@@ -252,13 +295,29 @@ impl PtyPane {
         let replay = history_replay_text(&self.output_tail, &self.input_history);
         if !replay.is_empty() {
             self.parser.process(replay.as_bytes());
+            self.screen_revision = self.screen_revision.wrapping_add(1);
         }
     }
 
     pub fn write(&self, bytes: &[u8]) -> Result<()> {
-        let mut writer = self.writer.lock().expect("PTY writer lock poisoned");
-        writer.write_all(bytes).context("failed to write to PTY")?;
-        writer.flush().context("failed to flush PTY")
+        match self.writer.try_send(bytes.to_vec()) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(anyhow!("PTY input queue is full")),
+            Err(TrySendError::Disconnected(_)) => Err(anyhow!("PTY writer has stopped")),
+        }
+    }
+
+    pub fn apply_workload(
+        &self,
+        policy: PaneWorkloadPolicy,
+        class: PaneWorkloadClass,
+    ) -> Result<()> {
+        if let Some(error) = &self.workload_error {
+            return Err(anyhow!(error.clone()));
+        }
+        self.workload
+            .apply(policy, class)
+            .context("failed to update pane workload policy")
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
@@ -277,6 +336,7 @@ impl PtyPane {
             .context("failed to resize PTY")?;
         self.rows = rows;
         self.cols = cols;
+        self.screen_revision = self.screen_revision.wrapping_add(1);
         Ok(())
     }
 
@@ -294,6 +354,9 @@ impl PtyPane {
     }
 
     fn answer_terminal_queries(&mut self, bytes: &[u8]) {
+        if self.response_scan_tail.is_empty() && !bytes.contains(&0x1b) {
+            return;
+        }
         let mut scan = Vec::with_capacity(self.response_scan_tail.len() + bytes.len());
         scan.extend_from_slice(&self.response_scan_tail);
         scan.extend_from_slice(bytes);
@@ -325,6 +388,9 @@ impl PtyPane {
     }
 
     fn update_cwd_from_osc7(&mut self, bytes: &[u8]) {
+        if self.osc_scan_tail.is_empty() && !bytes.contains(&0x1b) {
+            return;
+        }
         let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
         scan.extend_from_slice(&self.osc_scan_tail);
         scan.extend_from_slice(bytes);
@@ -335,8 +401,7 @@ impl PtyPane {
             }
         }
 
-        let tail_start = scan.len().saturating_sub(MAX_OSC_SCAN);
-        self.osc_scan_tail = scan[tail_start..].to_vec();
+        self.osc_scan_tail = incomplete_osc_tail(&scan);
     }
 
     pub fn terminate(&mut self) {
@@ -348,14 +413,17 @@ impl PtyPane {
         self.exited = true;
     }
 
-    fn append_plain_output(&mut self, bytes: &[u8]) {
-        let plain = plain_terminal_text(bytes);
+    fn append_plain_output(&mut self, plain: &str) {
         if plain.is_empty() {
             return;
         }
 
-        self.output_tail.push_str(&plain);
-        trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
+        self.output_tail.push_str(plain);
+        self.output_tail_chars += plain.chars().count();
+        if self.output_tail_chars > OUTPUT_TAIL_TRIM_AT_CHARS {
+            trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
+            self.output_tail_chars = self.output_tail.chars().count();
+        }
     }
 }
 
@@ -452,7 +520,7 @@ fn powershell_cwd_hook() -> &'static str {
 fn spawn_reader(
     pane: PaneId,
     generation: u64,
-    event_tx: mpsc::UnboundedSender<PtyEvent>,
+    event_tx: mpsc::Sender<PtyEvent>,
     mut reader: Box<dyn Read + Send>,
 ) {
     thread::spawn(move || {
@@ -460,23 +528,49 @@ fn spawn_reader(
         loop {
             match reader.read(&mut buffer) {
                 Ok(0) => {
-                    let _ = event_tx.send(PtyEvent::Exited { pane, generation });
+                    let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
                     break;
                 }
                 Ok(n) => {
-                    let _ = event_tx.send(PtyEvent::Output {
+                    let _ = event_tx.blocking_send(PtyEvent::Output {
                         pane,
                         generation,
                         bytes: buffer[..n].to_vec(),
                     });
                 }
                 Err(_) => {
-                    let _ = event_tx.send(PtyEvent::Exited { pane, generation });
+                    let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
                     break;
                 }
             }
         }
     });
+}
+
+fn spawn_writer(
+    pane: PaneId,
+    generation: u64,
+    event_tx: mpsc::Sender<PtyEvent>,
+    mut writer: Box<dyn Write + Send>,
+) -> SyncSender<Vec<u8>> {
+    let (tx, rx) = sync_channel::<Vec<u8>>(PTY_WRITE_QUEUE_MESSAGES);
+    thread::spawn(move || {
+        while let Ok(bytes) = rx.recv() {
+            let result = writer
+                .write_all(&bytes)
+                .and_then(|()| writer.flush())
+                .context("failed to write to PTY");
+            if let Err(error) = result {
+                let _ = event_tx.blocking_send(PtyEvent::WriteFailed {
+                    pane,
+                    generation,
+                    error: format!("{error:#}"),
+                });
+                break;
+            }
+        }
+    });
+    tx
 }
 
 fn contains_sequence(buffer: &[u8], sequence: &[u8]) -> bool {
@@ -704,13 +798,11 @@ fn history_replay_text(output_tail: &str, input_history: &[String]) -> String {
 pub(crate) fn plain_terminal_text(bytes: &[u8]) -> String {
     let raw = String::from_utf8_lossy(bytes);
     let mut plain = String::new();
-    let chars = raw.chars().collect::<Vec<_>>();
-    let mut index = 0;
+    let mut chars = raw.chars().peekable();
 
-    while index < chars.len() {
-        let ch = chars[index];
+    while let Some(ch) = chars.next() {
         if ch == '\x1b' {
-            index = skip_escape_chars(&chars, index);
+            skip_escape_chars(&mut chars);
             continue;
         }
 
@@ -732,7 +824,6 @@ pub(crate) fn plain_terminal_text(bytes: &[u8]) -> String {
             ch if ch.is_control() => {}
             ch => plain.push(ch),
         }
-        index += 1;
     }
 
     plain
@@ -781,47 +872,58 @@ fn skip_escape_sequence(bytes: &[u8], start: usize) -> usize {
     index
 }
 
-fn skip_escape_chars(chars: &[char], start: usize) -> usize {
-    let mut index = start.saturating_add(1);
-    if index >= chars.len() {
-        return index;
-    }
-
-    match chars[index] {
+fn skip_escape_chars(chars: &mut std::iter::Peekable<impl Iterator<Item = char>>) {
+    let Some(kind) = chars.next() else {
+        return;
+    };
+    match kind {
         '[' => {
-            index += 1;
-            while index < chars.len() {
-                let ch = chars[index];
-                index += 1;
+            for ch in chars.by_ref() {
                 if ('\u{40}'..='\u{7e}').contains(&ch) {
                     break;
                 }
             }
         }
         'O' => {
-            index += 1;
-            if index < chars.len() {
-                index += 1;
-            }
+            let _ = chars.next();
         }
         ']' => {
-            index += 1;
-            while index < chars.len() {
-                if chars[index] == '\x07' {
-                    index += 1;
+            while let Some(ch) = chars.next() {
+                if ch == '\x07' {
                     break;
                 }
-                if chars[index] == '\x1b' && index + 1 < chars.len() && chars[index + 1] == '\\' {
-                    index += 2;
+                if ch == '\x1b' && chars.next_if_eq(&'\\').is_some() {
                     break;
                 }
-                index += 1;
             }
         }
-        _ => index += 1,
+        _ => {}
     }
+}
 
-    index
+fn incomplete_osc_tail(buffer: &[u8]) -> Vec<u8> {
+    let start = buffer.len().saturating_sub(MAX_OSC_SCAN);
+    for index in (start..buffer.len()).rev() {
+        if buffer[index] != 0x1b {
+            continue;
+        }
+        if index + 1 == buffer.len() {
+            return buffer[index..].to_vec();
+        }
+        if buffer[index + 1] != b']' {
+            continue;
+        }
+
+        let payload = &buffer[index + 2..];
+        let complete =
+            payload.contains(&0x07) || payload.windows(2).any(|window| window == [0x1b, b'\\']);
+        return if complete {
+            Vec::new()
+        } else {
+            buffer[index..].to_vec()
+        };
+    }
+    Vec::new()
 }
 
 fn trim_string_tail(value: &mut String, max_chars: usize) {
@@ -857,13 +959,79 @@ fn tail_chars(value: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use std::{
-        env,
+        env, io,
         path::Path,
+        sync::{Arc, Mutex},
         thread,
         time::{Duration, Instant},
     };
 
     use super::*;
+
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("shared writer")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _bytes: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn writer_worker_preserves_enqueued_input_order() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let (event_tx, _event_rx) = mpsc::channel(4);
+        let writer = spawn_writer(
+            PaneId(3),
+            7,
+            event_tx,
+            Box::new(SharedWriter(output.clone())),
+        );
+        writer.send(b"first".to_vec()).expect("first write");
+        writer.send(b"-second".to_vec()).expect("second write");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while output.lock().expect("output").len() < 12 && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert_eq!(&*output.lock().expect("output"), b"first-second");
+    }
+
+    #[test]
+    fn writer_worker_reports_asynchronous_failures() {
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let writer = spawn_writer(PaneId(4), 2, event_tx, Box::new(FailingWriter));
+        writer.send(b"input".to_vec()).expect("queue input");
+
+        let event = event_rx.blocking_recv().expect("write failure event");
+        assert!(matches!(
+            event,
+            PtyEvent::WriteFailed {
+                pane: PaneId(4),
+                generation: 2,
+                ..
+            }
+        ));
+    }
 
     #[test]
     fn counts_split_terminal_query_sequences() {
@@ -885,6 +1053,17 @@ mod tests {
         scan.extend_from_slice(b"prompt");
 
         assert_eq!(count_sequence(&scan, CURSOR_POSITION_QUERY), 0);
+    }
+
+    #[test]
+    fn osc_tail_keeps_only_incomplete_sequences() {
+        assert!(incomplete_osc_tail(b"ordinary output").is_empty());
+        assert!(incomplete_osc_tail(b"\x1b]7;file:///tmp\x07done").is_empty());
+        assert_eq!(
+            incomplete_osc_tail(b"output\x1b]7;file:///tmp"),
+            b"\x1b]7;file:///tmp"
+        );
+        assert_eq!(incomplete_osc_tail(b"output\x1b"), b"\x1b");
     }
 
     #[cfg(windows)]
@@ -989,7 +1168,7 @@ mod tests {
     #[test]
     #[ignore = "Windows ConPTY smoke test requires an interactive console; run manually when debugging PTY I/O"]
     fn spawned_pty_receives_output_and_input() {
-        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::channel(64);
         let cwd = env::current_dir().expect("current dir");
         let mut pane = PtyPane::spawn(
             "cmd",
@@ -1007,6 +1186,7 @@ mod tests {
             &cwd,
             &[],
             PaneProcessPriority::BelowNormal,
+            PaneWorkloadPolicy::Adaptive,
             event_tx,
         )
         .expect("spawn cmd pty");
@@ -1023,6 +1203,7 @@ mod tests {
                         raw_output.extend(bytes);
                     }
                     PtyEvent::Exited { .. } => pane.exited = true,
+                    PtyEvent::WriteFailed { error, .. } => panic!("PTY write failed: {error}"),
                 }
             }
 
@@ -1051,7 +1232,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn spawned_unix_pty_receives_output_and_input() {
-        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (event_tx, mut event_rx) = mpsc::channel(64);
         let cwd = env::current_dir().expect("current dir");
         let mut pane = PtyPane::spawn(
             "sh",
@@ -1066,6 +1247,7 @@ mod tests {
             &cwd,
             &[],
             PaneProcessPriority::BelowNormal,
+            PaneWorkloadPolicy::Adaptive,
             event_tx,
         )
         .expect("spawn Unix PTY");
@@ -1082,6 +1264,7 @@ mod tests {
                         raw_output.extend(bytes);
                     }
                     PtyEvent::Exited { .. } => pane.exited = true,
+                    PtyEvent::WriteFailed { error, .. } => panic!("PTY write failed: {error}"),
                 }
             }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -41,6 +41,15 @@ pub struct DrawState {
     pub pane_settings_stop_goal_button: Option<Rect>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct PaneRenderCache {
+    revision: u64,
+    width: u16,
+    height: u16,
+    selection: Option<PaneSelection>,
+    lines: Vec<Line<'static>>,
+}
+
 const QUIET_MARKER: &str = " *";
 const STATUS_BRAND: &str = " GridBash ";
 const PREVIOUS_PANES_BUTTON: &str = " Panes ";
@@ -167,7 +176,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         } else if sleeping {
             render_sleeping_screen(frame, inner);
         } else {
-            render_screen(frame, inner, pane.screen(), app.selection_for_pane(index));
+            let selection = app.selection_for_pane(index);
+            let lines = app.pane_screen_lines(index, inner.width, inner.height, selection);
+            render_screen_lines(frame, inner, lines);
         }
 
         if focused && !sleeping && !modal_open && pane.screen().scrollback() == 0 {
@@ -2532,24 +2543,45 @@ fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
     frame.render_widget(Paragraph::new(lines).style(style), area);
 }
 
-fn render_screen(
-    frame: &mut Frame<'_>,
-    area: Rect,
-    screen: &vt100::Screen,
-    selection: Option<PaneSelection>,
-) {
+fn render_screen_lines(frame: &mut Frame<'_>, area: Rect, lines: Vec<Line<'static>>) {
     if area.width == 0 || area.height == 0 {
         return;
     }
-
-    let lines = (0..area.height)
-        .map(|row| render_screen_row(screen, row, area.width, selection))
-        .collect::<Vec<_>>();
 
     frame.render_widget(
         Paragraph::new(lines).style(Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)),
         area,
     );
+}
+
+pub fn cached_screen_lines(
+    cache: &mut PaneRenderCache,
+    revision: u64,
+    screen: &vt100::Screen,
+    width: u16,
+    height: u16,
+    selection: Option<PaneSelection>,
+) -> Vec<Line<'static>> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+    if cache.revision == revision
+        && cache.width == width
+        && cache.height == height
+        && cache.selection == selection
+    {
+        return cache.lines.clone();
+    }
+
+    let lines = (0..height)
+        .map(|row| render_screen_row(screen, row, width, selection))
+        .collect::<Vec<_>>();
+    cache.revision = revision;
+    cache.width = width;
+    cache.height = height;
+    cache.selection = selection;
+    cache.lines.clone_from(&lines);
+    lines
 }
 
 fn render_screen_row<'a>(
@@ -2908,6 +2940,41 @@ mod tests {
             Style::default()
                 .fg(rgb_color(group_color))
                 .add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn pane_render_cache_reuses_revision_and_invalidates_on_output() {
+        let mut parser = vt100::Parser::new(2, 10, 100);
+        parser.process(b"hello");
+        let mut cache = PaneRenderCache::default();
+
+        let first = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
+        parser.process(b" world");
+        let cached = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
+        assert_eq!(cached, first);
+
+        let refreshed = cached_screen_lines(&mut cache, 2, parser.screen(), 10, 2, None);
+        assert_ne!(refreshed, first);
+    }
+
+    #[test]
+    fn pane_render_cache_keys_selection_and_dimensions() {
+        let mut parser = vt100::Parser::new(2, 10, 100);
+        parser.process(b"hello");
+        let mut cache = PaneRenderCache::default();
+        let plain = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
+        let selection = Some(PaneSelection {
+            start_row: 0,
+            start_column: 0,
+            end_row: 0,
+            end_column: 4,
+        });
+        let selected = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, selection);
+        assert_ne!(selected, plain);
+        assert_eq!(
+            cached_screen_lines(&mut cache, 1, parser.screen(), 5, 2, selection).len(),
+            2
         );
     }
 }


### PR DESCRIPTION
## Summary
- bound and fairly schedule PTY event draining so output cannot starve input
- move pane writes to ordered background workers and route PTY events without linear pane scans
- cache pane rendering and conversation summaries by screen revision
- suppress redundant hidden/sleeping redraws and cap output-driven frames for large grids
- add adaptive Windows Job Object weights while keeping every pane running
- amortize terminal history trimming and reduce parser allocations

## Validation
- `cargo test` after merging latest main: 125 passed, 1 ignored
- `cargo clippy --all-targets -- -D warnings`
- `npm run test:launcher`: 11 passed
- `cargo build --release`
- `cargo fmt -- --check`
- `git diff --check`

Refs #78