### PR TITLE
chore-automate-cross-platform-nightly-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
 
       - run: node --test npm/scripts/update-star-history.test.js
 
+      - run: node --test npm/scripts/version.test.js
+
       - run: node npm/scripts/prepare.js
 
       - name: Verify packaged Linux voice helper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,33 +3,51 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "patch, minor, major, or an exact version; macOS previews use x.y.z-macos.N"
+      channel:
+        description: "Create a versioned release or an ephemeral nightly from main."
         required: true
+        type: choice
+        options:
+          - release
+          - nightly
+        default: release
+      version:
+        description: "For releases: patch, minor, major, or an exact version. macOS previews use x.y.z-macos.N."
+        required: false
         default: "patch"
       notes:
-        description: "Devlog or release notes path. Defaults to latest docs/devlogs entry."
+        description: "For releases: devlog or release notes path. Defaults to the latest devlog."
         required: false
         default: ""
       skip_checks:
-        description: "Skip release validation checks. Use only for emergency retries."
+        description: "For releases: skip preparation checks. Use only for emergency retries."
         required: false
         type: boolean
         default: false
+      force_nightly:
+        description: "For nightlies: publish again even when main has not changed."
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: "17 08 * * *"
   push:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
+concurrency:
+  group: release-${{ (github.event_name == 'schedule' || inputs.channel == 'nightly') && 'nightly' || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   prepare:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.channel == 'release'
     runs-on: windows-latest
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,34 +76,104 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           $requested = "${{ inputs.version }}"
-          $existingTag = "v$requested"
-          git fetch origin "refs/tags/${existingTag}:refs/tags/${existingTag}" --force 2>$null
-          $tagExists = $LASTEXITCODE -eq 0
-          if (-not $tagExists) {
-            git rev-parse --verify $existingTag *> $null
+          $tagExists = $false
+          if ($requested -match "^\d+\.\d+\.\d+(?:-.+)?$") {
+            $existingTag = "v$requested"
+            git fetch origin "refs/tags/${existingTag}:refs/tags/${existingTag}" --force 2>$null
             $tagExists = $LASTEXITCODE -eq 0
+            if (-not $tagExists) {
+              git rev-parse --verify $existingTag *> $null
+              $tagExists = $LASTEXITCODE -eq 0
+            }
           }
 
           if ($tagExists) {
             Write-Output "$existingTag already exists; publishing that tag."
-            "tag=$existingTag" >> $env:GITHUB_OUTPUT
-            exit 0
+            $version = $requested
+          } else {
+            $releaseArgs = @($requested, "--push", "--yes")
+            if ("${{ inputs.notes }}") {
+              $releaseArgs += @("--notes", "${{ inputs.notes }}")
+            }
+            if ("${{ inputs.skip_checks }}" -eq "true") {
+              $releaseArgs += "--skip-checks"
+            }
+
+            node npm/scripts/release.js @releaseArgs
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+            $version = node -p "require('./package.json').version"
           }
 
-          $releaseArgs = @($requested, "--push", "--yes")
-          if ("${{ inputs.notes }}") {
-            $releaseArgs += @("--notes", "${{ inputs.notes }}")
-          }
-          if ("${{ inputs.skip_checks }}" -eq "true") {
-            $releaseArgs += "--skip-checks"
-          }
+          "tag=v$version" >> $env:GITHUB_OUTPUT
+          "version=$version" >> $env:GITHUB_OUTPUT
 
-          node npm/scripts/release.js @releaseArgs
-          "tag=v$requested" >> $env:GITHUB_OUTPUT
+  nightly-meta:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'nightly')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.meta.outputs.publish }}
+      ref: ${{ steps.meta.outputs.ref }}
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Choose immutable nightly version
+        id: meta
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE_NIGHTLY: ${{ github.event_name == 'workflow_dispatch' && inputs.force_nightly || false }}
+        run: |
+          set -euo pipefail
+          date_utc="$(date -u +%Y%m%d)"
+          main_sha="$(git rev-parse HEAD)"
+          version="$(node npm/scripts/version.js nightly "$date_utc" "$GITHUB_RUN_NUMBER" "$main_sha")"
+          short_sha="${main_sha:0:12}"
+          current="$(npm view gridbash dist-tags.nightly 2>/dev/null || true)"
+          publish=true
+
+          if [[ "$FORCE_NIGHTLY" != "true" && "$current" == *".g${short_sha}" ]] && gh release view "v$current" >/dev/null 2>&1; then
+            echo "main is unchanged from $current; skipping publication."
+            publish=false
+          fi
+
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          echo "ref=$main_sha" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Nightly"
+            echo
+            echo "- Version: $version"
+            echo "- Commit: $main_sha"
+            echo "- Publish: $publish"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-native:
-    needs: prepare
-    if: ${{ always() && (github.event_name == 'push' || needs.prepare.result == 'success') }}
+    needs: [prepare, nightly-meta]
+    if: >-
+      always() &&
+      (
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && inputs.channel == 'release' && needs.prepare.result == 'success') ||
+        (
+          (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'nightly')) &&
+          needs.nightly-meta.result == 'success' &&
+          needs.nightly-meta.outputs.publish == 'true'
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -101,19 +189,29 @@ jobs:
           - runner: macos-15-intel
             platform_key: darwin-x64
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     env:
+      IS_NIGHTLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'nightly') }}
       MACOSX_DEPLOYMENT_TARGET: "13.0"
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && needs.prepare.outputs.tag || github.ref_name }}
+      RELEASE_REF: ${{ github.event_name == 'push' && github.ref_name || (github.event_name == 'workflow_dispatch' && inputs.channel == 'release') && needs.prepare.outputs.tag || needs.nightly-meta.outputs.ref }}
+      RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || (github.event_name == 'workflow_dispatch' && inputs.channel == 'release') && needs.prepare.outputs.tag || needs.nightly-meta.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.nightly-meta.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.RELEASE_REF }}
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Stamp nightly version
+        if: env.IS_NIGHTLY == 'true'
+        run: node npm/scripts/version.js set "${{ env.RELEASE_VERSION }}"
 
       - name: Install Linux voice build dependencies
         if: runner.os == 'Linux'
@@ -133,6 +231,8 @@ jobs:
 
       - run: node --test npm/scripts/gridbash-launcher.test.js
 
+      - run: node --test npm/scripts/version.test.js
+
       - run: node npm/scripts/prepare.js
 
       - name: Verify packaged Linux voice helper
@@ -148,21 +248,36 @@ jobs:
           name: native-${{ matrix.platform_key }}
           path: npm/platforms/${{ matrix.platform_key }}/*.tgz
           if-no-files-found: error
+          retention-days: 7
 
   publish:
-    needs: [prepare, build-native]
+    needs: [prepare, nightly-meta, build-native]
     if: ${{ always() && needs.build-native.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && needs.prepare.outputs.tag || github.ref_name }}
+      IS_NIGHTLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'nightly') }}
+      RELEASE_REF: ${{ github.event_name == 'push' && github.ref_name || (github.event_name == 'workflow_dispatch' && inputs.channel == 'release') && needs.prepare.outputs.tag || needs.nightly-meta.outputs.ref }}
+      RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || (github.event_name == 'workflow_dispatch' && inputs.channel == 'release') && needs.prepare.outputs.tag || needs.nightly-meta.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.nightly-meta.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.RELEASE_REF }}
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Use an npm CLI with trusted publishing support
+        run: npm install --global npm@11
+
+      - name: Stamp nightly version
+        if: env.IS_NIGHTLY == 'true'
+        run: node npm/scripts/version.js set "${{ env.RELEASE_VERSION }}"
 
       - uses: actions/download-artifact@v4
         with:
@@ -174,6 +289,7 @@ jobs:
         id: root-pack
         shell: bash
         run: |
+          set -euo pipefail
           tarball="$(npm pack --ignore-scripts | tail -n 1)"
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
 
@@ -184,9 +300,12 @@ jobs:
           ROOT_TARBALL: ${{ steps.root-pack.outputs.tarball }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
           version="${RELEASE_TAG#v}"
           dist_tag="latest"
-          if [[ "$version" == *-* ]]; then
+          if [[ "$version" == *"-nightly."* ]]; then
+            dist_tag="nightly"
+          elif [[ "$version" == *-* ]]; then
             dist_tag="next"
           fi
 
@@ -196,12 +315,60 @@ jobs:
             unset NODE_AUTH_TOKEN
           fi
 
+          expected=(
+            gridbash-win32-x64
+            gridbash-linux-x64
+            gridbash-linux-arm64
+            gridbash-darwin-arm64
+            gridbash-darwin-x64
+          )
+          native_tarballs=(artifacts/*.tgz)
+          if [[ "${#native_tarballs[@]}" -ne "${#expected[@]}" ]]; then
+            echo "expected ${#expected[@]} native tarballs, found ${#native_tarballs[@]}" >&2
+            exit 1
+          fi
+
+          declare -A tarball_by_name=()
+          package_field() {
+            local tarball="$1"
+            local field="$2"
+            tar -xOf "$tarball" package/package.json |
+              node -e "const fs=require('fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8'))[process.argv[1]])" "$field"
+          }
+
+          for tarball in "${native_tarballs[@]}"; do
+            name="$(package_field "$tarball" name)"
+            package_version="$(package_field "$tarball" version)"
+            if [[ "$package_version" != "$version" ]]; then
+              echo "$tarball contains $name@$package_version; expected $version" >&2
+              exit 1
+            fi
+            case " ${expected[*]} " in
+              *" $name "*) ;;
+              *)
+                echo "unexpected native package: $name" >&2
+                exit 1
+                ;;
+            esac
+            if [[ -n "${tarball_by_name[$name]:-}" ]]; then
+              echo "duplicate native package: $name" >&2
+              exit 1
+            fi
+            tarball_by_name[$name]="$tarball"
+          done
+
+          root_name="$(package_field "$ROOT_TARBALL" name)"
+          root_version="$(package_field "$ROOT_TARBALL" version)"
+          if [[ "$root_name" != "gridbash" || "$root_version" != "$version" ]]; then
+            echo "root tarball contains $root_name@$root_version; expected gridbash@$version" >&2
+            exit 1
+          fi
+
           publish_if_missing() {
             local tarball="$1"
-            local manifest name package_version published
-            manifest="$(tar -xOf "$tarball" package/package.json)"
-            name="$(node -e 'const fs=require("fs"); console.log(JSON.parse(fs.readFileSync(0,"utf8")).name)' <<<"$manifest")"
-            package_version="$(node -e 'const fs=require("fs"); console.log(JSON.parse(fs.readFileSync(0,"utf8")).version)' <<<"$manifest")"
+            local name package_version published
+            name="$(package_field "$tarball" name)"
+            package_version="$(package_field "$tarball" version)"
             published="$(npm view "$name@$package_version" version 2>/dev/null || true)"
             if [[ "$published" == "$package_version" ]]; then
               echo "$name@$package_version already published; skipping."
@@ -210,8 +377,12 @@ jobs:
             npm publish "$tarball" --access public --provenance --tag "$dist_tag"
           }
 
-          for tarball in artifacts/*.tgz; do
-            publish_if_missing "$tarball"
+          for name in "${expected[@]}"; do
+            if [[ -z "${tarball_by_name[$name]:-}" ]]; then
+              echo "missing native package: $name" >&2
+              exit 1
+            fi
+            publish_if_missing "${tarball_by_name[$name]}"
           done
           publish_if_missing "$ROOT_TARBALL"
 
@@ -222,20 +393,46 @@ jobs:
           ROOT_TARBALL: ${{ steps.root-pack.outputs.tarball }}
         run: |
           set -euo pipefail
+          version="${RELEASE_TAG#v}"
           notes="docs/releases/$RELEASE_TAG.md"
-          if [[ ! -f "$notes" ]]; then
+
+          if [[ "$IS_NIGHTLY" == "true" ]]; then
+            notes="RELEASE_NOTES.md"
+            {
+              echo "# GridBash $version"
+              echo
+              echo "Automated cross-platform build from commit $RELEASE_REF."
+              echo
+              echo "Install this build with:"
+              echo
+              echo '~~~sh'
+              echo "npm install --global gridbash@nightly"
+              echo '~~~'
+              echo
+              echo "Nightlies are prerelease builds for testing current main."
+            } > "$notes"
+          elif [[ ! -f "$notes" ]]; then
             printf '# %s\n\nAutomated release for %s.\n' "$RELEASE_TAG" "$RELEASE_TAG" > RELEASE_NOTES.md
             notes="RELEASE_NOTES.md"
           fi
 
           assets=(artifacts/*.tgz "$ROOT_TARBALL")
+          release_flags=()
+          if [[ "$version" == *-* ]]; then
+            release_flags+=(--prerelease)
+          else
+            release_flags+=(--latest)
+          fi
+
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-            gh release edit "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file "$notes" --prerelease
+            gh release edit "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file "$notes" "${release_flags[@]}"
           else
-            gh release create "$RELEASE_TAG" "${assets[@]}" \
-              --title "$RELEASE_TAG" \
-              --notes-file "$notes" \
-              --verify-tag \
-              --prerelease
+            create_flags=(--title "$RELEASE_TAG" --notes-file "$notes")
+            if [[ "$IS_NIGHTLY" == "true" ]]; then
+              create_flags+=(--target "$RELEASE_REF")
+            else
+              create_flags+=(--verify-tag)
+            fi
+            gh release create "$RELEASE_TAG" "${assets[@]}" "${create_flags[@]}" "${release_flags[@]}"
           fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,16 +5,20 @@ This repo has an agent-friendly release path:
 1. Land and verify the product change.
 2. Create a devlog.
 3. Run the `Release` GitHub Actions workflow.
-4. GitHub Actions creates the release commit and tag.
+4. For a versioned release, GitHub Actions creates the release commit and tag;
+   nightly builds stamp only their ephemeral build workspace.
 5. GitHub Actions publishes npm and creates the GitHub release.
 
-The release workflow can be run manually from GitHub Actions and also responds
-to pushed tags named `v*`.
+The release workflow can be run manually from GitHub Actions, runs nightly from
+`main`, and also responds to pushed tags named `v*`.
 
 ## One-Time Setup
 
-Prefer npm Trusted Publishing for the `Release` workflow. Configure the package
-on npmjs.com to trust this repository's GitHub Actions workflow.
+Prefer npm Trusted Publishing for the `Release` workflow. Configure the root
+package and all five native packages on npmjs.com to trust this repository's
+`Release` workflow (owner `jasonsuhari`, repository `gridbash`). New package
+names must be bootstrapped once with a short-lived npm token before npm can
+attach their trusted publisher settings.
 
 As a fallback, add an npm automation token as a GitHub repository secret:
 
@@ -46,8 +50,10 @@ Fill in the generated file under `docs/devlogs/`. Keep it factual:
 After the change is merged to `main`:
 
 1. Open the `Release` workflow in GitHub Actions.
-2. Select `Run workflow`.
-3. Set `version` to `patch`, `minor`, `major`, or an exact version like `0.2.0`.
+2. Select `Run workflow` and leave `channel` set to `release`.
+3. Set `version` to an exact prerelease such as `0.2.0-macos.1` while macOS
+   signing is not configured. `patch`, `minor`, and `major` are available after
+   the stable macOS gate is opened.
 4. Optionally set `notes` to a devlog path such as `docs/devlogs/YYYY-MM-DD-title.md`.
 5. Run the workflow.
 
@@ -75,6 +81,27 @@ is already live and updates an existing GitHub release with `--clobber` assets.
 If the whole workflow needs to be dispatched again for an exact version whose
 tag already exists, the prepare job skips version preparation and publishes the
 existing tag.
+
+### Nightlies
+
+The same `Release` workflow runs daily from `main` and supports a manual
+`channel: nightly` dispatch. It stamps an immutable version such as
+`0.2.0-nightly.20260713.42.gabcdef123456` only in the build workspace, so
+nightlies do not create commits or tags on `main`. The workflow skips a nightly
+when the same commit already has a published nightly, unless `force_nightly` is
+selected.
+
+Install the rolling channel with:
+
+```sh
+npm install --global gridbash@nightly
+```
+
+Cross-platform preview releases use npm's `next` channel instead:
+
+```sh
+npm install --global gridbash@next
+```
 
 Separately, if a `v*` tag is pushed from a local release fallback, the tag push
 path in the same workflow publishes npm and creates the GitHub release.

--- a/docs/devlogs/2026-07-13-automate.md
+++ b/docs/devlogs/2026-07-13-automate.md
@@ -1,0 +1,43 @@
+# Automate nightly cross-platform releases
+
+Date: 2026-07-13
+Issue: #192
+Release target: unreleased
+
+## Summary
+
+- Add a scheduled, manually dispatchable nightly release channel to the
+  existing GitHub Actions release workflow.
+- Keep all native npm packages and the platform-neutral launcher on one
+  immutable SemVer prerelease version.
+
+## What Changed
+
+- Added centralized version stamping for Cargo, the root npm package, its
+  exact-version optional dependencies, and all five native package manifests.
+- Added version-stamping and nightly-version tests.
+- Added nightly builds for Windows x64, Linux x64/arm64, and macOS arm64/x64.
+- Added idempotent npm publication under the `nightly` dist-tag and matching
+  GitHub prereleases with the packaged tarballs attached.
+- Fixed release dispatch output for `patch`, `minor`, and `major` requests and
+  made stable GitHub releases non-prerelease when the macOS signing gate opens.
+
+## Why It Matters
+
+- Main can now be tested and installed continuously without creating release
+  commits or mutable tags for every nightly build.
+- The exact-version package contract is checked before any npm publication,
+  preventing a partial or mismatched cross-platform release.
+
+## Validation
+
+- `node --test npm/scripts/version.test.js`
+- Existing five-platform CI matrix (format, clippy, Rust tests, launcher
+  tests, native preparation, and package dry-runs)
+
+## Release Notes
+
+- Nightly publication still needs npm credentials or trusted-publisher
+  configuration for the five new native package names before the first run.
+- macOS remains preview-only until Developer ID signing, notarization, and
+  real-hardware smoke testing are complete (issue #173).

--- a/npm/platforms/darwin-arm64/package.json
+++ b/npm/platforms/darwin-arm64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.6",
   "description": "GridBash native application for macOS Apple Silicon.",
   "license": "MIT",
-  "repository": "github:jasonsuhari/gridbash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonsuhari/gridbash.git"
+  },
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": ["GridBash.app/"]

--- a/npm/platforms/darwin-x64/package.json
+++ b/npm/platforms/darwin-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.6",
   "description": "GridBash native application for macOS Intel.",
   "license": "MIT",
-  "repository": "github:jasonsuhari/gridbash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonsuhari/gridbash.git"
+  },
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": ["GridBash.app/"]

--- a/npm/platforms/linux-arm64/package.json
+++ b/npm/platforms/linux-arm64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.6",
   "description": "GridBash native binary for Linux arm64.",
   "license": "MIT",
-  "repository": "github:jasonsuhari/gridbash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonsuhari/gridbash.git"
+  },
   "os": ["linux"],
   "cpu": ["arm64"],
   "libc": ["glibc"],

--- a/npm/platforms/linux-x64/package.json
+++ b/npm/platforms/linux-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.6",
   "description": "GridBash native binary for Linux x64.",
   "license": "MIT",
-  "repository": "github:jasonsuhari/gridbash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonsuhari/gridbash.git"
+  },
   "os": ["linux"],
   "cpu": ["x64"],
   "libc": ["glibc"],

--- a/npm/platforms/win32-x64/package.json
+++ b/npm/platforms/win32-x64/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.6",
   "description": "GridBash native binary for Windows x64.",
   "license": "MIT",
-  "repository": "github:jasonsuhari/gridbash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonsuhari/gridbash.git"
+  },
   "os": ["win32"],
   "cpu": ["x64"],
   "files": ["bin/"]

--- a/npm/scripts/release.js
+++ b/npm/scripts/release.js
@@ -1,6 +1,7 @@
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
+const { setProjectVersion } = require("./version");
 
 const root = path.resolve(__dirname, "..", "..");
 const args = process.argv.slice(2);
@@ -81,10 +82,6 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
 }
 
-function writeJson(file, value) {
-  fs.writeFileSync(path.join(root, file), `${JSON.stringify(value, null, 2)}\n`);
-}
-
 function npmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
@@ -113,35 +110,6 @@ function nextVersion(current, requested) {
     default:
       fail("first argument must be patch, minor, major, or an explicit x.y.z version");
   }
-}
-
-function updateCargoVersion(version) {
-  const cargoPath = path.join(root, "Cargo.toml");
-  const raw = fs.readFileSync(cargoPath, "utf8");
-  if (!/^version = "([^"]+)"/m.test(raw)) {
-    fail("could not find Cargo.toml package version");
-  }
-
-  const updated = raw.replace(/^version = "([^"]+)"/m, `version = "${version}"`);
-  if (updated !== raw) {
-    fs.writeFileSync(cargoPath, updated);
-  }
-}
-
-function updateNativePackageVersions(version) {
-  const platformRoot = path.join(root, "npm", "platforms");
-  const manifests = fs
-    .readdirSync(platformRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => path.join(platformRoot, entry.name, "package.json"))
-    .filter((manifest) => fs.existsSync(manifest));
-
-  for (const manifest of manifests) {
-    const value = JSON.parse(fs.readFileSync(manifest, "utf8"));
-    value.version = version;
-    fs.writeFileSync(manifest, `${JSON.stringify(value, null, 2)}\n`);
-  }
-  return manifests;
 }
 
 function latestDevlog() {
@@ -339,13 +307,7 @@ assertTagFree(tag);
 
 console.log(`release: ${packageJson.version} -> ${version}`);
 
-packageJson.version = version;
-for (const dependency of Object.keys(packageJson.optionalDependencies || {})) {
-  packageJson.optionalDependencies[dependency] = version;
-}
-writeJson("package.json", packageJson);
-updateCargoVersion(version);
-const nativeManifests = updateNativePackageVersions(version);
+const { nativeManifests } = setProjectVersion(root, version);
 const notesPath = releaseNotesPath(version);
 
 run("cargo", ["check"]);

--- a/npm/scripts/version.js
+++ b/npm/scripts/version.js
@@ -1,0 +1,140 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const projectRoot = path.resolve(__dirname, "..", "..");
+const exactVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function assertExactVersion(version) {
+  if (!exactVersionPattern.test(version)) {
+    throw new Error(`unsupported version: ${version}`);
+  }
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function nativeManifestPaths(root) {
+  const platformRoot = path.join(root, "npm", "platforms");
+  return fs
+    .readdirSync(platformRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(platformRoot, entry.name, "package.json"))
+    .filter((manifest) => fs.existsSync(manifest))
+    .sort();
+}
+
+function setProjectVersion(root, version) {
+  assertExactVersion(version);
+
+  const packagePath = path.join(root, "package.json");
+  const cargoPath = path.join(root, "Cargo.toml");
+  const packageJson = readJson(packagePath);
+  const cargoToml = fs.readFileSync(cargoPath, "utf8");
+  const packageVersionPattern = /(\[package\][\s\S]*?^version\s*=\s*")[^"]+(".*$)/m;
+
+  if (!packageVersionPattern.test(cargoToml)) {
+    throw new Error("could not find Cargo.toml package version");
+  }
+
+  const manifests = nativeManifestPaths(root);
+  if (manifests.length === 0) {
+    throw new Error("no native npm package manifests found");
+  }
+
+  const nativePackages = manifests.map((manifest) => ({
+    manifest,
+    value: readJson(manifest),
+  }));
+  const optionalDependencies = packageJson.optionalDependencies || {};
+
+  for (const nativePackage of nativePackages) {
+    if (!nativePackage.value.name) {
+      throw new Error(`native package is missing a name: ${nativePackage.manifest}`);
+    }
+    if (!(nativePackage.value.name in optionalDependencies)) {
+      throw new Error(`root optionalDependencies is missing ${nativePackage.value.name}`);
+    }
+  }
+
+  packageJson.version = version;
+  for (const nativePackage of nativePackages) {
+    optionalDependencies[nativePackage.value.name] = version;
+    nativePackage.value.version = version;
+  }
+  packageJson.optionalDependencies = optionalDependencies;
+
+  writeJson(packagePath, packageJson);
+  fs.writeFileSync(
+    cargoPath,
+    cargoToml.replace(
+      packageVersionPattern,
+      (_match, before, after) => `${before}${version}${after}`,
+    ),
+  );
+  for (const nativePackage of nativePackages) {
+    writeJson(nativePackage.manifest, nativePackage.value);
+  }
+
+  return {
+    packagePath,
+    cargoPath,
+    nativeManifests: manifests,
+  };
+}
+
+function nightlyVersion(currentVersion, date, runNumber, commitSha) {
+  assertExactVersion(currentVersion);
+  if (!/^\d{8}$/.test(date)) {
+    throw new Error(`nightly date must be YYYYMMDD: ${date}`);
+  }
+  if (!/^[1-9]\d*$/.test(String(runNumber))) {
+    throw new Error(`nightly run number must be a positive integer: ${runNumber}`);
+  }
+  if (!/^[0-9a-f]{7,64}$/i.test(commitSha)) {
+    throw new Error(`nightly commit must be a git SHA: ${commitSha}`);
+  }
+
+  const [coreVersion, prerelease] = currentVersion.split("-", 2);
+  const [major, minor] = coreVersion.split(".").map(Number);
+  const baseVersion = prerelease
+    ? coreVersion
+    : `${major}.${minor + 1}.0`;
+  const shortSha = commitSha.slice(0, 12).toLowerCase();
+  return `${baseVersion}-nightly.${date}.${runNumber}.g${shortSha}`;
+}
+
+function usage() {
+  console.error(`Usage:
+  node npm/scripts/version.js set <version>
+  node npm/scripts/version.js nightly <YYYYMMDD> <run-number> <commit-sha>`);
+}
+
+if (require.main === module) {
+  const [command, ...args] = process.argv.slice(2);
+  try {
+    if (command === "set" && args.length === 1) {
+      setProjectVersion(projectRoot, args[0]);
+      console.log(args[0]);
+    } else if (command === "nightly" && args.length === 3) {
+      const currentVersion = readJson(path.join(projectRoot, "package.json")).version;
+      console.log(nightlyVersion(currentVersion, args[0], args[1], args[2]));
+    } else {
+      usage();
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`version: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  assertExactVersion,
+  nightlyVersion,
+  setProjectVersion,
+};

--- a/npm/scripts/version.test.js
+++ b/npm/scripts/version.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  nightlyVersion,
+  setProjectVersion,
+} = require("./version");
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function projectFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gridbash-version-"));
+  writeJson(path.join(root, "package.json"), {
+    name: "gridbash",
+    version: "0.1.6",
+    optionalDependencies: {
+      "gridbash-linux-x64": "0.1.6",
+      "gridbash-win32-x64": "0.1.6",
+    },
+  });
+  fs.writeFileSync(
+    path.join(root, "Cargo.toml"),
+    `[package]\nname = "gridbash"\nversion = "0.1.6"\n\n[dependencies]\nanyhow = "1.0"\n`,
+  );
+  writeJson(path.join(root, "npm", "platforms", "linux-x64", "package.json"), {
+    name: "gridbash-linux-x64",
+    version: "0.1.6",
+  });
+  writeJson(path.join(root, "npm", "platforms", "win32-x64", "package.json"), {
+    name: "gridbash-win32-x64",
+    version: "0.1.6",
+  });
+  return root;
+}
+
+test("setProjectVersion keeps every package on one exact version", (t) => {
+  const root = projectFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = setProjectVersion(root, "0.2.0-nightly.20260713.42.gabcdef123456");
+  const rootPackage = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+
+  assert.equal(rootPackage.version, "0.2.0-nightly.20260713.42.gabcdef123456");
+  assert.deepEqual(rootPackage.optionalDependencies, {
+    "gridbash-linux-x64": "0.2.0-nightly.20260713.42.gabcdef123456",
+    "gridbash-win32-x64": "0.2.0-nightly.20260713.42.gabcdef123456",
+  });
+  assert.match(
+    fs.readFileSync(path.join(root, "Cargo.toml"), "utf8"),
+    /version = "0\.2\.0-nightly\.20260713\.42\.gabcdef123456"/,
+  );
+  assert.equal(result.nativeManifests.length, 2);
+  for (const manifest of result.nativeManifests) {
+    assert.equal(
+      JSON.parse(fs.readFileSync(manifest, "utf8")).version,
+      "0.2.0-nightly.20260713.42.gabcdef123456",
+    );
+  }
+});
+
+test("setProjectVersion validates the complete package contract before writing", (t) => {
+  const root = projectFixture();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const packagePath = path.join(root, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  delete packageJson.optionalDependencies["gridbash-linux-x64"];
+  writeJson(packagePath, packageJson);
+
+  assert.throws(
+    () => setProjectVersion(root, "0.2.0"),
+    /root optionalDependencies is missing gridbash-linux-x64/,
+  );
+  assert.equal(JSON.parse(fs.readFileSync(packagePath, "utf8")).version, "0.1.6");
+});
+
+test("nightlyVersion reuses a prerelease core and advances a stable patch", () => {
+  const sha = "ABCDEF1234567890ABCDEF1234567890ABCDEF12";
+  assert.equal(
+    nightlyVersion("0.2.0-macos.1", "20260713", "42", sha),
+    "0.2.0-nightly.20260713.42.gabcdef123456",
+  );
+  assert.equal(
+    nightlyVersion("0.2.0", "20260714", "43", sha),
+    "0.3.0-nightly.20260714.43.gabcdef123456",
+  );
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:launcher": "node --test npm/scripts/gridbash-launcher.test.js",
     "test:review-agent": "node --test npm/scripts/review-agent.test.js",
     "test:star-history": "node --test npm/scripts/update-star-history.test.js",
+    "test:version": "node --test npm/scripts/version.test.js",
     "test": "cargo test"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- publish the cross-platform release matrix through the existing Release workflow
- add scheduled and manually dispatchable immutable nightly builds under npm's `nightly` dist-tag
- centralize exact version stamping across Cargo, the root launcher, and all five native npm packages
- fix computed release tags and stable/prerelease GitHub release classification
- document release channels, trusted-publisher bootstrap, and the macOS preview gate

Closes #192

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `node --test npm/scripts/version.test.js npm/scripts/gridbash-launcher.test.js npm/scripts/review-agent.test.js npm/scripts/update-star-history.test.js` (28 passed)
- `npm pack --dry-run --ignore-scripts`
- release workflow parsed successfully with PyYAML

The full local `cargo test` suite was stopped after five minutes because the
interactive GridBash integration processes did not exit in this environment;
the five-platform CI matrix remains the required broad validation.
