### PR TITLE
docs: define v1 and daemon architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ agents are all part of the same development session.
 - Devlogs live in `docs/devlogs/`.
 - Versioned release notes live in `docs/releases/` and are used for GitHub release notes.
 - npm packages include `docs/devlogs/` and `docs/releases/` so published package contents carry the logs too.
+- The [v1.0 acceptance checklist](docs/V1_ACCEPTANCE.md) defines the stable-release gates.
+- The [daemon architecture proposal](docs/DAEMON_ARCHITECTURE.md) defines the detach/reattach direction beyond v1.
 
 ## Highlights
 

--- a/docs/DAEMON_ARCHITECTURE.md
+++ b/docs/DAEMON_ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# Daemon Detach and Reattach Architecture
+
+## Status and goal
+
+This is a design proposal, not the v1 runtime contract. GridBash v1 intentionally
+owns PTYs inside the foreground TUI process. The next major architecture should
+let a user detach the UI while pane processes continue, then attach one or more
+clients without changing ordinary single-machine workflows.
+
+The first daemon release should preserve local PTYs and local trust boundaries.
+Remote access, web clients, plugins, and multi-host orchestration should build on
+the protocol later instead of expanding the first implementation.
+
+## Process boundary
+
+`gridbashd` is the long-lived owner of sessions, PTY masters, child process
+trees, terminal parsers, input ordering, and durable session metadata. The
+`gridbash` command remains the interactive client and owns terminal setup,
+Ratatui rendering, mouse decoding, clipboard integration, and local overlays.
+
+```text
+gridbash client ── local authenticated IPC ── gridbashd
+                                               ├── session A / pane PTYs
+                                               ├── session B / pane PTYs
+                                               └── snapshot and event journal
+```
+
+Launching `gridbash` should connect to the per-user daemon or start it on demand.
+An explicit `gridbash daemon stop` performs a graceful shutdown only after the
+user chooses what happens to live sessions. Client exit never implicitly kills
+daemon-owned panes.
+
+## Ownership and lifecycle
+
+- The daemon creates every PTY and child process and remains its sole writer.
+- Clients send ordered input commands tagged with session, pane, client, and
+  monotonically increasing request IDs.
+- The daemon assigns stable opaque IDs to sessions, tabs, panes, and generations.
+  Array indexes remain a presentation detail and are never protocol identity.
+- A pane generation changes after restart so late output/input acknowledgements
+  cannot target the replacement process.
+- The daemon owns shutdown escalation and records exit status before releasing a
+  PTY. Platform-specific Job Objects/process groups remain behind one lifecycle
+  interface.
+- A detached session continues parsing output into bounded scrollback. It does
+  not require a render loop or connected client.
+
+## IPC and trust
+
+Use a local per-user transport: named pipes with an owner-only ACL on Windows and
+a Unix domain socket with mode `0600` on Unix. The daemon writes a discovery file
+containing protocol version, endpoint, process ID, and a random boot nonce in the
+user runtime directory. Never place bearer API keys or auth tokens in that file.
+
+Every connection performs a version handshake. Mutating messages require the
+boot nonce plus same-user transport credentials where the platform exposes them.
+Remote TCP listeners are out of scope for the first daemon release.
+
+Messages should use a length-prefixed, versioned envelope. JSON is acceptable for
+the prototype; a schema-backed binary format can follow only if profiling shows
+serialization is material. Unknown optional fields are ignored, while unknown
+required capabilities fail the handshake with an actionable version error.
+
+## State synchronization
+
+The daemon exposes a snapshot plus ordered event stream:
+
+1. Client requests a session snapshot at revision `N`.
+2. Daemon returns layout, pane metadata, bounded screen state, and current
+   revision.
+3. Client subscribes from that revision.
+4. Daemon sends output, title/cwd, layout, lifecycle, and status events in order.
+5. If the client falls behind the bounded event buffer, the daemon requests a
+   fresh snapshot instead of growing memory without limit.
+
+Terminal screen diffs should be added only after a full-screen snapshot protocol
+works correctly. Output events may be coalesced, but input acknowledgements and
+lifecycle transitions must preserve order.
+
+## Multiple clients
+
+Multiple read-only clients are safe by default. Mutating clients use a renewable
+input lease per session. The lease holder may type, resize, restart, or change
+layout; other clients can request control or explicitly share it. This avoids two
+terminals interleaving bytes accidentally while still allowing observers.
+
+Client-local state includes focused pane, local scroll position, open dialogs,
+palette overrides, and terminal dimensions. Daemon state includes tabs, layout,
+pane labels, selected input targets only when explicitly shared, goals, and
+process/session metadata.
+
+## Persistence and recovery
+
+Keep metadata in an atomic versioned snapshot and append-only bounded journal.
+Write to a temporary file, flush, then rename over the previous snapshot. On
+startup, validate the newest snapshot and fall back to the previous known-good
+generation if it is corrupt.
+
+PTY processes cannot be adopted portably after a daemon crash. A recovered record
+therefore distinguishes `running`, `exited`, and `lost`. Lost panes retain bounded
+history and launch metadata and offer restart; they must never be presented as
+still attached.
+
+Session records must not contain environment secrets, auth tokens, full process
+environments, or manager API keys. Store references to named profiles and reload
+secrets from their existing protected locations when launching a replacement.
+
+## Configuration and compatibility
+
+The existing user config remains the source for profiles and defaults. Daemon
+startup loads and validates it, while clients may request a redacted effective
+configuration. Config edits use compare-and-swap revisions so an older client
+cannot overwrite newer settings.
+
+The client and daemon advertise protocol major/minor versions and capabilities.
+Major mismatches refuse mutation; compatible minor versions negotiate features.
+The npm launcher should install matching client/daemon native binaries from one
+package version and report both versions in diagnostics.
+
+The current single-process mode should remain available behind an explicit
+fallback during migration. Existing bounded session snapshots need a one-way,
+idempotent importer; migration must copy rather than destroy the old records.
+
+## Failure behavior
+
+- Client disconnect: release its input lease after a short grace period; panes
+  continue running.
+- Slow client: coalesce output, then require resnapshot when its queue is full.
+- Daemon shutdown: reject new mutations, snapshot state, gracefully terminate or
+  preserve sessions according to the explicit command, then remove discovery.
+- Daemon crash: clients show a disconnected state and retry with backoff; they do
+  not silently start a second daemon while the old endpoint may still be live.
+- Version mismatch: print installed client/daemon versions and the exact upgrade
+  or restart command.
+- Disk full/corrupt snapshot: keep live PTYs running, surface the persistence
+  failure, and avoid overwriting the last known-good snapshot.
+
+## Prototypes required before implementation
+
+1. Measure named-pipe and Unix-socket throughput for 100 noisy panes with bounded
+   client queues and snapshot recovery.
+2. Prove owner-only endpoint discovery and peer identity on supported platforms.
+3. Prototype stable screen snapshots and resubscription across terminal resize,
+   alternate screen, wide characters, and scrollback.
+4. Test Windows Job Object and Unix process-group behavior when the daemon or
+   client crashes independently.
+5. Validate the input-lease UX with two clients, including disconnect and stale
+   lease recovery.
+6. Exercise snapshot/journal corruption, disk-full behavior, and migration from
+   existing session records.
+
+## Decisions still open
+
+- Whether the initial protocol uses JSON or a schema-backed encoding after the
+  throughput prototype.
+- Whether selections are always client-local or can become explicitly shared
+  session state.
+- How long detached scrollback and exited sessions are retained by default.
+- Whether pane-local manager requests execute in the daemon or in a privileged
+  client helper.
+- Which capabilities are mandatory for the first daemon preview versus deferred
+  to multi-client or remote milestones.
+
+Implementation should not begin with a broad refactor. Land the transport and
+version handshake first, then one daemon-owned PTY, snapshots, detach/reattach,
+and finally multi-pane/multi-client behavior behind compatibility tests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,7 @@
 - Built-in CLI agent profiles.
 - Demo-ready dark theme.
 - Release as a single Windows x64 executable.
+- Stable-release gates are tracked in [`V1_ACCEPTANCE.md`](V1_ACCEPTANCE.md).
 
 ## V2
 
@@ -15,6 +16,8 @@
 - Multi-client attach.
 - Agent status classifiers.
 - Plugin API.
+- The proposed process, protocol, persistence, and migration boundaries are in
+  [`DAEMON_ARCHITECTURE.md`](DAEMON_ARCHITECTURE.md).
 
 ## V3
 

--- a/docs/V1_ACCEPTANCE.md
+++ b/docs/V1_ACCEPTANCE.md
@@ -1,0 +1,102 @@
+# GridBash v1.0 Acceptance Checklist
+
+This checklist defines the minimum evidence required to call the Windows build
+of GridBash stable. A release candidate may ship before every box is checked,
+but the stable `v1.0.0` tag must not.
+
+Record evidence beside each item in the release PR or linked test report. A
+passing check from an older commit does not qualify unless the release commit is
+an ancestor of that tested commit and no relevant code changed afterward.
+
+## Installation and launch
+
+- [ ] `npm install -g gridbash` succeeds for a clean Windows x64 user without a
+      Rust toolchain.
+- [ ] `gridbash --version` reports the npm package version and launches the
+      packaged native executable rather than a repository worktree.
+- [ ] First launch with no GridBash config discovers available Windows shells,
+      saves the chosen default, and uses it on the next launch.
+- [ ] PowerShell, PowerShell 7, cmd, and Git Bash invocation inheritance each
+      select the expected pane shell unless an explicit profile overrides it.
+- [ ] Paths containing spaces and non-ASCII characters work for installation,
+      config, current directories, and managed worktrees.
+
+## PTY and process lifecycle
+
+- [ ] A pane can launch, accept keyboard and pasted input, resize, produce ANSI
+      output, report its cwd, and exit without corrupting sibling panes.
+- [ ] Closing GridBash terminates every owned child process tree without taskkill
+      success spam or orphaned descendants.
+- [ ] Restarting an exited pane preserves its profile, cwd, label, auth choice,
+      and managed-worktree metadata.
+- [ ] A 10x10 grid can start and shut down cleanly; busy output does not make
+      focus movement, selection, or quit controls unusable.
+- [ ] Unicode input/output, OSC 52 copy, cursor queries, alternate-screen apps,
+      and xterm mouse reporting have regression coverage.
+
+## Profiles and configuration
+
+- [ ] `gridbash --list-profiles` clearly identifies available, missing, and
+      selected profiles without exposing credentials or unnecessary user paths.
+- [ ] Built-in Windows profiles resolve expected executables, and a custom
+      profile reports an actionable error when its executable is missing.
+- [ ] Config defaults remain backward compatible; unknown legacy tables do not
+      prevent startup.
+- [ ] Settings that claim persistence survive restart, while session-only
+      controls are labeled as session-only.
+- [ ] Claude and Codex auth profile selection never prints tokens and keeps
+      account labels masked.
+
+## Grid interaction
+
+- [ ] Focus movement wraps predictably and skips sleeping panes where required.
+- [ ] Single-pane input, selected multi-pane input, and select-all behavior route
+      bytes only to the intended live panes.
+- [ ] Drag selection and wheel scrolling stay inside the pane under the pointer.
+- [ ] Rename, swap, sleep/wake, grid resize, tabs, command bar, pane settings,
+      help, and recovery dialogs work at both 80x24 and 160x50.
+- [ ] Every modeless GridBash shortcut is discoverable in the in-app help and
+      documented in the README.
+
+## Sessions and worktrees
+
+- [ ] Session snapshots are bounded, recover from a truncated/corrupt newest
+      record, and never store credentials.
+- [ ] `gridbash resume --list`, `--latest`, and unique-id selection restore grid,
+      profile, cwd, label, auth, and recent-history metadata without replaying
+      commands automatically.
+- [ ] Managed worktrees are created inside the configured repository, use unique
+      branch names, and are not deleted when GridBash exits.
+- [ ] Launch or cleanup failures identify the affected pane/worktree and leave
+      existing user branches untouched.
+
+## Documentation and support
+
+- [ ] README install, quickstart, controls, config, profile, session, and local
+      development instructions match the release candidate.
+- [ ] `--help`, example config, release documentation, and npm package contents
+      agree on supported Windows versions and profiles.
+- [ ] Security reporting, support, contribution, license, and code-of-conduct
+      links are present and valid.
+- [ ] Known v1 limitations explicitly include single-process lifetime and the
+      lack of daemon-backed detach/reattach.
+
+## Packaging and release
+
+- [ ] `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`,
+      `cargo test`, launcher tests, and a release build pass on the release commit.
+- [ ] CI builds and packs Windows x64 from a clean runner, and the produced npm
+      tarballs contain only the expected launcher, metadata, docs, and executable.
+- [ ] Native packages publish before the root launcher; exact versions match
+      across Cargo, npm root, optional native package, tag, and GitHub release.
+- [ ] npm trusted publishing/provenance and the token fallback are tested or
+      explicitly waived with a documented reason.
+- [ ] A clean-machine smoke test installs from the intended npm dist-tag, launches
+      a real pane, exercises input/resize/quit, and removes the package cleanly.
+
+## Stability decision
+
+The v1.0 release PR must link the completed evidence, list every waived item,
+and identify an owner and follow-up issue for each waiver. Any failure involving
+data loss, credential exposure, orphaned process trees, unusable input, or an
+uninstallable package blocks the stable tag.

--- a/docs/devlogs/2026-07-12-define-v1-and-daemon-architecture.md
+++ b/docs/devlogs/2026-07-12-define-v1-and-daemon-architecture.md
@@ -1,0 +1,32 @@
+# Define v1 and daemon architecture
+
+Date: 2026-07-12
+Release target: unreleased
+
+## Summary
+
+- Added concrete stable-v1 acceptance gates and the proposed detach/reattach architecture.
+
+## What Changed
+
+- Defined release evidence for installation, PTY lifecycle, profiles, interaction,
+  sessions, worktrees, documentation, packaging, and stability decisions.
+- Defined daemon/client ownership, local IPC trust, synchronization, multi-client
+  leases, persistence, compatibility, failure behavior, required prototypes, and
+  open design decisions.
+- Linked both documents from the README and roadmap.
+
+## Why It Matters
+
+- Stable-release and daemon work now have reviewable boundaries instead of broad
+  milestone labels that could hide incompatible assumptions.
+
+## Validation
+
+- `git diff --check`
+- Reviewed links and headings against the current README, roadmap, CI, packaging,
+  profile, PTY, session, and release behavior.
+
+## Release Notes
+
+- Documented the GridBash v1.0 release gates and post-v1 detach/reattach design.


### PR DESCRIPTION
## Summary
- add a concrete Windows v1.0 acceptance checklist with required release evidence
- define the post-v1 daemon/client boundary for detach and reattach
- cover ownership, IPC trust, synchronization, multi-client leases, persistence, compatibility, failure behavior, prototypes, and open decisions
- link both documents from the README and roadmap

## Validation
- `git diff --check`
- verified all added local links resolve
- reviewed the checklist against current README, CI, packaging, profiles, PTY, sessions, and release behavior

Refs #10
Refs #11