### PR TITLE
feat: add pane settings arrow navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+c | Expand and focus the command line, or close it when focused |
 | Alt+Shift+V | Listen for one dictated utterance; press again to cancel |
 | Alt+h or F1 | Open or close the in-app help and shortcut legend |
-| Alt+p | Open a focused-pane activity summary with its latest meaningful terminal output |
+| Alt+p | Open the focused-pane activity summary; use Up/Down and Enter to navigate its controls |
 | Alt+Shift+p | Open the previous panes list |
 | Alt+r | Rename the focused pane |
 | Alt+Shift+r | Rename the current tab |
@@ -317,18 +317,19 @@ GridBash captures drag selection so selected text stays inside the pane where th
 | Alt+o | Open settings |
 | Alt+q | Quit |
 
-The focused-pane activity summary also includes pane settings, sleep/wake, and
-manager-goal controls. Press `z` to
-sleep or wake that pane, `g` to create or edit its manager goal, and `u` to stop
-the goal. A pane manager only reads and writes the pane that owns its goal.
+The focused-pane activity summary includes auth, rename, refresh, sleep/wake,
+and manager-goal controls. Use `Up`/`Down` to select a control and `Enter` or
+`Space` to use it. The direct shortcuts remain available: `n` renames, `r`
+refreshes the activity snapshot, `z` sleeps or wakes the pane, `g` creates or
+edits its manager goal, and `u` stops the goal. A pane manager only reads and
+writes the pane that owns its goal.
 
 Each pane's top border shows its latest activity summary instead of repeating
 the folder, branch, and launch profile. When a manager goal is set, the goal
 objective takes that spot until the goal is removed.
 
-In the activity summary, press `Enter`, `Space`, or `r` to refresh the latest
-captured terminal result. Press `Esc`, `q`, or `Alt+p` to close it, or
-`Alt+o` to switch to overall settings.
+Press `Esc`, `q`, or `Alt+p` to close the activity summary, or `Alt+o` to switch
+to overall settings.
 
 When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter`,
 `r`, or `t` to restart it, or press `z` to put it to sleep. `Alt+Shift+t` restarts
@@ -411,7 +412,7 @@ Auth settings controls:
 | r | Refresh local account and usage status |
 | Esc / q | Close settings |
 
-For a Claude or Codex pane, open Pane Activity with `Alt+p`, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the activity snapshot.
+For a Claude or Codex pane, open Pane Activity with `Alt+p`, use Up/Down to select the auth control, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the activity snapshot.
 
 Usage status is best-effort. GridBash reads local auth metadata, masks account emails, and uses short-timeout `curl.exe` (Windows) or `curl` (macOS) requests only while the Auth settings view is refreshed.
 

--- a/docs/devlogs/2026-07-12-add-pane-settings-arrow-navigation.md
+++ b/docs/devlogs/2026-07-12-add-pane-settings-arrow-navigation.md
@@ -1,0 +1,29 @@
+# Add pane settings arrow navigation
+
+Date: 2026-07-12
+Release target: unreleased
+
+## Summary
+
+- Made the focused-pane activity controls fully navigable without reaching for their letter shortcuts or the mouse.
+
+## What Changed
+
+- Added a visible selection across auth, rename, history, sleep/wake, and manager-goal controls.
+- Added Up/Down selection, contextual Left/Right auth choice, and Enter/Space activation.
+- Kept the existing direct shortcuts and mouse controls available.
+
+## Why It Matters
+
+- Alt+p now opens a coherent keyboard-first activity and settings workflow instead of a collection of individually discoverable actions.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo test pane_settings`
+- `cargo test` with `GRIDBASH_INVOKING_PROFILE` removed from the child test environment
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Pane Activity controls can now be navigated with the arrow keys and activated with Enter or Space.

--- a/src/app.rs
+++ b/src/app.rs
@@ -708,6 +708,7 @@ pub struct PaneSettingsView {
     pub auth_kind: Option<AgentKind>,
     pub auth_options: Vec<PaneAuthOption>,
     pub auth_cursor: usize,
+    pub selected_target: PaneSettingsTarget,
     pub goal: Option<PaneGoalView>,
     pub manager_configured: bool,
 }
@@ -720,20 +721,57 @@ pub struct PaneAuthOption {
     pub current: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PaneSettingsTarget {
+    Auth,
+    Rename,
+    #[default]
+    Reload,
+    Sleep,
+    Goal,
+    StopGoal,
+}
+
+impl PaneSettingsTarget {
+    fn available(has_auth: bool, has_goal: bool) -> Vec<Self> {
+        let mut targets = Vec::with_capacity(6);
+        if has_auth {
+            targets.push(Self::Auth);
+        }
+        targets.extend([Self::Rename, Self::Reload, Self::Sleep, Self::Goal]);
+        if has_goal {
+            targets.push(Self::StopGoal);
+        }
+        targets
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct PaneSettingsState {
     open: bool,
     pane_index: usize,
     history_summary: Option<String>,
     auth_cursor: usize,
+    selected_target: PaneSettingsTarget,
 }
 
 impl PaneSettingsState {
-    fn open(&mut self, pane_index: usize, history_summary: String, auth_cursor: usize) {
+    fn open(
+        &mut self,
+        pane_index: usize,
+        history_summary: String,
+        auth_cursor: usize,
+        has_auth: bool,
+    ) {
         self.open = true;
         self.pane_index = pane_index;
         self.history_summary = Some(history_summary);
         self.auth_cursor = auth_cursor;
+        self.selected_target = if has_auth {
+            PaneSettingsTarget::Auth
+        } else {
+            PaneSettingsTarget::Reload
+        };
     }
 
     fn close(&mut self) {
@@ -743,6 +781,25 @@ impl PaneSettingsState {
 
     fn refresh_history(&mut self, history_summary: String) {
         self.history_summary = Some(history_summary);
+    }
+
+    fn selected_target(&self, has_auth: bool, has_goal: bool) -> PaneSettingsTarget {
+        match self.selected_target {
+            PaneSettingsTarget::Auth if !has_auth => PaneSettingsTarget::Reload,
+            PaneSettingsTarget::StopGoal if !has_goal => PaneSettingsTarget::Goal,
+            target => target,
+        }
+    }
+
+    fn move_target(&mut self, delta: isize, has_auth: bool, has_goal: bool) {
+        let targets = PaneSettingsTarget::available(has_auth, has_goal);
+        let selected = self.selected_target(has_auth, has_goal);
+        let current = targets
+            .iter()
+            .position(|target| *target == selected)
+            .unwrap_or(0) as isize;
+        let next = (current + delta).clamp(0, targets.len().saturating_sub(1) as isize) as usize;
+        self.selected_target = targets[next];
     }
 }
 
@@ -3418,13 +3475,18 @@ impl App {
             .as_ref()
             .and_then(|plan| plan.panes.get(pane_index))
             .and_then(|spec| spec.auth_name.as_deref());
-        let auth_cursor = self
-            .compatible_auth_profiles(pane_index)
-            .iter()
-            .position(|profile| Some(profile.name.as_str()) == current_auth)
-            .unwrap_or(0);
+        let (auth_cursor, has_auth) = {
+            let profiles = self.compatible_auth_profiles(pane_index);
+            (
+                profiles
+                    .iter()
+                    .position(|profile| Some(profile.name.as_str()) == current_auth)
+                    .unwrap_or(0),
+                !profiles.is_empty(),
+            )
+        };
         self.pane_settings
-            .open(pane_index, history_summary, auth_cursor);
+            .open(pane_index, history_summary, auth_cursor, has_auth);
         self.status = format!("pane {} activity summary open", pane_index + 1);
     }
 
@@ -3454,15 +3516,18 @@ impl App {
             return Ok(KeyOutcome::Render);
         }
         if pane_settings_rename_requested(&key) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Rename;
             self.begin_rename_for(self.pane_settings.pane_index);
             return Ok(KeyOutcome::Render);
         }
         if matches!(key.code, KeyCode::Char('z') | KeyCode::Char('Z')) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Sleep;
             let pane_index = self.pane_settings.pane_index;
             self.toggle_sleep_for_panes(&[pane_index]);
             return Ok(KeyOutcome::Render);
         }
         if matches!(key.code, KeyCode::Char('g') | KeyCode::Char('G')) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             let pane_index = self.pane_settings.pane_index;
             self.pane_settings.close();
             self.open_goal_editor_for(pane_index);
@@ -3471,6 +3536,7 @@ impl App {
         if matches!(key.code, KeyCode::Char('u') | KeyCode::Char('U')) {
             let pane_index = self.pane_settings.pane_index;
             self.stop_pane_goal(pane_index);
+            self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             return Ok(KeyOutcome::Render);
         }
 
@@ -3479,15 +3545,36 @@ impl App {
                 self.close_pane_settings();
                 true
             }
-            KeyCode::Left | KeyCode::Up => {
-                self.move_pane_auth_cursor(-1);
+            KeyCode::Up => {
+                self.move_pane_settings_target(-1);
                 true
             }
-            KeyCode::Right | KeyCode::Down => {
-                self.move_pane_auth_cursor(1);
+            KeyCode::Down => {
+                self.move_pane_settings_target(1);
                 true
             }
-            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('a') | KeyCode::Char('A') => {
+            KeyCode::Left => {
+                if self.selected_pane_settings_target() == PaneSettingsTarget::Auth {
+                    self.move_pane_auth_cursor(-1);
+                    true
+                } else {
+                    false
+                }
+            }
+            KeyCode::Right => {
+                if self.selected_pane_settings_target() == PaneSettingsTarget::Auth {
+                    self.move_pane_auth_cursor(1);
+                    true
+                } else {
+                    false
+                }
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.activate_selected_pane_setting()?;
+                true
+            }
+            KeyCode::Char('a') | KeyCode::Char('A') => {
+                self.pane_settings.selected_target = PaneSettingsTarget::Auth;
                 if self.selected_pane_auth_profile().is_some() {
                     self.apply_selected_pane_auth()?;
                 } else {
@@ -3496,6 +3583,7 @@ impl App {
                 true
             }
             KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.pane_settings.selected_target = PaneSettingsTarget::Reload;
                 self.reload_pane_history();
                 true
             }
@@ -3507,6 +3595,44 @@ impl App {
         } else {
             Ok(KeyOutcome::Continue)
         }
+    }
+
+    fn pane_settings_target_context(&self) -> (bool, bool) {
+        let pane_index = self.pane_settings.pane_index;
+        let has_auth = !self.compatible_auth_profiles(pane_index).is_empty();
+        let has_goal = self.pane_goals.get(pane_index).is_some_and(Option::is_some);
+        (has_auth, has_goal)
+    }
+
+    fn selected_pane_settings_target(&self) -> PaneSettingsTarget {
+        let (has_auth, has_goal) = self.pane_settings_target_context();
+        self.pane_settings.selected_target(has_auth, has_goal)
+    }
+
+    fn move_pane_settings_target(&mut self, delta: isize) {
+        let (has_auth, has_goal) = self.pane_settings_target_context();
+        self.pane_settings.move_target(delta, has_auth, has_goal);
+    }
+
+    fn activate_selected_pane_setting(&mut self) -> Result<()> {
+        let target = self.selected_pane_settings_target();
+        self.pane_settings.selected_target = target;
+        let pane_index = self.pane_settings.pane_index;
+        match target {
+            PaneSettingsTarget::Auth => self.apply_selected_pane_auth()?,
+            PaneSettingsTarget::Rename => self.begin_rename_for(pane_index),
+            PaneSettingsTarget::Reload => self.reload_pane_history(),
+            PaneSettingsTarget::Sleep => self.toggle_sleep_for_panes(&[pane_index]),
+            PaneSettingsTarget::Goal => {
+                self.pane_settings.close();
+                self.open_goal_editor_for(pane_index);
+            }
+            PaneSettingsTarget::StopGoal => {
+                self.stop_pane_goal(pane_index);
+                self.pane_settings.selected_target = PaneSettingsTarget::Goal;
+            }
+        }
+        Ok(())
     }
 
     fn compatible_auth_profiles(&self, pane_index: usize) -> Vec<&AuthProfile> {
@@ -4247,15 +4373,18 @@ impl App {
         }
 
         if self.pane_settings_reload_button_at(mouse.column, mouse.row) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Reload;
             self.reload_pane_history();
             return true;
         }
         if self.pane_settings_sleep_button_at(mouse.column, mouse.row) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Sleep;
             let pane_index = self.pane_settings.pane_index;
             self.toggle_sleep_for_panes(&[pane_index]);
             return true;
         }
         if self.pane_settings_goal_button_at(mouse.column, mouse.row) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             let pane_index = self.pane_settings.pane_index;
             self.pane_settings.close();
             self.open_goal_editor_for(pane_index);
@@ -4264,9 +4393,11 @@ impl App {
         if self.pane_settings_stop_goal_button_at(mouse.column, mouse.row) {
             let pane_index = self.pane_settings.pane_index;
             self.stop_pane_goal(pane_index);
+            self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             return true;
         }
         if self.pane_settings_rename_button_at(mouse.column, mouse.row) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Rename;
             self.begin_rename_for(self.pane_settings.pane_index);
             return true;
         }
@@ -5480,7 +5611,18 @@ impl App {
                 ready: profile.ready,
                 current: Some(profile.name.as_str()) == current_auth,
             })
-            .collect();
+            .collect::<Vec<_>>();
+        let goal = self
+            .pane_goals
+            .get(index)
+            .and_then(Option::as_ref)
+            .map(|goal| PaneGoalView {
+                objective: goal.objective.clone(),
+                status: goal.status.clone(),
+            });
+        let selected_target = self
+            .pane_settings
+            .selected_target(!auth_options.is_empty(), goal.is_some());
         Some(PaneSettingsView {
             index,
             label: self.pane_label(index),
@@ -5501,14 +5643,8 @@ impl App {
             auth_kind: spec.and_then(|spec| spec.command.agent_kind),
             auth_options,
             auth_cursor: self.pane_settings.auth_cursor,
-            goal: self
-                .pane_goals
-                .get(index)
-                .and_then(Option::as_ref)
-                .map(|goal| PaneGoalView {
-                    objective: goal.objective.clone(),
-                    status: goal.status.clone(),
-                }),
+            selected_target,
+            goal,
             manager_configured: self.config.manager.is_configured(),
         })
     }
@@ -7602,7 +7738,7 @@ mod tests {
     #[test]
     fn pane_settings_tracks_active_pane_history() {
         let mut settings = PaneSettingsState::default();
-        settings.open(2, "Assistant: ready".into(), 1);
+        settings.open(2, "Assistant: ready".into(), 1, true);
         assert!(settings.open);
         assert_eq!(settings.pane_index, 2);
         assert_eq!(
@@ -7610,6 +7746,7 @@ mod tests {
             Some("Assistant: ready")
         );
         assert_eq!(settings.auth_cursor, 1);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Auth);
 
         settings.refresh_history("User: rerun tests".into());
         assert_eq!(
@@ -7620,6 +7757,148 @@ mod tests {
         settings.close();
         assert!(!settings.open);
         assert!(settings.history_summary.is_none());
+    }
+
+    #[test]
+    fn pane_settings_moves_through_visible_targets() {
+        let mut settings = PaneSettingsState::default();
+        settings.open(0, "waiting for output".into(), 0, false);
+
+        assert_eq!(
+            settings.selected_target(false, false),
+            PaneSettingsTarget::Reload
+        );
+        settings.move_target(-1, false, false);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Rename);
+        settings.move_target(-1, false, false);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Rename);
+
+        settings.move_target(1, false, false);
+        settings.move_target(1, false, false);
+        settings.move_target(1, false, false);
+        settings.move_target(1, false, false);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Goal);
+    }
+
+    #[test]
+    fn pane_settings_key_handler_uses_vertical_arrows_for_controls() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let mut app = App::new(cli, Config::default()).expect("app");
+        app.pane_settings
+            .open(0, "waiting for output".into(), 0, false);
+
+        assert_eq!(
+            app.handle_pane_settings_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE,))
+                .expect("down"),
+            KeyOutcome::Render
+        );
+        assert_eq!(app.pane_settings.selected_target, PaneSettingsTarget::Sleep);
+        assert_eq!(
+            app.handle_pane_settings_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+                .expect("up"),
+            KeyOutcome::Render
+        );
+        assert_eq!(
+            app.pane_settings.selected_target,
+            PaneSettingsTarget::Reload
+        );
+        assert_eq!(
+            app.handle_pane_settings_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE,))
+                .expect("left"),
+            KeyOutcome::Continue
+        );
+        assert_eq!(app.pane_settings.auth_cursor, 0);
+
+        assert_eq!(
+            app.handle_pane_settings_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE,))
+                .expect("activate"),
+            KeyOutcome::Render
+        );
+        assert!(!app.pane_settings.open);
+        assert!(app.status.contains("no longer available"));
+    }
+
+    #[test]
+    fn pane_settings_normalizes_optional_targets() {
+        let mut settings = PaneSettingsState::default();
+        settings.open(0, "waiting for output".into(), 0, true);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Auth);
+
+        settings.selected_target = PaneSettingsTarget::StopGoal;
+        assert_eq!(
+            settings.selected_target(true, false),
+            PaneSettingsTarget::Goal
+        );
+        assert_eq!(
+            settings.selected_target(true, true),
+            PaneSettingsTarget::StopGoal
+        );
+
+        settings.selected_target = PaneSettingsTarget::Auth;
+        assert_eq!(
+            settings.selected_target(false, false),
+            PaneSettingsTarget::Reload
+        );
+    }
+
+    #[test]
+    fn pane_settings_includes_optional_targets_in_navigation_order() {
+        assert_eq!(
+            PaneSettingsTarget::available(false, false),
+            vec![
+                PaneSettingsTarget::Rename,
+                PaneSettingsTarget::Reload,
+                PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Goal,
+            ]
+        );
+        assert_eq!(
+            PaneSettingsTarget::available(true, false),
+            vec![
+                PaneSettingsTarget::Auth,
+                PaneSettingsTarget::Rename,
+                PaneSettingsTarget::Reload,
+                PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Goal,
+            ]
+        );
+        assert_eq!(
+            PaneSettingsTarget::available(false, true),
+            vec![
+                PaneSettingsTarget::Rename,
+                PaneSettingsTarget::Reload,
+                PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Goal,
+                PaneSettingsTarget::StopGoal,
+            ]
+        );
+        assert_eq!(
+            PaneSettingsTarget::available(true, true),
+            vec![
+                PaneSettingsTarget::Auth,
+                PaneSettingsTarget::Rename,
+                PaneSettingsTarget::Reload,
+                PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Goal,
+                PaneSettingsTarget::StopGoal,
+            ]
+        );
+
+        let mut settings = PaneSettingsState {
+            selected_target: PaneSettingsTarget::Goal,
+            ..PaneSettingsState::default()
+        };
+        settings.move_target(1, false, true);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::StopGoal);
+        settings.move_target(10, false, true);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::StopGoal);
+
+        settings.selected_target = PaneSettingsTarget::Auth;
+        settings.move_target(1, false, false);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Sleep);
+        settings.selected_target = PaneSettingsTarget::StopGoal;
+        settings.move_target(-1, false, false);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Sleep);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,8 +10,8 @@ use vt100::Cell;
 use crate::{
     app::{
         App, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView, GridPalette, PaneSelection,
-        PaneSettingsView, PreviousPaneView, PreviousPanesView, RenamePaneView, RenameTabView,
-        SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind, TabLabel,
+        PaneSettingsTarget, PaneSettingsView, PreviousPaneView, PreviousPanesView, RenamePaneView,
+        RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind, TabLabel,
     },
     auth::{AgentKind, AuthProfile},
     composer::GridPickerMode,
@@ -765,12 +765,21 @@ fn pane_settings_lines(
                 .get(view.auth_cursor)
                 .map(|option| option.name.as_str())
                 .unwrap_or("none");
+            let selected = view.selected_target == PaneSettingsTarget::Auth;
             lines.push(Line::from(Span::styled(
                 fixed_width(
-                    &format!(" {} auth: {auth}", kind.display_name()),
+                    &format!(
+                        "{} {} auth: {auth}",
+                        if selected { ">" } else { " " },
+                        kind.display_name()
+                    ),
                     width as usize,
                 ),
-                Style::default().fg(SETTINGS_TEXT),
+                Style::default().fg(SETTINGS_TEXT).bg(if selected {
+                    SETTINGS_ROW_ACTIVE
+                } else {
+                    SETTINGS_BG
+                }),
             )));
         }
         lines.push(Line::from(Span::styled(
@@ -780,14 +789,39 @@ fn pane_settings_lines(
             ),
             Style::default().fg(SETTINGS_TEXT),
         )));
-        lines.push(pane_settings_rename_line(width, palette));
-        lines.push(pane_settings_reload_line(width, palette));
-        lines.push(pane_settings_sleep_line(width, view.sleeping, palette));
-        lines.push(pane_settings_goal_line(width, view.goal.is_some(), palette));
+        lines.push(pane_settings_rename_line(
+            width,
+            palette,
+            view.selected_target == PaneSettingsTarget::Rename,
+        ));
+        lines.push(pane_settings_reload_line(
+            width,
+            palette,
+            view.selected_target == PaneSettingsTarget::Reload,
+        ));
+        lines.push(pane_settings_sleep_line(
+            width,
+            view.sleeping,
+            palette,
+            view.selected_target == PaneSettingsTarget::Sleep,
+        ));
+        lines.push(pane_settings_goal_line(
+            width,
+            view.goal.is_some(),
+            palette,
+            view.selected_target == PaneSettingsTarget::Goal,
+        ));
         if view.goal.is_some() {
-            lines.push(pane_settings_stop_goal_line(width, palette));
+            lines.push(pane_settings_stop_goal_line(
+                width,
+                palette,
+                view.selected_target == PaneSettingsTarget::StopGoal,
+            ));
         }
-        lines.push(pane_settings_command_bar(width, view.auth_kind.is_some()));
+        lines.push(pane_settings_command_bar(
+            width,
+            !view.auth_options.is_empty(),
+        ));
         return lines;
     }
 
@@ -828,20 +862,25 @@ fn pane_settings_lines(
             } else {
                 "login needed"
             };
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled("< ", Style::default().fg(Color::Yellow)),
-                Span::styled(
-                    truncate_text(
-                        &format!("{} | {} | {}{}", option.name, account, status, current),
-                        width.saturating_sub(8) as usize,
-                    ),
-                    Style::default()
-                        .fg(kind_color(kind))
-                        .add_modifier(Modifier::BOLD),
+            let selected = view.selected_target == PaneSettingsTarget::Auth;
+            let account = truncate_text(
+                &format!("{} | {} | {}{}", option.name, account, status, current),
+                width.saturating_sub(8) as usize,
+            );
+            lines.push(Line::from(Span::styled(
+                fixed_width(
+                    &format!("{} < {account} >", if selected { ">" } else { " " }),
+                    width as usize,
                 ),
-                Span::styled(" >", Style::default().fg(Color::Yellow)),
-            ]));
+                Style::default()
+                    .fg(kind_color(kind))
+                    .bg(if selected {
+                        SETTINGS_ROW_ACTIVE
+                    } else {
+                        SETTINGS_BG
+                    })
+                    .add_modifier(Modifier::BOLD),
+            )));
         } else {
             lines.push(Line::from(vec![
                 Span::raw("  "),
@@ -873,8 +912,16 @@ fn pane_settings_lines(
     if view.auth_kind.is_none() {
         lines.push(Line::from(""));
     }
-    lines.push(pane_settings_rename_line(width, palette));
-    lines.push(pane_settings_reload_line(width, palette));
+    lines.push(pane_settings_rename_line(
+        width,
+        palette,
+        view.selected_target == PaneSettingsTarget::Rename,
+    ));
+    lines.push(pane_settings_reload_line(
+        width,
+        palette,
+        view.selected_target == PaneSettingsTarget::Reload,
+    ));
     lines.push(settings_section(
         "PANE CONTROLS",
         if view.manager_configured {
@@ -896,25 +943,42 @@ fn pane_settings_lines(
             ),
         ]));
     }
-    lines.push(pane_settings_sleep_line(width, view.sleeping, palette));
-    lines.push(pane_settings_goal_line(width, view.goal.is_some(), palette));
+    lines.push(pane_settings_sleep_line(
+        width,
+        view.sleeping,
+        palette,
+        view.selected_target == PaneSettingsTarget::Sleep,
+    ));
+    lines.push(pane_settings_goal_line(
+        width,
+        view.goal.is_some(),
+        palette,
+        view.selected_target == PaneSettingsTarget::Goal,
+    ));
     if view.goal.is_some() {
-        lines.push(pane_settings_stop_goal_line(width, palette));
+        lines.push(pane_settings_stop_goal_line(
+            width,
+            palette,
+            view.selected_target == PaneSettingsTarget::StopGoal,
+        ));
     }
     if view.auth_kind.is_none() {
         lines.push(Line::from(""));
     }
-    lines.push(pane_settings_command_bar(width, view.auth_kind.is_some()));
+    lines.push(pane_settings_command_bar(
+        width,
+        !view.auth_options.is_empty(),
+    ));
 
     lines
 }
 
-fn pane_settings_rename_line(width: u16, palette: &GridPalette) -> Line<'static> {
-    pane_settings_action_line("[ Rename pane ]", width, palette.selected())
+fn pane_settings_rename_line(width: u16, palette: &GridPalette, selected: bool) -> Line<'static> {
+    pane_settings_action_line("[ Rename pane ]", width, palette.selected(), selected)
 }
 
-fn pane_settings_reload_line(width: u16, palette: &GridPalette) -> Line<'static> {
-    pane_settings_action_line("[ Refresh activity ]", width, palette.focus())
+fn pane_settings_reload_line(width: u16, palette: &GridPalette, selected: bool) -> Line<'static> {
+    pane_settings_action_line("[ Refresh activity ]", width, palette.focus(), selected)
 }
 
 fn render_goal_editor(frame: &mut Frame<'_>, area: Rect, editor: &GoalEditorView) {
@@ -959,7 +1023,12 @@ fn render_goal_editor(frame: &mut Frame<'_>, area: Rect, editor: &GoalEditorView
     );
 }
 
-fn pane_settings_sleep_line(width: u16, sleeping: bool, palette: &GridPalette) -> Line<'static> {
+fn pane_settings_sleep_line(
+    width: u16,
+    sleeping: bool,
+    palette: &GridPalette,
+    selected: bool,
+) -> Line<'static> {
     pane_settings_action_line(
         if sleeping {
             "[ Wake pane ]"
@@ -968,10 +1037,16 @@ fn pane_settings_sleep_line(width: u16, sleeping: bool, palette: &GridPalette) -
         },
         width,
         palette.quiet(),
+        selected,
     )
 }
 
-fn pane_settings_goal_line(width: u16, has_goal: bool, palette: &GridPalette) -> Line<'static> {
+fn pane_settings_goal_line(
+    width: u16,
+    has_goal: bool,
+    palette: &GridPalette,
+    selected: bool,
+) -> Line<'static> {
     pane_settings_action_line(
         if has_goal {
             "[ Edit manager goal ]"
@@ -980,16 +1055,31 @@ fn pane_settings_goal_line(width: u16, has_goal: bool, palette: &GridPalette) ->
         },
         width,
         palette.accent(),
+        selected,
     )
 }
 
-fn pane_settings_stop_goal_line(width: u16, palette: &GridPalette) -> Line<'static> {
-    pane_settings_action_line("[ Stop manager goal ]", width, palette.exited())
+fn pane_settings_stop_goal_line(
+    width: u16,
+    palette: &GridPalette,
+    selected: bool,
+) -> Line<'static> {
+    pane_settings_action_line("[ Stop manager goal ]", width, palette.exited(), selected)
 }
 
-fn pane_settings_action_line(label: &str, width: u16, background: Color) -> Line<'static> {
+fn pane_settings_action_line(
+    label: &str,
+    width: u16,
+    background: Color,
+    selected: bool,
+) -> Line<'static> {
+    let label = if selected {
+        format!("> {label} <")
+    } else {
+        label.to_string()
+    };
     let text = if width as usize <= label.len() + 4 {
-        fixed_width(label, width as usize)
+        fixed_width(&label, width as usize)
     } else {
         let left = ((width as usize).saturating_sub(label.len())) / 2;
         let right = (width as usize).saturating_sub(left + label.len());
@@ -999,22 +1089,28 @@ fn pane_settings_action_line(label: &str, width: u16, background: Color) -> Line
     Line::from(Span::styled(
         text,
         Style::default()
-            .fg(Color::Black)
-            .bg(background)
+            .fg(if selected {
+                SETTINGS_TEXT
+            } else {
+                Color::Black
+            })
+            .bg(if selected {
+                SETTINGS_ROW_ACTIVE
+            } else {
+                background
+            })
             .add_modifier(Modifier::BOLD),
     ))
 }
 
 fn pane_settings_command_bar(width: u16, has_auth: bool) -> Line<'static> {
-    if width < 58 {
+    if width < 64 {
         return Line::from(vec![
             Span::raw("  "),
-            command_key("z"),
-            Span::styled(" sleep  ", Style::default().fg(Color::Gray)),
-            command_key("g"),
-            Span::styled(" goal  ", Style::default().fg(Color::Gray)),
-            command_key("u"),
-            Span::styled(" stop  ", Style::default().fg(Color::Gray)),
+            command_key("Up/Down"),
+            Span::styled(" select  ", Style::default().fg(Color::Gray)),
+            command_key("Enter"),
+            Span::styled(" use  ", Style::default().fg(Color::Gray)),
             command_key("Esc"),
             Span::styled(" close", Style::default().fg(Color::Gray)),
         ]);
@@ -1022,16 +1118,10 @@ fn pane_settings_command_bar(width: u16, has_auth: bool) -> Line<'static> {
 
     let mut spans = vec![
         Span::raw("  "),
-        command_key("n"),
-        Span::styled(" rename  ", Style::default().fg(Color::Gray)),
-        command_key("r"),
-        Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
-        command_key("z"),
-        Span::styled(" sleep/wake  ", Style::default().fg(Color::Gray)),
-        command_key("g"),
-        Span::styled(" goal  ", Style::default().fg(Color::Gray)),
-        command_key("u"),
-        Span::styled(" stop  ", Style::default().fg(Color::Gray)),
+        command_key("Up/Down"),
+        Span::styled(" select  ", Style::default().fg(Color::Gray)),
+        command_key(if width >= 72 { "Enter/Space" } else { "Enter" }),
+        Span::styled(" use  ", Style::default().fg(Color::Gray)),
     ];
     if has_auth {
         spans.push(command_key("Left/Right"));
@@ -3005,6 +3095,7 @@ mod tests {
             auth_kind: None,
             auth_options: Vec::new(),
             auth_cursor: 0,
+            selected_target: PaneSettingsTarget::Reload,
             goal: None,
             manager_configured: false,
         };
@@ -3074,6 +3165,85 @@ mod tests {
             pane_settings_stop_goal_rect(Rect::new(5, 10, 40, 14), false, false),
             None
         );
+    }
+
+    #[test]
+    fn selected_pane_setting_has_a_focus_marker_and_active_background() {
+        let selected = pane_settings_action_line("[ Refresh activity ]", 40, Color::Yellow, true);
+        assert!(
+            selected.spans[0]
+                .content
+                .contains("> [ Refresh activity ] <")
+        );
+        assert_eq!(selected.spans[0].style.fg, Some(SETTINGS_TEXT));
+        assert_eq!(selected.spans[0].style.bg, Some(SETTINGS_ROW_ACTIVE));
+        assert!(
+            selected.spans[0]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+
+        let unselected =
+            pane_settings_action_line("[ Refresh activity ]", 40, Color::Yellow, false);
+        assert!(!unselected.spans[0].content.contains("> ["));
+        assert_eq!(unselected.spans[0].style.bg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn pane_settings_command_bar_describes_arrow_navigation() {
+        let text = pane_settings_command_bar(100, true)
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(text.contains("Up/Down"));
+        assert!(text.contains("Enter/Space"));
+        assert!(text.contains("Left/Right"));
+
+        let no_auth = pane_settings_command_bar(100, false)
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(!no_auth.contains("Left/Right"));
+    }
+
+    #[test]
+    fn pane_settings_render_one_selected_row_at_compact_and_wide_widths() {
+        let view = PaneSettingsView {
+            index: 0,
+            label: "1".into(),
+            folder: "gridbash".into(),
+            worktree: None,
+            history_summary: "Assistant: ready".into(),
+            focused: true,
+            selected: false,
+            sleeping: false,
+            exited: false,
+            auth_kind: None,
+            auth_options: Vec::new(),
+            auth_cursor: 0,
+            selected_target: PaneSettingsTarget::Reload,
+            goal: None,
+            manager_configured: false,
+        };
+
+        for width in [32, 80] {
+            let lines = pane_settings_lines(&view, width, &GridPalette::default());
+            let active = lines
+                .iter()
+                .flat_map(|line| line.spans.iter())
+                .filter(|span| span.style.bg == Some(SETTINGS_ROW_ACTIVE))
+                .collect::<Vec<_>>();
+
+            assert_eq!(active.len(), 1, "width {width}");
+            assert!(
+                active[0].content.contains("Refresh activity"),
+                "width {width}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add keyboard selection to focused-pane activity controls
- support Up/Down navigation, contextual Left/Right auth selection, and Enter/Space activation
- keep direct shortcuts and mouse interactions synchronized with the selected row
- add focused tests and update README/devlog guidance

Refs #189

## Validation

- `cargo fmt --check`
- `cargo test pane_settings` (9 passed)
- `cargo test` (142 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`