### PR TITLE
feat: add terminal activity summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ _Refreshed daily by the [Star History workflow](https://github.com/jasonsuhari/g
 - Modeless Alt shortcuts for pane focus, selection, rename, settings, pane-local goals, and quit.
 - Pane-local manager goals can review and follow up in one pane without observing or routing work across sibling panes.
 - Compact dark theme with focus, selection, sleep, exit, usage, and quiet-output cues.
-- Claude, Codex, and other agent panes show a compact conversation summary in the footer line.
+- Pane headers show live terminal activity, with a configured manager goal taking priority.
 - Built-in launch profiles for common CLI coding agents.
 - Startup dimension picker with a live grid preview.
 - `gridbash resume` for reopening prior grids with per-pane command and output context.
@@ -305,7 +305,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+c | Focus or unfocus the command bar |
 | Alt+Shift+V | Listen for one dictated utterance; press again to cancel |
 | Alt+h or F1 | Open or close the in-app help and shortcut legend |
-| Alt+p | Open settings for the focused pane; use Reload past history to refresh its visible conversation snapshot |
+| Alt+p | Open a focused-pane activity summary with its latest meaningful terminal output |
 | Alt+Shift+p | Open the previous panes list |
 | Alt+r | Rename the focused pane |
 | Alt+Shift+r | Rename the current tab |
@@ -318,12 +318,17 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+o | Open settings |
 | Alt+q | Quit |
 
-Focused-pane settings include sleep/wake and manager-goal controls. Press `z` to
+The focused-pane activity summary also includes pane settings, sleep/wake, and
+manager-goal controls. Press `z` to
 sleep or wake that pane, `g` to create or edit its manager goal, and `u` to stop
 the goal. A pane manager only reads and writes the pane that owns its goal.
 
-In focused-pane settings, press `Enter`, `Space`, or `r` to reload the visible
-conversation history snapshot. Press `Esc`, `q`, or `Alt+p` to close it, or
+Each pane's top border shows its latest activity summary instead of repeating
+the folder, branch, and launch profile. When a manager goal is set, the goal
+objective takes that spot until the goal is removed.
+
+In the activity summary, press `Enter`, `Space`, or `r` to refresh the latest
+captured terminal result. Press `Esc`, `q`, or `Alt+p` to close it, or
 `Alt+o` to switch to overall settings.
 
 When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter`,
@@ -371,7 +376,7 @@ does not forward mouse reporting; keyboard navigation remains available.
 
 Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
 
-Settings includes a General tab for local runtime display controls and an Auth tab for GridBash-wide Claude/Codex auth defaults and launch policy. Pane Settings lets each Claude or Codex pane select its own compatible auth account; applying a different account restarts only that pane.
+Settings includes a General tab for local runtime display controls and an Auth tab for GridBash-wide Claude/Codex auth defaults and launch policy. Pane Activity lets each Claude or Codex pane select its own compatible auth account; applying a different account restarts only that pane.
 
 Pane titles add a small quiet-output marker after roughly three seconds without output. The marker means a pane produced output and then went idle; it does not mean the process exited or completed its task.
 
@@ -407,7 +412,7 @@ Auth settings controls:
 | r | Refresh local account and usage status |
 | Esc / q | Close settings |
 
-For a Claude or Codex pane, open Pane Settings with `Alt+P`, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the pane's history snapshot.
+For a Claude or Codex pane, open Pane Activity with `Alt+p`, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the activity snapshot.
 
 Usage status is best-effort. GridBash reads local auth metadata, masks account emails, and uses short-timeout `curl.exe` (Windows) or `curl` (macOS) requests only while the Auth settings view is refreshed.
 
@@ -496,7 +501,7 @@ the Workload policy under Performance settings while GridBash is running.
 Pane managers use the OpenAI-compatible chat-completions endpoint, model, and API
 key under `[manager]`. These values can also be edited from the Manager tab in
 GridBash settings; the key is masked in the UI and stored in the local GridBash
-config. Press `Alt+g` or use focused-pane settings to create a goal. Reviews and
+config. Press `Alt+g` or use focused-pane activity controls to create a goal. Reviews and
 follow-ups remain bound to that pane even when panes are selected, reordered, or
 moved between tabs.
 

--- a/docs/devlogs/2026-07-12-add-terminal-activity-summary.md
+++ b/docs/devlogs/2026-07-12-add-terminal-activity-summary.md
@@ -1,0 +1,33 @@
+# Add terminal activity summary
+
+Date: 2026-07-12
+Release target: unreleased
+
+## Summary
+
+- Made `Alt+p` show a readable summary of the focused terminal's recent activity.
+
+## What Changed
+
+- Expanded focused-pane settings into a centered activity view that stays readable in dense grids.
+- Summarized the pane's latest meaningful output without surfacing raw terminal input.
+- Replaced folder, branch, and profile text in pane headers with live activity summaries.
+- Made a configured pane goal override the activity summary in that pane's header.
+- Preserved pane auth, rename, sleep, and manager-goal controls in the same view.
+- Corrected the status-bar labels for `Alt+p` and `Alt+Shift+p`.
+
+## Why It Matters
+
+- A quick shortcut now answers what a terminal has been working on without requiring users to scan its full scrollback.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo check`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `npm run test:launcher`
+
+## Release Notes
+
+- Pane headers now show current activity, or the pane goal when one is set; press `Alt+p` for the focused terminal's detailed output summary and controls.

--- a/src/app.rs
+++ b/src/app.rs
@@ -239,6 +239,12 @@ enum PaneRoute {
     Inactive { tab: usize, pane: usize },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaneOverlayShortcut {
+    Summary,
+    Previous,
+}
+
 struct PtyDrainBudget {
     started: Instant,
     events: usize,
@@ -1720,10 +1726,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+Shift+V voice | Alt+p pane settings | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+e output | Alt+x swap | Alt+z sleep | Alt+g pane goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -2315,6 +2321,12 @@ impl App {
         }
 
         self.applied_workloads.retain(|id, _| seen.contains(id));
+        self.pane_render_cache
+            .borrow_mut()
+            .retain(|id, _| seen.contains(id));
+        self.conversation_cache
+            .borrow_mut()
+            .retain(|id, _| seen.contains(id));
         if let Some(error) = failure
             && !self.workload_warning_shown
         {
@@ -3294,10 +3306,11 @@ impl App {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return KeyOutcome::Quit;
         }
-        if key.modifiers.contains(KeyModifiers::ALT)
-            && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
-        {
-            self.close_previous_panes();
+        if let Some(shortcut) = pane_overlay_shortcut(&key) {
+            match shortcut {
+                PaneOverlayShortcut::Summary => self.open_pane_settings(),
+                PaneOverlayShortcut::Previous => self.close_previous_panes(),
+            }
             return KeyOutcome::Render;
         }
 
@@ -3415,23 +3428,24 @@ impl App {
             .unwrap_or(0);
         self.pane_settings
             .open(pane_index, history_summary, auth_cursor);
-        self.status = format!("pane {} settings open", pane_index + 1);
+        self.status = format!("pane {} activity summary open", pane_index + 1);
     }
 
     fn close_pane_settings(&mut self) {
         let pane_number = self.pane_settings.pane_index + 1;
         self.pane_settings.close();
-        self.status = format!("pane {pane_number} settings closed");
+        self.status = format!("pane {pane_number} activity summary closed");
     }
 
     fn handle_pane_settings_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return Ok(KeyOutcome::Quit);
         }
-        if key.modifiers.contains(KeyModifiers::ALT)
-            && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
-        {
-            self.close_pane_settings();
+        if let Some(shortcut) = pane_overlay_shortcut(&key) {
+            match shortcut {
+                PaneOverlayShortcut::Summary => self.close_pane_settings(),
+                PaneOverlayShortcut::Previous => self.open_previous_panes(),
+            }
             return Ok(KeyOutcome::Render);
         }
         if key.modifiers.contains(KeyModifiers::ALT)
@@ -3576,7 +3590,7 @@ impl App {
 
         let history_summary = self.pane_history_summary(index);
         self.pane_settings.refresh_history(history_summary);
-        self.status = format!("reloaded past history for pane {}", index + 1);
+        self.status = format!("refreshed activity for pane {}", index + 1);
     }
 
     fn handle_rename_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -5448,11 +5462,12 @@ impl App {
             .collect()
     }
 
-    pub fn pane_settings_view(&self, index: usize) -> Option<PaneSettingsView> {
-        if !self.pane_settings.open || self.pane_settings.pane_index != index {
+    pub fn pane_settings_view(&self) -> Option<PaneSettingsView> {
+        if !self.pane_settings.open {
             return None;
         }
 
+        let index = self.pane_settings.pane_index;
         let pane = self.panes.get(index)?;
         let spec = self
             .launch_plan
@@ -5517,8 +5532,8 @@ impl App {
                         .as_ref()
                         .and_then(|plan| plan.panes.get(index))
                         .and_then(|pane| pane.agent_label());
-                    let summary = conversation_summary(pane.screen())
-                        .unwrap_or_else(|| "waiting for output".into());
+                    let summary =
+                        pane_activity_summary(pane).unwrap_or_else(|| "waiting for output".into());
                     let summary = agent_label
                         .map(|label| format!("{label} | {summary}"))
                         .unwrap_or(summary);
@@ -5615,13 +5630,6 @@ impl App {
             .map(|pane| pane.folder_name.as_str())
     }
 
-    pub fn pane_profile(&self, index: usize) -> Option<&str> {
-        self.launch_plan
-            .as_ref()
-            .and_then(|plan| plan.panes.get(index))
-            .map(|pane| pane.profile_name.as_str())
-    }
-
     pub fn pane_worktree(&self, index: usize) -> Option<&str> {
         self.launch_plan
             .as_ref()
@@ -5629,31 +5637,21 @@ impl App {
             .and_then(|pane| pane.worktree_name.as_deref())
     }
 
-    pub fn pane_auth(&self, index: usize) -> Option<&str> {
-        self.launch_plan
-            .as_ref()
-            .and_then(|plan| plan.panes.get(index))
-            .and_then(|pane| pane.auth_name.as_deref())
-    }
+    pub fn pane_header_summary(&self, index: usize, max_chars: usize) -> String {
+        if let Some(goal) = self.pane_goals.get(index).and_then(Option::as_ref) {
+            return pane_header_text(Some(&goal.objective), None, max_chars);
+        }
 
-    pub fn pane_conversation_footer(&self, index: usize, max_chars: usize) -> Option<String> {
-        let label = self
-            .launch_plan
-            .as_ref()
-            .and_then(|plan| plan.panes.get(index))
-            .and_then(|pane| pane.agent_label())?;
-        let pane = self.panes.get(index)?;
+        let Some(pane) = self.panes.get(index) else {
+            return String::new();
+        };
         let mut caches = self.conversation_cache.borrow_mut();
         let cache = caches.entry(pane.id()).or_default();
         if cache.revision != pane.screen_revision() {
             cache.revision = pane.screen_revision();
-            cache.summary = conversation_summary(pane.screen());
+            cache.summary = pane_activity_summary(pane);
         }
-        let summary = cache
-            .summary
-            .clone()
-            .unwrap_or_else(|| "waiting for conversation".into());
-        Some(truncate_chars(&format!("{label} | {summary}"), max_chars))
+        pane_header_text(None, cache.summary.as_deref(), max_chars)
     }
 
     fn pane_history_summary(&self, index: usize) -> String {
@@ -5661,8 +5659,7 @@ impl App {
             return "pane is no longer available".into();
         };
 
-        let summary =
-            conversation_summary(pane.screen()).unwrap_or_else(|| "waiting for output".into());
+        let summary = pane_activity_summary(pane).unwrap_or_else(|| "waiting for output".into());
         self.launch_plan
             .as_ref()
             .and_then(|plan| plan.panes.get(index))
@@ -7612,6 +7609,25 @@ mod tests {
         assert!(!settings.open);
         assert!(settings.history_summary.is_none());
     }
+
+    #[test]
+    fn pane_overlay_shortcuts_keep_summary_and_previous_panes_distinct() {
+        assert_eq!(
+            pane_overlay_shortcut(&KeyEvent::new(KeyCode::Char('p'), KeyModifiers::ALT)),
+            Some(PaneOverlayShortcut::Summary)
+        );
+        assert_eq!(
+            pane_overlay_shortcut(&KeyEvent::new(
+                KeyCode::Char('P'),
+                KeyModifiers::ALT | KeyModifiers::SHIFT
+            )),
+            Some(PaneOverlayShortcut::Previous)
+        );
+        assert_eq!(
+            pane_overlay_shortcut(&KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE)),
+            None
+        );
+    }
 }
 
 fn conversation_summary(screen: &Screen) -> Option<String> {
@@ -7623,6 +7639,40 @@ fn conversation_summary(screen: &Screen) -> Option<String> {
         .into_iter()
         .filter_map(|line| normalize_conversation_line(&line))
         .next()
+}
+
+fn pane_overlay_shortcut(key: &KeyEvent) -> Option<PaneOverlayShortcut> {
+    if !key.modifiers.contains(KeyModifiers::ALT)
+        || !matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
+    {
+        return None;
+    }
+
+    Some(if key.modifiers.contains(KeyModifiers::SHIFT) {
+        PaneOverlayShortcut::Previous
+    } else {
+        PaneOverlayShortcut::Summary
+    })
+}
+
+fn pane_activity_summary(pane: &PtyPane) -> Option<String> {
+    output_tail_summary(pane.output_tail()).or_else(|| conversation_summary(pane.screen()))
+}
+
+fn output_tail_summary(output_tail: &str) -> Option<String> {
+    output_tail
+        .lines()
+        .rev()
+        .filter_map(normalize_conversation_line)
+        .next()
+}
+
+fn pane_header_text(goal: Option<&str>, activity: Option<&str>, max_chars: usize) -> String {
+    let text = goal
+        .filter(|goal| !goal.trim().is_empty())
+        .map(|goal| format!("goal: {}", goal.trim()))
+        .unwrap_or_else(|| activity.unwrap_or("waiting for output").to_string());
+    truncate_chars(&text, max_chars)
 }
 
 fn normalize_conversation_line(line: &str) -> Option<String> {
@@ -7642,6 +7692,9 @@ fn is_low_signal_terminal_line(line: &str) -> bool {
     let lower = line.to_ascii_lowercase();
     lower == "esc"
         || lower == "escape"
+        || lower == "last output"
+        || lower == "previous commands"
+        || lower.starts_with("gridbash resumed pane history")
         || lower.contains("alt+q quit")
         || lower.contains("ctrl+c")
         || lower.contains("press enter")
@@ -7814,6 +7867,31 @@ mod selection_tests {
             conversation_summary(parser.screen()).as_deref(),
             Some("Assistant: tests are passing")
         );
+    }
+
+    #[test]
+    fn summarizes_latest_meaningful_output_tail_line() {
+        assert_eq!(
+            output_tail_summary(
+                "older work\nGridBash resumed pane history. Commands were not replayed.\nlatest result\nAlt+q quit\n"
+            )
+            .as_deref(),
+            Some("latest result")
+        );
+        assert_eq!(output_tail_summary("\nAlt+q quit\n"), None);
+    }
+
+    #[test]
+    fn pane_header_prefers_a_goal_over_the_activity_summary() {
+        assert_eq!(
+            pane_header_text(Some("finish the API"), Some("tests are passing"), 80),
+            "goal: finish the API"
+        );
+        assert_eq!(
+            pane_header_text(None, Some("tests are passing"), 80),
+            "tests are passing"
+        );
+        assert_eq!(pane_header_text(None, None, 80), "waiting for output");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,10 @@
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
-use std::path::Path;
 use vt100::Cell;
 
 use crate::{
@@ -53,7 +52,7 @@ pub struct PaneRenderCache {
 const QUIET_MARKER: &str = " *";
 const STATUS_BRAND: &str = " GridBash ";
 const PREVIOUS_PANES_BUTTON: &str = " Panes ";
-const PANE_SETTINGS_BUTTON: &str = " Pane ";
+const PANE_SETTINGS_BUTTON: &str = " Summary ";
 
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
@@ -85,7 +84,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let previous_panes_view = app.previous_panes_view();
     let follow_up_dialog = app.follow_up_dialog();
     let goal_editor_view = app.goal_editor_view();
-    let pane_settings_open = app.pane_settings_open();
+    let pane_settings_view = app.pane_settings_view();
+    let pane_settings_open = pane_settings_view.is_some();
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let help_open = app.help_open();
@@ -141,43 +141,26 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             palette,
         );
 
-        let folder = app
-            .pane_folder(index)
-            .map(label_name)
-            .unwrap_or_else(|| folder_label(pane.cwd()));
+        let header_summary = app.pane_header_summary(index, rect.width as usize);
         let usage = app.pane_usage_label(index);
         let title = pane_title(
             &app.pane_label(index),
             chrome.quiet_marker,
-            &folder,
-            app.pane_worktree(index),
-            app.pane_profile(index),
-            app.pane_auth(index),
+            &header_summary,
             usage.as_deref(),
             chrome.badge,
             app.compact_titles_enabled(),
+            rect.width.saturating_sub(2),
         );
 
-        let mut block = Block::default()
+        let block = Block::default()
             .borders(Borders::ALL)
             .border_style(chrome.border_style)
             .title(title);
-        if let Some(footer) =
-            app.pane_conversation_footer(index, rect.width.saturating_sub(4) as usize)
-        {
-            block = block.title_bottom(conversation_footer(footer, focused || selected));
-        }
 
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        if let Some(view) = app.pane_settings_view(index) {
-            let buttons = render_pane_settings(frame, inner, &view, palette);
-            pane_settings_rename_button = buttons.rename;
-            pane_settings_reload_button = buttons.reload;
-            pane_settings_sleep_button = buttons.sleep;
-            pane_settings_goal_button = buttons.goal;
-            pane_settings_stop_goal_button = buttons.stop_goal;
-        } else if sleeping {
+        if sleeping {
             render_sleeping_screen(frame, inner);
         } else {
             let selection = app.selection_for_pane(index);
@@ -243,7 +226,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+e output | Alt+p panes | Alt+P pane | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c command | Alt+Shift+V voice | Alt+e output | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -253,6 +236,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
     if app.settings_open() {
         render_settings(frame, area, app, palette);
+    } else if let Some(view) = pane_settings_view.as_ref() {
+        let buttons = render_pane_settings(frame, area, view, palette);
+        pane_settings_rename_button = buttons.rename;
+        pane_settings_reload_button = buttons.reload;
+        pane_settings_sleep_button = buttons.sleep;
+        pane_settings_goal_button = buttons.goal;
+        pane_settings_stop_goal_button = buttons.stop_goal;
     } else if let Some(dialog) = follow_up_dialog.as_ref() {
         render_follow_up_dialog(frame, area, dialog);
     }
@@ -297,37 +287,47 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn pane_title(
     label: &str,
     quiet_marker: &str,
-    folder: &str,
-    worktree: Option<&str>,
-    profile: Option<&str>,
-    auth: Option<&str>,
+    summary: &str,
     usage: Option<&str>,
     badge: &str,
     compact: bool,
+    max_width: u16,
 ) -> String {
-    if compact {
-        return format!(" {label}{quiet_marker}{badge} ");
+    let max_width = max_width as usize;
+    if max_width == 0 {
+        return String::new();
     }
 
-    let mut parts = vec![format!("{label}{quiet_marker}"), folder.to_string()];
-    if let Some(worktree) = worktree.filter(|value| !value.is_empty()) {
-        parts.push(worktree.to_string());
-    }
-    if let Some(profile) = profile.filter(|value| !value.is_empty()) {
-        parts.push(profile.to_string());
-    }
-    if let Some(auth) = auth.filter(|value| !value.is_empty()) {
-        parts.push(auth.to_string());
-    }
-    if let Some(usage) = usage.filter(|value| !value.is_empty()) {
+    let usage = if !compact && max_width >= 48 {
+        usage.filter(|value| !value.is_empty())
+    } else {
+        None
+    };
+    let summary_reserve = if summary.is_empty() {
+        0
+    } else {
+        3 + summary.chars().count().min(8)
+    };
+    let reserved = 2
+        + quiet_marker.chars().count()
+        + badge.chars().count()
+        + usage
+            .map(|value| 3 + value.chars().count())
+            .unwrap_or_default()
+        + summary_reserve;
+    let label = truncate_text(label, max_width.saturating_sub(reserved).max(1));
+    let mut parts = vec![format!("{label}{quiet_marker}{badge}")];
+    if let Some(usage) = usage {
         parts.push(usage.to_string());
     }
+    if !summary.is_empty() {
+        parts.push(summary.to_string());
+    }
 
-    format!(" {}{} ", parts.join(" | "), badge)
+    truncate_text(&format!(" {} ", parts.join(" | ")), max_width)
 }
 
 fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &GridPalette) {
@@ -661,17 +661,51 @@ fn render_pane_settings(
         return PaneSettingsButtons::default();
     }
 
-    frame.render_widget(Clear, area);
-    let lines = pane_settings_lines(view, area.width, palette);
-    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), area);
+    let width = area.width.saturating_sub(4).min(100).max(area.width.min(1));
+    let inner_width = width.saturating_sub(2);
+    let lines = pane_settings_lines(view, inner_width, palette);
+    let desired_height = (lines.len() as u16).saturating_add(2);
+    let height = area
+        .height
+        .saturating_sub(2)
+        .min(desired_height)
+        .max(area.height.min(1));
+    let modal = Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    };
+    let shadow = settings_shadow_rect(area, modal);
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+
+    frame.render_widget(Clear, modal);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Pane Activity ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), inner);
 
     PaneSettingsButtons {
-        rename: pane_settings_rename_rect(area, view.auth_kind.is_some()),
-        reload: pane_settings_reload_rect(area, view.auth_kind.is_some()),
-        sleep: pane_settings_sleep_rect(area, view.auth_kind.is_some(), view.goal.is_some()),
-        goal: pane_settings_goal_rect(area, view.auth_kind.is_some(), view.goal.is_some()),
+        rename: pane_settings_rename_rect(inner, view.auth_kind.is_some()),
+        reload: pane_settings_reload_rect(inner, view.auth_kind.is_some()),
+        sleep: pane_settings_sleep_rect(inner, view.auth_kind.is_some(), view.goal.is_some()),
+        goal: pane_settings_goal_rect(inner, view.auth_kind.is_some(), view.goal.is_some()),
         stop_goal: pane_settings_stop_goal_rect(
-            area,
+            inner,
             view.auth_kind.is_some(),
             view.goal.is_some(),
         ),
@@ -716,7 +750,10 @@ fn pane_settings_lines(
 
     if width < 36 {
         lines.push(Line::from(Span::styled(
-            fixed_width(" Pane Settings", width as usize),
+            fixed_width(
+                &format!(" Pane {} {}", view.index + 1, view.label),
+                width as usize,
+            ),
             Style::default()
                 .fg(palette.focus())
                 .bg(SETTINGS_BG)
@@ -736,6 +773,13 @@ fn pane_settings_lines(
                 Style::default().fg(SETTINGS_TEXT),
             )));
         }
+        lines.push(Line::from(Span::styled(
+            fixed_width(
+                &format!(" latest: {}", view.history_summary),
+                width as usize,
+            ),
+            Style::default().fg(SETTINGS_TEXT),
+        )));
         lines.push(pane_settings_rename_line(width, palette));
         lines.push(pane_settings_reload_line(width, palette));
         lines.push(pane_settings_sleep_line(width, view.sleeping, palette));
@@ -750,7 +794,7 @@ fn pane_settings_lines(
     lines.push(Line::from(vec![
         Span::raw("  "),
         Span::styled(
-            "Pane Settings",
+            "Pane Activity",
             Style::default()
                 .fg(palette.focus())
                 .add_modifier(Modifier::BOLD),
@@ -814,14 +858,15 @@ fn pane_settings_lines(
         lines.push(Line::from(""));
     }
     lines.push(settings_section(
-        "HISTORY",
-        "visible conversation snapshot",
+        "RECENT ACTIVITY",
+        "latest meaningful terminal output",
         width,
     ));
     lines.push(Line::from(vec![
         Span::raw("  "),
+        Span::styled("summary  ", Style::default().fg(SETTINGS_MUTED)),
         Span::styled(
-            truncate_text(&view.history_summary, width.saturating_sub(2) as usize),
+            truncate_text(&view.history_summary, width.saturating_sub(11) as usize),
             Style::default().fg(SETTINGS_TEXT),
         ),
     ]));
@@ -869,7 +914,7 @@ fn pane_settings_rename_line(width: u16, palette: &GridPalette) -> Line<'static>
 }
 
 fn pane_settings_reload_line(width: u16, palette: &GridPalette) -> Line<'static> {
-    pane_settings_action_line("[ Reload past history ]", width, palette.focus())
+    pane_settings_action_line("[ Refresh activity ]", width, palette.focus())
 }
 
 fn render_goal_editor(frame: &mut Frame<'_>, area: Rect, editor: &GoalEditorView) {
@@ -980,7 +1025,7 @@ fn pane_settings_command_bar(width: u16, has_auth: bool) -> Line<'static> {
         command_key("n"),
         Span::styled(" rename  ", Style::default().fg(Color::Gray)),
         command_key("r"),
-        Span::styled(" reload  ", Style::default().fg(Color::Gray)),
+        Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
         command_key("z"),
         Span::styled(" sleep/wake  ", Style::default().fg(Color::Gray)),
         command_key("g"),
@@ -1001,9 +1046,9 @@ fn pane_settings_command_bar(width: u16, has_auth: bool) -> Line<'static> {
 
 fn pane_settings_rename_rect(area: Rect, has_auth: bool) -> Option<Rect> {
     let row = if area.width < 36 && has_auth {
-        2
+        3
     } else if area.width < 36 {
-        1
+        2
     } else {
         6
     };
@@ -1012,9 +1057,9 @@ fn pane_settings_rename_rect(area: Rect, has_auth: bool) -> Option<Rect> {
 
 fn pane_settings_reload_rect(area: Rect, has_auth: bool) -> Option<Rect> {
     let row = if area.width < 36 && has_auth {
-        3
+        4
     } else if area.width < 36 {
-        2
+        3
     } else {
         7
     };
@@ -1023,7 +1068,7 @@ fn pane_settings_reload_rect(area: Rect, has_auth: bool) -> Option<Rect> {
 
 fn pane_settings_sleep_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
     let row = if area.width < 36 {
-        if has_auth { 4 } else { 3 }
+        if has_auth { 5 } else { 4 }
     } else if has_goal {
         10
     } else {
@@ -1034,7 +1079,7 @@ fn pane_settings_sleep_rect(area: Rect, has_auth: bool, has_goal: bool) -> Optio
 
 fn pane_settings_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
     let row = if area.width < 36 {
-        if has_auth { 5 } else { 4 }
+        if has_auth { 6 } else { 5 }
     } else if has_goal {
         11
     } else {
@@ -1048,7 +1093,7 @@ fn pane_settings_stop_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> O
         return None;
     }
     let row = if area.width < 36 {
-        if has_auth { 6 } else { 5 }
+        if has_auth { 7 } else { 6 }
     } else {
         12
     };
@@ -2064,24 +2109,6 @@ fn kind_color(kind: AgentKind) -> Color {
     }
 }
 
-fn conversation_footer(summary: String, emphasized: bool) -> Line<'static> {
-    let summary_style = if emphasized {
-        Style::default()
-            .fg(Color::LightCyan)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Gray)
-    };
-
-    Line::from(vec![
-        Span::raw(" "),
-        Span::styled("conv ", Style::default().fg(Color::Cyan)),
-        Span::styled(summary, summary_style),
-        Span::raw(" "),
-    ])
-    .alignment(Alignment::Center)
-}
-
 fn settings_summary(width: u16) -> String {
     let text = if width < 70 {
         "Refine pane chrome, todo prompts, and highlight color."
@@ -2368,7 +2395,7 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+t", "switch to next tab"),
         ("Alt+Shift+r", "rename current tab"),
         ("Alt+c", "focus the command bar"),
-        ("Alt+p", "open focused-pane settings"),
+        ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+l", "resize the grid"),
         ("Alt+r", "rename focused pane"),
@@ -2613,25 +2640,6 @@ fn wrap_dialog_text(text: &str, width: usize, max_lines: usize) -> Vec<String> {
     }
 
     lines
-}
-
-fn folder_label(cwd: &Path) -> String {
-    let label = cwd
-        .file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| cwd.display().to_string());
-
-    label_name(&label)
-}
-
-fn label_name(name: &str) -> String {
-    let mut label = name.to_string();
-    if !matches!(label.chars().last(), Some('/') | Some('\\')) {
-        label.push('/');
-    }
-
-    label
 }
 
 fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
@@ -2901,62 +2909,34 @@ mod tests {
     }
 
     #[test]
-    fn pane_title_uses_custom_label_in_number_slot() {
+    fn pane_title_uses_activity_summary_instead_of_launch_metadata() {
         assert_eq!(
             pane_title(
                 "api",
                 "",
-                "gridbash/",
-                Some("feat/rename-panes"),
-                None,
-                None,
+                "reviewing the latest changes",
                 None,
                 "",
                 false,
+                120,
             ),
-            " api | gridbash/ | feat/rename-panes "
+            " api | reviewing the latest changes "
         );
         assert_eq!(
-            pane_title(
-                "1",
-                "",
-                "gridbash/",
-                None,
-                None,
-                None,
-                None,
-                " selected",
-                false,
-            ),
-            " 1 | gridbash/ selected "
+            pane_title("1", "", "tests passed", None, " selected", false, 120),
+            " 1 selected | tests passed "
         );
         assert_eq!(
             pane_title(
                 "2",
                 "",
-                "gridbash/",
-                None,
-                None,
-                None,
+                "goal: finish the API",
                 Some("5h 80% left"),
                 " selected",
                 false,
+                120,
             ),
-            " 2 | gridbash/ | 5h 80% left selected "
-        );
-        assert_eq!(
-            pane_title(
-                "api",
-                "",
-                "gridbash/",
-                Some("main"),
-                Some("codex"),
-                Some("codex-2"),
-                Some("5h 80% left"),
-                " selected",
-                false,
-            ),
-            " api | gridbash/ | main | codex | codex-2 | 5h 80% left selected "
+            " 2 selected | 5h 80% left | goal: finish the API "
         );
     }
 
@@ -2966,42 +2946,90 @@ mod tests {
             pane_title(
                 "api",
                 QUIET_MARKER,
-                "gridbash/",
-                None,
-                None,
-                None,
+                "waiting for output",
                 None,
                 "",
                 false,
+                120,
             ),
-            " api * | gridbash/ "
+            " api * | waiting for output "
         );
     }
 
     #[test]
-    fn compact_pane_title_omits_folder_and_profile_details() {
+    fn compact_pane_title_keeps_summary_but_omits_usage_details() {
         assert_eq!(
             pane_title(
                 "api",
                 QUIET_MARKER,
-                "gridbash/",
-                Some("main"),
-                Some("codex"),
-                Some("codex-2"),
+                "reviewing the latest changes",
                 Some("5h 80% left"),
                 " selected",
                 true,
+                120,
             ),
-            " api * selected "
+            " api * selected | reviewing the latest changes "
         );
     }
 
     #[test]
-    fn conversation_footer_is_centered() {
-        assert_eq!(
-            conversation_footer("reviewing changes".into(), false).alignment,
-            Some(Alignment::Center)
+    fn narrow_pane_title_keeps_state_before_truncated_activity() {
+        let title = pane_title(
+            "very-long-pane-name",
+            QUIET_MARKER,
+            "reviewing the latest changes",
+            Some("5h 80% left"),
+            " selected",
+            false,
+            30,
         );
+
+        assert!(title.chars().count() <= 30);
+        assert!(title.contains("selected"));
+        assert!(title.contains("review"));
+        assert!(!title.contains("5h 80% left"));
+    }
+
+    #[test]
+    fn pane_activity_lines_show_latest_output_at_wide_and_narrow_widths() {
+        let view = PaneSettingsView {
+            index: 1,
+            label: "api".into(),
+            folder: "gridbash".into(),
+            worktree: Some("feat/activity-summary".into()),
+            history_summary: "all focused tests passed".into(),
+            focused: true,
+            selected: false,
+            sleeping: false,
+            exited: false,
+            auth_kind: None,
+            auth_options: Vec::new(),
+            auth_cursor: 0,
+            goal: None,
+            manager_configured: false,
+        };
+        let line_text = |line: &Line<'_>| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        };
+
+        let wide = pane_settings_lines(&view, 80, &GridPalette::default())
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(wide.contains("RECENT ACTIVITY"));
+        assert!(wide.contains("summary  all focused tests passed"));
+        assert!(!wide.contains("run the focused tests"));
+
+        let narrow = pane_settings_lines(&view, 30, &GridPalette::default())
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(narrow.contains("latest: all focused tests"));
     }
 
     #[test]
@@ -3016,11 +3044,11 @@ mod tests {
         );
         assert_eq!(
             pane_settings_rename_rect(Rect::new(5, 10, 20, 5), true),
-            Some(Rect::new(5, 12, 20, 1))
+            Some(Rect::new(5, 13, 20, 1))
         );
         assert_eq!(
             pane_settings_reload_rect(Rect::new(5, 10, 20, 5), true),
-            Some(Rect::new(5, 13, 20, 1))
+            Some(Rect::new(5, 14, 20, 1))
         );
         assert_eq!(
             pane_settings_rename_rect(Rect::new(5, 10, 40, 6), false),


### PR DESCRIPTION
## Summary

- make `Alt+p` open a centered focused-pane activity summary while preserving pane controls
- replace folder/branch/profile header metadata with live output summaries, with pane goals taking priority
- keep activity privacy-safe by reading bounded terminal output instead of raw submitted input
- preserve compact-title summaries and distinguish `Alt+p` from `Alt+Shift+p` across open overlays

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
- `cargo test` (134 passed, 1 ignored; GridBash profile environment cleared for the first-run onboarding test)
- `cargo clippy --all-targets -- -D warnings`
- `npm run test:launcher` (11 passed)

Closes #185
