### PR TITLE
fix: disclose review input limitations

### DIFF
--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -38,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           REVIEW_MODEL: openai/gpt-4.1
+          REVIEW_MODELS_API_VERSION: "2026-03-10"
           REVIEW_MAX_DIFF_CHARS: "18000"
           REVIEW_MAX_OUTPUT_TOKENS: "1800"
         run: node npm/scripts/review-agent.js

--- a/docs/AUTOMATED_REVIEW.md
+++ b/docs/AUTOMATED_REVIEW.md
@@ -13,8 +13,9 @@ Models usage is separate and opt-in; the workflow does not enable billing.
 
 The workflow uses `openai/gpt-4.1` by default. Change `REVIEW_MODEL` in
 `.github/workflows/review-agent.yml` to select another model allowed by the
-repository. The checked-in `.github/copilot-instructions.md` file defines the
-project-specific review standard.
+repository. `REVIEW_MODELS_API_VERSION` keeps the GitHub Models API contract
+explicit and configurable. The checked-in `.github/copilot-instructions.md`
+file defines the project-specific review standard.
 
 To re-run a review manually:
 
@@ -25,6 +26,8 @@ gh workflow run review-agent.yml -f pr_number=123
 The agent updates one marker-based comment instead of adding a new comment on
 every push. A failed model request updates that same report with the error and
 fails the workflow check so configuration and quota problems stay visible.
+When the input budget is exceeded, the report names the truncated and omitted
+files instead of implying the complete change was reviewed.
 
 ## Security model
 

--- a/docs/devlogs/2026-07-13-automatic-pr-review-agent.md
+++ b/docs/devlogs/2026-07-13-automatic-pr-review-agent.md
@@ -15,6 +15,8 @@ Release target: unreleased
 - Added a dependency-free, tested reviewer that paginates changed files,
   bounds model input, resists prompt injection, and upserts its report.
 - Added GridBash-specific review instructions and setup/security documentation.
+- Added explicit truncated/omitted filename reporting and a configurable Models
+  API version after dogfooding the live reviewer on its own implementation PR.
 
 ## Why It Matters
 

--- a/npm/scripts/review-agent.js
+++ b/npm/scripts/review-agent.js
@@ -26,6 +26,23 @@ function boundedUntrustedText(value, maximumCharacters) {
     : `${text.slice(0, maximumCharacters)}\n[truncated]`;
 }
 
+function summarizeFileNames(fileNames) {
+  const visible = fileNames.slice(0, 10).map((name) => boundedUntrustedText(name, 240));
+  const remainder = fileNames.length - visible.length;
+  return `${JSON.stringify(visible)}${remainder > 0 ? ` (+${remainder} more)` : ""}`;
+}
+
+function describeInputLimitations(renderedDiff) {
+  const limitations = [];
+  if (renderedDiff.partialFileNames?.length) {
+    limitations.push(`Truncated patches: ${summarizeFileNames(renderedDiff.partialFileNames)}`);
+  }
+  if (renderedDiff.omittedFileNames?.length) {
+    limitations.push(`Omitted files: ${summarizeFileNames(renderedDiff.omittedFileNames)}`);
+  }
+  return limitations.join("\n");
+}
+
 async function requestJson(fetchImpl, url, options = {}) {
   const method = options.method || "GET";
   const headers = {
@@ -87,6 +104,7 @@ function renderChangedFiles(files, maximumCharacters = DEFAULT_MAX_DIFF_CHARS) {
   let text = "";
   let includedFiles = 0;
   let partialFiles = 0;
+  const partialFileNames = [];
 
   for (let index = 0; index < files.length; index += 1) {
     const file = files[index];
@@ -111,22 +129,27 @@ function renderChangedFiles(files, maximumCharacters = DEFAULT_MAX_DIFF_CHARS) {
       text += suffix.slice(0, Math.min(suffix.length, maximumCharacters - text.length));
       includedFiles += 1;
       partialFiles += 1;
+      partialFileNames.push(file.filename);
     }
     break;
   }
+
+  const omittedFileNames = files.slice(includedFiles).map((file) => file.filename);
 
   return {
     text,
     includedFiles,
     partialFiles,
-    omittedFiles: Math.max(0, files.length - includedFiles),
+    partialFileNames,
+    omittedFiles: omittedFileNames.length,
+    omittedFileNames,
     truncated: includedFiles < files.length || partialFiles > 0,
   };
 }
 
 function buildReviewMessages(pullRequest, renderedDiff, instructions) {
   const scopeNote = renderedDiff.truncated
-    ? `The input budget truncated ${renderedDiff.partialFiles} patch(es) and omitted ${renderedDiff.omittedFiles} file(s). Do not claim those portions were reviewed.`
+    ? `The input budget limited this review. Do not claim the following portions were reviewed:\n${describeInputLimitations(renderedDiff)}`
     : "All changed-file patches returned by GitHub are included.";
   const metadata = {
     number: pullRequest.number,
@@ -171,11 +194,19 @@ function buildReviewMessages(pullRequest, renderedDiff, instructions) {
   ];
 }
 
-async function callReviewModel(fetchImpl, endpoint, token, model, messages, maxTokens) {
+async function callReviewModel(
+  fetchImpl,
+  endpoint,
+  token,
+  model,
+  messages,
+  maxTokens,
+  apiVersion = "2026-03-10",
+) {
   const payload = await requestJson(fetchImpl, endpoint, {
     method: "POST",
     token,
-    apiVersion: "2026-03-10",
+    apiVersion,
     body: {
       model,
       messages,
@@ -198,15 +229,34 @@ function sanitizeModelOutput(review) {
     .slice(0, 40_000);
 }
 
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("@", "@\u200b");
+}
+
 function formatReviewComment(review, pullRequest, renderedDiff, model) {
   const scope = renderedDiff.truncated
     ? `${renderedDiff.includedFiles}/${pullRequest.changed_files} files represented; input was truncated`
     : `${renderedDiff.includedFiles}/${pullRequest.changed_files} files represented`;
+  const limitations = renderedDiff.truncated
+    ? [
+        "",
+        "<details><summary>Review input limitations</summary>",
+        "",
+        `<pre>${escapeHtml(describeInputLimitations(renderedDiff))}</pre>`,
+        "</details>",
+      ]
+    : [];
   return [
     COMMENT_MARKER,
     "## 🛡️ GridBash Review Agent",
     "",
     sanitizeModelOutput(review),
+    ...limitations,
     "",
     "---",
     `<sub>Model: \`${model}\` · Commit: \`${pullRequest.head.sha.slice(0, 12)}\` · Scope: ${scope}. AI feedback can be wrong; verify findings before changing code.</sub>`,
@@ -272,6 +322,7 @@ async function runReview(options = {}) {
   const apiBase = environment.GITHUB_API_URL || "https://api.github.com";
   const endpoint = environment.REVIEW_MODELS_ENDPOINT || "https://models.github.ai/inference/chat/completions";
   const model = environment.REVIEW_MODEL || DEFAULT_MODEL;
+  const modelsApiVersion = environment.REVIEW_MODELS_API_VERSION || "2026-03-10";
   const maximumCharacters = boundedInteger(
     environment.REVIEW_MAX_DIFF_CHARS,
     DEFAULT_MAX_DIFF_CHARS,
@@ -297,6 +348,7 @@ async function runReview(options = {}) {
     model,
     messages,
     maximumTokens,
+    modelsApiVersion,
   );
   const result = await upsertReviewComment(
     fetchImpl,
@@ -343,6 +395,7 @@ module.exports = {
   COMMENT_MARKER,
   buildReviewMessages,
   callReviewModel,
+  describeInputLimitations,
   fetchChangedFiles,
   formatReviewComment,
   renderChangedFiles,

--- a/npm/scripts/review-agent.test.js
+++ b/npm/scripts/review-agent.test.js
@@ -8,6 +8,7 @@ const {
   COMMENT_MARKER,
   buildReviewMessages,
   callReviewModel,
+  describeInputLimitations,
   fetchChangedFiles,
   formatReviewComment,
   renderChangedFiles,
@@ -33,9 +34,13 @@ test("renderChangedFiles enforces the input budget and reports omissions", () =>
   assert.equal(rendered.text.length, 180);
   assert.equal(rendered.includedFiles, 1);
   assert.equal(rendered.partialFiles, 1);
+  assert.deepEqual(rendered.partialFileNames, ["src/app.rs"]);
   assert.equal(rendered.omittedFiles, 1);
+  assert.deepEqual(rendered.omittedFileNames, ["src/ui.rs"]);
   assert.equal(rendered.truncated, true);
   assert.match(rendered.text, /Patch truncated/);
+  assert.match(describeInputLimitations(rendered), /src\/app\.rs/);
+  assert.match(describeInputLimitations(rendered), /src\/ui\.rs/);
 });
 
 test("fetchChangedFiles paginates until GitHub returns a short page", async () => {
@@ -94,8 +99,10 @@ test("review prompt bounds contributor-controlled metadata", () => {
 
 test("callReviewModel sends a bounded deterministic request", async () => {
   let request;
+  let apiVersion;
   const fetchImpl = async (_url, options) => {
     request = JSON.parse(options.body);
+    apiVersion = options.headers["X-GitHub-Api-Version"];
     return jsonResponse({ choices: [{ message: { content: "## Verdict\nNo findings." } }] });
   };
 
@@ -106,11 +113,13 @@ test("callReviewModel sends a bounded deterministic request", async () => {
     "openai/gpt-4.1",
     [{ role: "user", content: "review" }],
     900,
+    "2099-01-01",
   );
   assert.equal(result, "## Verdict\nNo findings.");
   assert.equal(request.model, "openai/gpt-4.1");
   assert.equal(request.temperature, 0.1);
   assert.equal(request.max_tokens, 900);
+  assert.equal(apiVersion, "2099-01-01");
 });
 
 test("upsertReviewComment updates the existing bot report", async () => {
@@ -149,6 +158,24 @@ test("review comments neutralize mentions and marker injection", () => {
   );
   assert.equal(body.match(/gridbash-review-agent/g).length, 1);
   assert.match(body, /1234567890ab/);
+});
+
+test("truncated review comments name omitted files without allowing markup or mentions", () => {
+  const body = formatReviewComment(
+    "## Verdict\nReview was limited.",
+    { changed_files: 2, head: { sha: "1234567890abcdef" } },
+    {
+      includedFiles: 1,
+      truncated: true,
+      partialFileNames: ["src/@owner<partial>.rs"],
+      omittedFileNames: ["src/omitted.rs"],
+    },
+    "openai/gpt-4.1",
+  );
+
+  assert.match(body, /Review input limitations/);
+  assert.match(body, /@\u200bowner&lt;partial&gt;\.rs/);
+  assert.match(body, /src\/omitted\.rs/);
 });
 
 test("runReview completes the API-to-model-to-comment flow", async () => {


### PR DESCRIPTION
## Summary
- name truncated and omitted files in both the model prompt and PR report
- HTML-escape scope details and neutralize mentions before posting
- make the GitHub Models API version explicit and configurable
- add regression coverage for scope names, markup, mentions, and custom API versions

## Context
The newly deployed review agent dogfooded PR 180 and correctly disclosed that its input was truncated, but suggested naming the exact files. This follow-up adopts that useful feedback. The remaining suggestions were evaluated as non-actionable: all ASCII mentions are already neutralized, and transient/API failures already update the PR report and fail the workflow.

## Validation
- `npm run test:review-agent`: 9 passed
- `npm run test:launcher`: 11 passed
- `actionlint` on the workflow
- `git diff --check`

Refs #179