### PR TITLE
feat: add live README star history chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
       - run: node --test npm/scripts/review-agent.test.js
 
+      - run: node --test npm/scripts/update-star-history.test.js
+
       - run: node npm/scripts/prepare.js
 
       - name: Verify packaged Linux voice helper

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,44 @@
+name: Refresh Star History
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: refresh-star-history
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Update README chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: true
+
+      - name: Generate star history chart
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node npm/scripts/update-star-history.js
+
+      - name: Commit updated chart
+        shell: bash
+        run: |
+          if [[ -z "$(git status --porcelain -- docs/assets/gridbash-star-history.svg)" ]]; then
+            echo "Star history chart is already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/assets/gridbash-star-history.svg
+          git commit --signoff -m "docs: refresh star history chart"
+          git push

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ agents are all part of the same development session.
 - The [v1.0 acceptance checklist](docs/V1_ACCEPTANCE.md) defines the stable-release gates.
 - The [daemon architecture proposal](docs/DAEMON_ARCHITECTURE.md) defines the detach/reattach direction beyond v1.
 
+## Star History
+
+[![GridBash GitHub star history chart](docs/assets/gridbash-star-history.svg)](https://github.com/jasonsuhari/gridbash/stargazers)
+
+_Refreshed daily by the [Star History workflow](https://github.com/jasonsuhari/gridbash/actions/workflows/star-history.yml). Click the chart to see the current stargazers._
+
 ## Highlights
 
 - Real PTY-backed panes through Windows ConPTY or Unix PTYs via `portable-pty`.

--- a/docs/assets/gridbash-star-history.svg
+++ b/docs/assets/gridbash-star-history.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="480" viewBox="0 0 960 480" role="img" aria-labelledby="chart-title chart-description">
+  <title id="chart-title">jasonsuhari/gridbash GitHub star history</title>
+  <desc id="chart-description">Cumulative GitHub stars from Jul 5, 2026 through Jul 13, 2026. Current total: 41 stars.</desc>
+  <defs>
+    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.38" />
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0.03" />
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+  </defs>
+  <style>
+    .background { fill: #ffffff; }
+    .title { fill: #111827; font: 700 24px ui-sans-serif, system-ui, sans-serif; }
+    .subtitle { fill: #6b7280; font: 14px ui-sans-serif, system-ui, sans-serif; }
+    .axis-label { fill: #6b7280; font: 12px ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .grid { stroke: #e5e7eb; stroke-width: 1; }
+    .vertical { stroke-dasharray: 3 6; }
+    .line { fill: none; stroke: #2563eb; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }
+    .point { fill: #2563eb; stroke: #ffffff; stroke-width: 3; }
+    .count { fill: #2563eb; font: 700 16px ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .background { fill: #0d1117; }
+      .title { fill: #f0f6fc; }
+      .subtitle, .axis-label { fill: #8b949e; }
+      .grid { stroke: #30363d; }
+      .line { stroke: #58a6ff; }
+      .point { fill: #58a6ff; stroke: #0d1117; }
+      .count { fill: #58a6ff; }
+    }
+  </style>
+  <rect class="background" width="960" height="480" rx="18" />
+  <text class="title" x="72" y="38">Star history</text>
+  <text class="subtitle" x="72" y="61">jasonsuhari/gridbash · updated 2026-07-13</text>
+  <line class="grid" x1="72" y1="412.00" x2="918" y2="412.00" />
+<text class="axis-label" x="58" y="417.00" text-anchor="end">0</text>
+<line class="grid" x1="72" y1="345.20" x2="918" y2="345.20" />
+<text class="axis-label" x="58" y="350.20" text-anchor="end">10</text>
+<line class="grid" x1="72" y1="278.40" x2="918" y2="278.40" />
+<text class="axis-label" x="58" y="283.40" text-anchor="end">20</text>
+<line class="grid" x1="72" y1="211.60" x2="918" y2="211.60" />
+<text class="axis-label" x="58" y="216.60" text-anchor="end">30</text>
+<line class="grid" x1="72" y1="144.80" x2="918" y2="144.80" />
+<text class="axis-label" x="58" y="149.80" text-anchor="end">40</text>
+<line class="grid" x1="72" y1="78.00" x2="918" y2="78.00" />
+<text class="axis-label" x="58" y="83.00" text-anchor="end">50</text>
+  <line class="grid vertical" x1="72.00" y1="78" x2="72.00" y2="412" />
+<text class="axis-label" x="72.00" y="442" text-anchor="middle">Jul 5, 2026</text>
+<line class="grid vertical" x1="283.50" y1="78" x2="283.50" y2="412" />
+<text class="axis-label" x="283.50" y="442" text-anchor="middle">Jul 7, 2026</text>
+<line class="grid vertical" x1="495.00" y1="78" x2="495.00" y2="412" />
+<text class="axis-label" x="495.00" y="442" text-anchor="middle">Jul 9, 2026</text>
+<line class="grid vertical" x1="706.50" y1="78" x2="706.50" y2="412" />
+<text class="axis-label" x="706.50" y="442" text-anchor="middle">Jul 11, 2026</text>
+<line class="grid vertical" x1="918.00" y1="78" x2="918.00" y2="412" />
+<text class="axis-label" x="918.00" y="442" text-anchor="middle">Jul 13, 2026</text>
+  <path d="M 72.00,412.00 L 389.25,331.84 L 495.00,285.08 L 600.75,238.32 L 706.50,178.20 L 812.25,144.80 L 918.00,138.12 L 918.00,412.00 L 72,412.00 Z" fill="url(#area-gradient)" />
+  <path class="line" d="M 72.00,412.00 L 389.25,331.84 L 495.00,285.08 L 600.75,238.32 L 706.50,178.20 L 812.25,144.80 L 918.00,138.12" />
+  <circle class="point" cx="918.00" cy="138.12" r="6" filter="url(#glow)" />
+  <text class="count" x="906.00" y="124.12" text-anchor="end">41 ★</text>
+</svg>

--- a/docs/devlogs/2026-07-13-star-history-chart.md
+++ b/docs/devlogs/2026-07-13-star-history-chart.md
@@ -1,0 +1,34 @@
+# Automatically refreshed star history chart
+
+Date: 2026-07-13
+Release target: unreleased
+
+## Summary
+
+- Add a live README chart showing GridBash's cumulative GitHub star history.
+
+## What Changed
+
+- Added a dependency-free SVG generator backed by GitHub's timestamped
+  stargazer API.
+- Added a pinned daily/manual workflow that refreshes the chart with the
+  repository's short-lived token and commits only changed output.
+- Added accessible light/dark chart styling, deterministic tests, and npm
+  package inclusion for the generated asset.
+
+## Why It Matters
+
+- Visitors can see project growth directly in the README without giving a
+  third-party service a persistent or encrypted repository token.
+
+## Validation
+
+- `npm run test:star-history`
+- Live GitHub API generation against `jasonsuhari/gridbash`.
+- `actionlint` for the refresh workflow.
+- `npm pack --dry-run --ignore-scripts`.
+- Live workflow dispatch after merge.
+
+## Release Notes
+
+- The README now includes an automatically refreshed GitHub star history chart.

--- a/npm/scripts/update-star-history.js
+++ b/npm/scripts/update-star-history.js
@@ -1,0 +1,264 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const WIDTH = 960;
+const HEIGHT = 480;
+const PADDING = { top: 78, right: 42, bottom: 68, left: 72 };
+
+function requiredEnvironment(name, environment = process.env) {
+  const value = environment[name];
+  if (!value) {
+    throw new Error(`missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+async function requestJson(fetchImpl, url, token, accept = "application/vnd.github+json") {
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: accept,
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2026-03-10",
+    },
+  });
+  const text = await response.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : undefined;
+  } catch {
+    payload = text;
+  }
+  if (!response.ok) {
+    const message = typeof payload === "object" && payload?.message ? payload.message : text;
+    throw new Error(`GET ${new URL(url).pathname} failed with ${response.status}: ${message}`);
+  }
+  return payload;
+}
+
+async function fetchStarData(fetchImpl, apiBase, repository, token) {
+  const repositoryData = await requestJson(
+    fetchImpl,
+    `${apiBase}/repos/${repository}`,
+    token,
+  );
+  const stargazers = [];
+  for (let page = 1; page <= 1_000; page += 1) {
+    const batch = await requestJson(
+      fetchImpl,
+      `${apiBase}/repos/${repository}/stargazers?per_page=100&page=${page}`,
+      token,
+      "application/vnd.github.star+json",
+    );
+    if (!Array.isArray(batch)) {
+      throw new Error("stargazers response was not an array");
+    }
+    stargazers.push(...batch);
+    if (batch.length < 100) {
+      return { repository: repositoryData, stargazers };
+    }
+  }
+  throw new Error("repository exceeds the 100,000-star chart limit");
+}
+
+function utcDay(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`invalid date: ${value}`);
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeHistory(createdAt, stargazers, now = new Date()) {
+  const createdDay = utcDay(createdAt);
+  const today = utcDay(now);
+  const datedStars = stargazers
+    .map((entry) => entry.starred_at)
+    .filter(Boolean)
+    .map(utcDay)
+    .sort();
+  const pointsByDay = new Map([[createdDay, 0]]);
+  datedStars.forEach((day, index) => pointsByDay.set(day, index + 1));
+  pointsByDay.set(today, datedStars.length);
+
+  return [...pointsByDay.entries()]
+    .map(([day, stars]) => ({ day, time: Date.parse(`${day}T00:00:00Z`), stars }))
+    .sort((left, right) => left.time - right.time);
+}
+
+function niceStarMaximum(stars) {
+  if (stars <= 5) {
+    return 5;
+  }
+  const magnitude = 10 ** Math.floor(Math.log10(stars));
+  const interval = magnitude >= stars / 2 ? magnitude / 2 : magnitude;
+  return Math.ceil(stars / interval) * interval;
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function formatDate(time) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(time));
+}
+
+function renderChart(repository, points, generatedAt = new Date()) {
+  if (!points.length) {
+    throw new Error("star history requires at least one point");
+  }
+  const plotWidth = WIDTH - PADDING.left - PADDING.right;
+  const plotHeight = HEIGHT - PADDING.top - PADDING.bottom;
+  const firstTime = points[0].time;
+  const lastTime = points.at(-1).time;
+  const timeSpan = Math.max(1, lastTime - firstTime);
+  const currentStars = points.at(-1).stars;
+  const starLabel = `${currentStars} star${currentStars === 1 ? "" : "s"}`;
+  const starMaximum = niceStarMaximum(currentStars);
+  const x = (time) => PADDING.left + ((time - firstTime) / timeSpan) * plotWidth;
+  const y = (stars) => PADDING.top + plotHeight - (stars / starMaximum) * plotHeight;
+  const linePoints = points.map((point) => `${x(point.time).toFixed(2)},${y(point.stars).toFixed(2)}`);
+  if (linePoints.length === 1) {
+    linePoints.push(`${(PADDING.left + plotWidth).toFixed(2)},${y(points[0].stars).toFixed(2)}`);
+  }
+  const linePath = `M ${linePoints.join(" L ")}`;
+  const areaPath = `${linePath} L ${(PADDING.left + plotWidth).toFixed(2)},${(
+    PADDING.top + plotHeight
+  ).toFixed(2)} L ${PADDING.left},${(PADDING.top + plotHeight).toFixed(2)} Z`;
+
+  const horizontalGrid = Array.from({ length: 6 }, (_, index) => {
+    const value = (starMaximum * index) / 5;
+    const position = y(value);
+    return [
+      `<line class="grid" x1="${PADDING.left}" y1="${position.toFixed(2)}" x2="${
+        WIDTH - PADDING.right
+      }" y2="${position.toFixed(2)}" />`,
+      `<text class="axis-label" x="${PADDING.left - 14}" y="${(
+        position + 5
+      ).toFixed(2)}" text-anchor="end">${Math.round(value)}</text>`,
+    ].join("\n");
+  }).join("\n");
+
+  const dateTicks = Array.from({ length: 5 }, (_, index) => {
+    const ratio = index / 4;
+    const time = firstTime + timeSpan * ratio;
+    const position = PADDING.left + plotWidth * ratio;
+    return [
+      `<line class="grid vertical" x1="${position.toFixed(2)}" y1="${PADDING.top}" x2="${
+        position.toFixed(2)
+      }" y2="${PADDING.top + plotHeight}" />`,
+      `<text class="axis-label" x="${position.toFixed(2)}" y="${
+        HEIGHT - PADDING.bottom + 30
+      }" text-anchor="middle">${xmlEscape(formatDate(time))}</text>`,
+    ].join("\n");
+  }).join("\n");
+
+  const safeRepository = xmlEscape(repository);
+  const generatedDay = xmlEscape(utcDay(generatedAt));
+  const finalX = x(lastTime).toFixed(2);
+  const finalY = y(currentStars).toFixed(2);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img" aria-labelledby="chart-title chart-description">
+  <title id="chart-title">${safeRepository} GitHub star history</title>
+  <desc id="chart-description">Cumulative GitHub stars from ${xmlEscape(
+    formatDate(firstTime),
+  )} through ${xmlEscape(formatDate(lastTime))}. Current total: ${starLabel}.</desc>
+  <defs>
+    <linearGradient id="area-gradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.38" />
+      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0.03" />
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+  </defs>
+  <style>
+    .background { fill: #ffffff; }
+    .title { fill: #111827; font: 700 24px ui-sans-serif, system-ui, sans-serif; }
+    .subtitle { fill: #6b7280; font: 14px ui-sans-serif, system-ui, sans-serif; }
+    .axis-label { fill: #6b7280; font: 12px ui-monospace, SFMono-Regular, Consolas, monospace; }
+    .grid { stroke: #e5e7eb; stroke-width: 1; }
+    .vertical { stroke-dasharray: 3 6; }
+    .line { fill: none; stroke: #2563eb; stroke-width: 4; stroke-linecap: round; stroke-linejoin: round; }
+    .point { fill: #2563eb; stroke: #ffffff; stroke-width: 3; }
+    .count { fill: #2563eb; font: 700 16px ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .background { fill: #0d1117; }
+      .title { fill: #f0f6fc; }
+      .subtitle, .axis-label { fill: #8b949e; }
+      .grid { stroke: #30363d; }
+      .line { stroke: #58a6ff; }
+      .point { fill: #58a6ff; stroke: #0d1117; }
+      .count { fill: #58a6ff; }
+    }
+  </style>
+  <rect class="background" width="${WIDTH}" height="${HEIGHT}" rx="18" />
+  <text class="title" x="${PADDING.left}" y="38">Star history</text>
+  <text class="subtitle" x="${PADDING.left}" y="61">${safeRepository} · updated ${generatedDay}</text>
+  ${horizontalGrid}
+  ${dateTicks}
+  <path d="${areaPath}" fill="url(#area-gradient)" />
+  <path class="line" d="${linePath}" />
+  <circle class="point" cx="${finalX}" cy="${finalY}" r="6" filter="url(#glow)" />
+  <text class="count" x="${Math.max(PADDING.left, Number(finalX) - 12).toFixed(
+    2,
+  )}" y="${Math.max(PADDING.top + 18, Number(finalY) - 14).toFixed(
+    2,
+  )}" text-anchor="end">${currentStars} ★</text>
+</svg>
+`;
+}
+
+async function updateStarHistory(options = {}) {
+  const environment = options.environment || process.env;
+  const fetchImpl = options.fetchImpl || fetch;
+  const repository = requiredEnvironment("GITHUB_REPOSITORY", environment);
+  const token = requiredEnvironment("GITHUB_TOKEN", environment);
+  const apiBase = environment.GITHUB_API_URL || "https://api.github.com";
+  const now = new Date(environment.STAR_HISTORY_NOW || Date.now());
+  const root = options.root || path.resolve(__dirname, "..", "..");
+  const output = path.resolve(
+    root,
+    environment.STAR_HISTORY_OUTPUT || "docs/assets/gridbash-star-history.svg",
+  );
+  const data = await fetchStarData(fetchImpl, apiBase, repository, token);
+  const points = normalizeHistory(data.repository.created_at, data.stargazers, now);
+  const svg = renderChart(repository, points, now);
+  const previous = fs.existsSync(output) ? fs.readFileSync(output, "utf8") : undefined;
+  if (previous === svg) {
+    console.log(`star-history: ${path.relative(root, output)} is current`);
+    return false;
+  }
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, svg);
+  console.log(
+    `star-history: wrote ${path.relative(root, output)} with ${data.stargazers.length} stars`,
+  );
+  return true;
+}
+
+if (require.main === module) {
+  updateStarHistory().catch((error) => {
+    console.error(`star-history: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  fetchStarData,
+  niceStarMaximum,
+  normalizeHistory,
+  renderChart,
+  updateStarHistory,
+  xmlEscape,
+};

--- a/npm/scripts/update-star-history.test.js
+++ b/npm/scripts/update-star-history.test.js
@@ -1,0 +1,95 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  fetchStarData,
+  niceStarMaximum,
+  normalizeHistory,
+  renderChart,
+} = require("./update-star-history.js");
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("normalizeHistory sorts timestamps and accumulates stars by UTC day", () => {
+  const points = normalizeHistory(
+    "2026-07-01T12:00:00Z",
+    [
+      { starred_at: "2026-07-03T18:00:00Z" },
+      { starred_at: "2026-07-02T10:00:00Z" },
+      { starred_at: "2026-07-03T09:00:00Z" },
+    ],
+    new Date("2026-07-04T20:00:00Z"),
+  );
+
+  assert.deepEqual(
+    points.map(({ day, stars }) => ({ day, stars })),
+    [
+      { day: "2026-07-01", stars: 0 },
+      { day: "2026-07-02", stars: 1 },
+      { day: "2026-07-03", stars: 3 },
+      { day: "2026-07-04", stars: 3 },
+    ],
+  );
+});
+
+test("normalizeHistory safely handles a repository and stars from the same day", () => {
+  const points = normalizeHistory(
+    "2026-07-04T01:00:00Z",
+    [{ starred_at: "2026-07-04T02:00:00Z" }],
+    new Date("2026-07-04T20:00:00Z"),
+  );
+  assert.deepEqual(points.map(({ day, stars }) => ({ day, stars })), [
+    { day: "2026-07-04", stars: 1 },
+  ]);
+});
+
+test("niceStarMaximum leaves chart headroom at small and larger totals", () => {
+  assert.equal(niceStarMaximum(0), 5);
+  assert.equal(niceStarMaximum(4), 5);
+  assert.equal(niceStarMaximum(41), 50);
+  assert.equal(niceStarMaximum(132), 150);
+});
+
+test("fetchStarData requests timestamp media and paginates stargazers", async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, accept: options.headers.Accept });
+    if (url === "https://api.example/repos/owner/repo") {
+      return jsonResponse({ created_at: "2026-07-01T00:00:00Z" });
+    }
+    const page = new URL(url).searchParams.get("page");
+    return jsonResponse(
+      page === "1"
+        ? Array.from({ length: 100 }, (_, index) => ({
+            starred_at: `2026-07-${String((index % 9) + 1).padStart(2, "0")}T00:00:00Z`,
+          }))
+        : [{ starred_at: "2026-07-10T00:00:00Z" }],
+    );
+  };
+
+  const data = await fetchStarData(fetchImpl, "https://api.example", "owner/repo", "token");
+  assert.equal(data.stargazers.length, 101);
+  assert.equal(calls.length, 3);
+  assert.equal(calls[1].accept, "application/vnd.github.star+json");
+  assert.match(calls[2].url, /page=2/);
+});
+
+test("renderChart produces accessible responsive-theme SVG without invalid numbers", () => {
+  const points = normalizeHistory(
+    "2026-07-01T00:00:00Z",
+    [{ starred_at: "2026-07-02T00:00:00Z" }],
+    new Date("2026-07-03T00:00:00Z"),
+  );
+  const svg = renderChart("owner/<repo>", points, new Date("2026-07-03T00:00:00Z"));
+
+  assert.match(svg, /role="img"/);
+  assert.match(svg, /prefers-color-scheme: dark/);
+  assert.match(svg, /owner\/&lt;repo&gt;/);
+  assert.match(svg, /Current total: 1 star\./);
+  assert.doesNotMatch(svg, /NaN|Infinity/);
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "docs/devlogs/",
     "docs/releases/",
     "docs/AUTOMATED_REVIEW.md",
+    "docs/assets/gridbash-star-history.svg",
     "docs/RELEASING.md",
     "README.md",
     "LICENSE",
@@ -32,6 +33,7 @@
     "release": "node npm/scripts/release.js",
     "test:launcher": "node --test npm/scripts/gridbash-launcher.test.js",
     "test:review-agent": "node --test npm/scripts/review-agent.test.js",
+    "test:star-history": "node --test npm/scripts/update-star-history.test.js",
     "test": "cargo test"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- add an accessible cumulative GitHub star history chart to the README
- generate the SVG inside the repository from timestamped stargazer data instead of publishing a third-party repository token
- refresh the tracked chart daily or on manual dispatch with a pinned, minimally permissioned workflow
- test pagination, UTC-day aggregation, same-day repositories, axis scaling, XML escaping, and SVG accessibility
- include the chart asset in the npm package so the README link remains valid

## Why not the Star History embed?
GitHub restricted timestamped stargazer access in July 2026. Star History's legacy public SVG endpoint now returns HTTP 500, while its current live embed requires an encrypted fine-grained token in the public README. This implementation keeps credentials inside GitHub and uses only the workflow's short-lived repository token.

## Validation
- live GitHub API generation: 41 stars
- rendered SVG visually inspected at 960x480 in dark mode
- `npm run test:star-history`: 5 passed
- `npm run test:review-agent`: 9 passed
- `npm run test:launcher`: 11 passed
- `cargo test`: 130 passed, 1 ignored interactive PTY test
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `actionlint` for the new and updated workflows
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

Refs #182