### PR TITLE
fix: publish nightly tarballs from local paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,7 @@ jobs:
           publish_if_missing "$ROOT_TARBALL"
 
       - name: Create or update GitHub release
+        if: ${{ !cancelled() }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,7 +374,7 @@ jobs:
               echo "$name@$package_version already published; skipping."
               return
             fi
-            npm publish "$tarball" --access public --provenance --tag "$dist_tag"
+            npm publish "./$tarball" --access public --provenance --tag "$dist_tag"
           }
 
           for name in "${expected[@]}"; do

--- a/docs/devlogs/2026-07-13-automate.md
+++ b/docs/devlogs/2026-07-13-automate.md
@@ -19,6 +19,8 @@ Release target: unreleased
 - Added nightly builds for Windows x64, Linux x64/arm64, and macOS arm64/x64.
 - Added idempotent npm publication under the `nightly` dist-tag and matching
   GitHub prereleases with the packaged tarballs attached.
+- Made native tarball arguments explicit relative filesystem paths so npm does
+  not interpret `artifacts/<package>.tgz` as GitHub repository shorthand.
 - Fixed release dispatch output for `patch`, `minor`, and `major` requests and
   made stable GitHub releases non-prerelease when the macOS signing gate opens.
 
@@ -32,6 +34,7 @@ Release target: unreleased
 ## Validation
 
 - `node --test npm/scripts/version.test.js`
+- `npm publish --dry-run --force ./artifacts/gridbash-0.1.6.tgz`
 - Existing five-platform CI matrix (format, clippy, Rust tests, launcher
   tests, native preparation, and package dry-runs)
 

--- a/docs/devlogs/2026-07-13-automate.md
+++ b/docs/devlogs/2026-07-13-automate.md
@@ -21,6 +21,9 @@ Release target: unreleased
   GitHub prereleases with the packaged tarballs attached.
 - Made native tarball arguments explicit relative filesystem paths so npm does
   not interpret `artifacts/<package>.tgz` as GitHub repository shorthand.
+- Kept GitHub release creation running after an npm publication failure so
+  packaged nightly artifacts remain available while new package names are
+  bootstrapped on npm.
 - Fixed release dispatch output for `patch`, `minor`, and `major` requests and
   made stable GitHub releases non-prerelease when the macOS signing gate opens.
 

--- a/npm/scripts/version.test.js
+++ b/npm/scripts/version.test.js
@@ -90,3 +90,16 @@ test("nightlyVersion reuses a prerelease core and advances a stable patch", () =
     "0.3.0-nightly.20260714.43.gabcdef123456",
   );
 });
+
+test("release workflow publishes tarballs as explicit filesystem paths", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", "..", ".github", "workflows", "release.yml"),
+    "utf8",
+  );
+
+  assert.match(
+    workflow,
+    /npm publish "\.\/\$tarball" --access public --provenance --tag "\$dist_tag"/,
+  );
+  assert.doesNotMatch(workflow, /npm publish "\$tarball"/);
+});

--- a/npm/scripts/version.test.js
+++ b/npm/scripts/version.test.js
@@ -91,7 +91,7 @@ test("nightlyVersion reuses a prerelease core and advances a stable patch", () =
   );
 });
 
-test("release workflow publishes tarballs as explicit filesystem paths", () => {
+test("release workflow keeps local tarballs and GitHub fallback available", () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, "..", "..", ".github", "workflows", "release.yml"),
     "utf8",
@@ -102,4 +102,8 @@ test("release workflow publishes tarballs as explicit filesystem paths", () => {
     /npm publish "\.\/\$tarball" --access public --provenance --tag "\$dist_tag"/,
   );
   assert.doesNotMatch(workflow, /npm publish "\$tarball"/);
+  assert.match(
+    workflow,
+    /- name: Create or update GitHub release\r?\n\s+if: \$\{\{ !cancelled\(\) \}\}/,
+  );
 });


### PR DESCRIPTION
## Summary

- publish generated npm tarballs through explicit local filesystem paths
- continue GitHub release creation when npm bootstrap publication fails
- add regression coverage for both release-workflow invariants
- document the failed-nightly fix in the existing release devlog

Refs #192

## Validation

- `node --test npm/scripts/version.test.js`
- `npm publish --dry-run --force ./artifacts/gridbash-0.1.6.tgz`
- `git diff --check`