### PR TITLE
feat: expand command CLI with Alt+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+t | Switch to the next tab |
 | Alt+s | Toggle focused pane selection |
 | Alt+a | Select all panes, or clear selection when all panes are selected |
-| Alt+c | Focus or unfocus the command bar |
+| Alt+c | Expand and focus the command line, or close it when focused |
 | Alt+Shift+V | Listen for one dictated utterance; press again to cancel |
 | Alt+h or F1 | Open or close the in-app help and shortcut legend |
 | Alt+p | Open settings for the focused pane; use Reload past history to refresh its visible conversation snapshot |
@@ -314,7 +314,6 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+g | Create or edit the focused pane's manager goal |
 | Alt+u | Stop the focused pane's manager goal |
 | Hover sleeping pane | Wake the pane and make its terminal contents visible again |
-| Alt+e | Expand or hide command output |
 | Alt+o | Open settings |
 | Alt+q | Quit |
 
@@ -330,7 +329,7 @@ When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter
 `r`, or `t` to restart it, or press `z` to put it to sleep. `Alt+Shift+t` restarts
 exited target panes directly.
 
-Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. When the one-line command bar is focused, typing stays in that bar; Enter runs the command from the cwd shown in the prompt and keeps output hidden until expanded.
+Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. Alt+C expands and focuses the command line with its captured output visible; typing stays in the command bar, and Enter runs the command from the cwd shown in the prompt. Press Alt+C again to close it and return input to the pane grid.
 
 The grid resizer uses the same row-and-column picker as startup, with active cells
 shown in blue. Shrinking removes live panes outside the retained upper-left

--- a/docs/devlogs/2026-07-13-expand-command-cli.md
+++ b/docs/devlogs/2026-07-13-expand-command-cli.md
@@ -1,0 +1,26 @@
+# Expand command CLI with Alt+C
+
+Date: 2026-07-13
+Release target: unreleased
+
+## Summary
+
+- Consolidated command-line focus and captured-output visibility under Alt+C.
+
+## What Changed
+
+- Alt+C now expands and focuses the command line, then closes it on the next press.
+- Removed the separate Alt+E command-output shortcut and updated the shortcut legends.
+
+## Why It Matters
+
+- Command output is visible as soon as users enter the command line, without a second shortcut.
+
+## Validation
+
+- Added a focused unit test for command-line focus and output visibility.
+- Ran Rust formatting, checks, and tests.
+
+## Release Notes
+
+- Alt+C now opens the full command-line view, including captured output.

--- a/src/app.rs
+++ b/src/app.rs
@@ -963,7 +963,6 @@ struct CommandLineState {
     input: String,
     cursor: usize,
     output_lines: Vec<String>,
-    output_expanded: bool,
     running: bool,
 }
 
@@ -984,9 +983,16 @@ impl CommandLineState {
             input: String::new(),
             cursor: 0,
             output_lines: Vec::new(),
-            output_expanded: false,
             running: false,
         }
+    }
+
+    fn toggle_focus(&mut self) {
+        self.focused = !self.focused;
+    }
+
+    fn output_expanded(&self) -> bool {
+        self.focused
     }
 
     fn insert_text(&mut self, text: &str) {
@@ -1720,10 +1726,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -3053,21 +3059,12 @@ impl App {
                 Ok(Some(false))
             }
             'c' => {
-                self.command_line.focused = !self.command_line.focused;
+                self.command_line.toggle_focus();
                 self.status = self.focus_status();
                 Ok(Some(false))
             }
             'v' if is_voice_shortcut(ch, modifiers) => {
                 self.toggle_voice_input();
-                Ok(Some(false))
-            }
-            'e' => {
-                self.command_line.output_expanded = !self.command_line.output_expanded;
-                self.status = if self.command_line.output_expanded {
-                    "command output expanded".into()
-                } else {
-                    "command output hidden".into()
-                };
                 Ok(Some(false))
             }
             'g' => {
@@ -5583,7 +5580,7 @@ impl App {
     }
 
     pub fn command_output_expanded(&self) -> bool {
-        self.command_line.output_expanded
+        self.command_line.output_expanded()
     }
 
     pub fn command_output_lines(&self) -> &[String] {
@@ -7528,6 +7525,21 @@ mod tests {
         assert_eq!(command.cursor_chars(), 3);
         assert!(command.backspace());
         assert_eq!(command.input, "abc");
+    }
+
+    #[test]
+    fn command_line_focus_controls_output_visibility() {
+        let mut command = CommandLineState::new(PathBuf::from("C:\\repo"));
+        assert!(!command.focused);
+        assert!(!command.output_expanded());
+
+        command.toggle_focus();
+        assert!(command.focused);
+        assert!(command.output_expanded());
+
+        command.toggle_focus();
+        assert!(!command.focused);
+        assert!(!command.output_expanded());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -243,7 +243,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -2367,7 +2367,7 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+n", "open a new tab"),
         ("Alt+t", "switch to next tab"),
         ("Alt+Shift+r", "rename current tab"),
-        ("Alt+c", "focus the command bar"),
+        ("Alt+c", "expand or close the command line"),
         ("Alt+p", "open focused-pane settings"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+l", "resize the grid"),


### PR DESCRIPTION
## Summary

- make Alt+C expand/focus the command line with captured output visible
- collapse the output whenever command-line focus is left
- remove the separate Alt+E output toggle and update shortcut documentation
- add a regression test and devlog entry

## Validation

- `cargo fmt -- --check`
- `cargo test command_line_focus_controls_output_visibility`
- `cargo test` (with GridBash profile environment variables cleared: 131 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`

Closes #186
