### PR TITLE
chore: automate issue labeling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
 
       - run: node --test npm/scripts/gridbash-launcher.test.js
 
+      - run: node --test npm/scripts/issue-labeler.test.js
+
       - run: node --test npm/scripts/review-agent.test.js
 
       - run: node --test npm/scripts/update-star-history.test.js

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,37 @@
+name: Label Issues
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Existing issue number to classify
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: issue-labeler-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply issue labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out trusted classifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Classify issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: node npm/scripts/issue-labeler.js

--- a/docs/COMMUNITY_SETUP.md
+++ b/docs/COMMUNITY_SETUP.md
@@ -73,6 +73,10 @@ Additional labels:
 - `platform:windows`
 - `type:test`, `type:design`, `type:maintenance`
 
+New issues are classified by `.github/workflows/issue-labeler.yml`. The
+automation adds only missing type, triage-status, area, and Windows-platform
+labels; priorities and resolution labels remain maintainer decisions.
+
 ## Milestones
 
 - `v0.2 Nostromo`: public launch polish.

--- a/docs/devlogs/2026-07-13-automatic-issue-labeling.md
+++ b/docs/devlogs/2026-07-13-automatic-issue-labeling.md
@@ -1,0 +1,37 @@
+# Automatic issue labeling
+
+Date: 2026-07-13
+Release target: unreleased
+
+## Summary
+
+- Automatically classify new GitHub issues with GridBash's existing label
+  taxonomy.
+
+## What Changed
+
+- Added a least-privilege workflow for newly opened issues plus a manual
+  recovery/backfill dispatch.
+- Added a dependency-free classifier for conventional titles, issue-form area
+  answers, conservative area keywords, and Windows-specific reports.
+- Preserved existing labels and kept priority and resolution decisions under
+  maintainer control.
+
+## Why It Matters
+
+- Issues created through the CLI or API now receive the same triage structure
+  as issues created through repository forms.
+- Maintainers get useful routing labels without losing intentional manual
+  classifications.
+
+## Validation
+
+- npm run test:issue-labeler
+- git diff --check
+- GitHub Actions workflow validation and live dispatch against the tracking
+  issue.
+
+## Release Notes
+
+- New issues now receive automatic type, triage, area, and platform labels when
+  the report contains a strong matching signal.

--- a/npm/scripts/issue-labeler.js
+++ b/npm/scripts/issue-labeler.js
@@ -1,0 +1,282 @@
+const fs = require("node:fs");
+
+const MAX_ISSUE_TEXT = 50_000;
+const TYPE_LABELS = new Set([
+  "bug",
+  "documentation",
+  "enhancement",
+  "question",
+  "type:design",
+  "type:maintenance",
+  "type:test",
+]);
+
+const PREFIX_LABELS = new Map([
+  ["bug", "bug"],
+  ["build", "type:maintenance"],
+  ["chore", "type:maintenance"],
+  ["ci", "type:maintenance"],
+  ["design", "type:design"],
+  ["docs", "documentation"],
+  ["feat", "enhancement"],
+  ["fix", "bug"],
+  ["perf", "type:maintenance"],
+  ["question", "question"],
+  ["refactor", "type:maintenance"],
+  ["release", "type:maintenance"],
+  ["rfc", "type:design"],
+  ["security", "bug"],
+  ["test", "type:test"],
+]);
+
+const FORM_AREA_LABELS = new Map([
+  ["documentation", ["area:docs"]],
+  ["npm packaging", ["area:packaging"]],
+  ["profiles/configuration", ["area:profiles", "area:config"]],
+  ["pty/process behavior", ["area:pty"]],
+  ["tui controls", ["area:tui"]],
+]);
+
+const AREA_RULES = [
+  {
+    label: "area:pty",
+    titlePattern: /\b(?:conpty|pty|pseudo[- ]terminal|process lifecycle|spawn(?:ing|ed)?|stdin|stdout|stderr|terminal i\/o)\b/i,
+  },
+  {
+    label: "area:tui",
+    titlePattern: /\b(?:tui|ratatui|terminal ui|pane settings|overlay|modal|focus|keybindings?|keyboard|mouse|shortcuts?|render(?:ing)?|layout|tabs?|scroll(?:ing)?|(?:pane|tui) controls?|alt\+[a-z0-9]|command output)\b/i,
+  },
+  {
+    label: "area:profiles",
+    titlePattern: /\b(?:terminal profiles?|agent profiles?|profile detection|shell profiles?|shell detection|codex|claude|gemini|authentication|auth usage)\b/i,
+  },
+  {
+    label: "area:composer",
+    titlePattern: /\b(?:composer|orchestrat(?:e|es|ed|ing|ion)|manager goals?|saved setups?)\b/i,
+  },
+  {
+    label: "area:config",
+    titlePattern: /\b(?:config(?:uration)?|schema|toml|preferences?|persist(?:ed|ence|ing)?|environment variables?)\b/i,
+  },
+  {
+    label: "area:packaging",
+    titlePattern: /\b(?:npm|packages?|packaging|tarball|install(?:er|ation|ing)?|publish(?:ing)?|release|signing|notarization|binar(?:y|ies)|distribution|dependenc(?:y|ies)|arm64|x64|github actions?|workflows?|ci)\b/i,
+  },
+  {
+    label: "area:docs",
+    titlePattern: /\b(?:documentation|docs?|readme|devlogs?|website|command reference|guides?)\b/i,
+  },
+  {
+    label: "area:architecture",
+    titlePattern: /\b(?:architecture|daemon|protocol|agent api|security|credentials?|permissions?|refactor|monolith|module (?:boundary|ownership))\b/i,
+  },
+];
+
+const WINDOWS_PATTERN = /\b(?:windows|win32|powershell|conpty)\b/i;
+
+function existingLabelNames(issue) {
+  return new Set(
+    (issue.labels || [])
+      .map((label) => (typeof label === "string" ? label : label && label.name))
+      .filter(Boolean),
+  );
+}
+
+function issueText(issue) {
+  const body = String(issue.body || "").replace(/^#{1,6}\s+.*$/gm, "\n");
+  return (String(issue.title || "") + "\n" + body).slice(0, MAX_ISSUE_TEXT);
+}
+
+function extractAreaAnswer(body) {
+  const match = String(body || "").match(
+    /(?:^|\r?\n)###\s+Area\s*\r?\n+([\s\S]*?)(?=\r?\n###\s+|$)/i,
+  );
+  if (!match) {
+    return undefined;
+  }
+  return match[1].trim().split(/\r?\n/, 1)[0].trim().toLowerCase();
+}
+
+function typeLabelForTitle(title) {
+  const text = String(title || "").trim();
+  const conventional = text.match(/^([a-z]+)(?:\([^)]+\))?!?:\s+/i);
+  if (conventional) {
+    return PREFIX_LABELS.get(conventional[1].toLowerCase());
+  }
+
+  if (/^(?:add|allow|create|enable|improve|introduce|make|provide|show|support)\b/i.test(text)) {
+    return "enhancement";
+  }
+  if (/^(?:avoid|correct|fix|prevent|resolve|restore|stop)\b/i.test(text)) {
+    return "bug";
+  }
+  if (/^(?:can|does|how|is|what|why)\b.*\?$/i.test(text)) {
+    return "question";
+  }
+  return undefined;
+}
+
+function labelsForIssue(issue) {
+  const existing = existingLabelNames(issue);
+  const labels = [];
+  const add = (label) => {
+    if (label && !existing.has(label) && !labels.includes(label)) {
+      labels.push(label);
+    }
+  };
+
+  let typeLabel = [...existing].find((label) => TYPE_LABELS.has(label));
+  if (!typeLabel) {
+    typeLabel = typeLabelForTitle(issue.title);
+    add(typeLabel);
+  }
+
+  if (
+    issue.state !== "closed" &&
+    ![...existing].some((label) => label.startsWith("status:"))
+  ) {
+    add("status:needs-triage");
+  }
+
+  if (![...existing].some((label) => label.startsWith("area:"))) {
+    const areaAnswer = extractAreaAnswer(issue.body);
+    const formLabels = FORM_AREA_LABELS.get(areaAnswer);
+    if (formLabels) {
+      formLabels.forEach(add);
+    } else if (typeLabel === "documentation") {
+      add("area:docs");
+    } else if (areaAnswer !== "other") {
+      const title = String(issue.title || "").slice(0, MAX_ISSUE_TEXT);
+      AREA_RULES.filter((rule) => rule.titlePattern.test(title)).forEach((rule) => add(rule.label));
+    }
+  }
+
+  if (
+    ![...existing].some((label) => label.startsWith("platform:")) &&
+    WINDOWS_PATTERN.test(issueText(issue))
+  ) {
+    add("platform:windows");
+  }
+
+  return labels;
+}
+
+function requiredEnvironment(name, environment) {
+  const value = environment[name];
+  if (!value) {
+    throw new Error("missing required environment variable " + name);
+  }
+  return value;
+}
+
+function repositoryName(value) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error("invalid GITHUB_REPOSITORY value");
+  }
+  return value;
+}
+
+function issueNumber(value) {
+  const text = String(value || "").trim();
+  if (!/^[1-9]\d*$/.test(text)) {
+    throw new Error("issue number must be a positive integer");
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error("issue number must be a positive integer");
+  }
+  return parsed;
+}
+
+async function requestJson(fetchImpl, url, options) {
+  const response = await fetchImpl(url, {
+    method: options.method || "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: "Bearer " + options.token,
+      "Content-Type": "application/json",
+      "User-Agent": "gridbash-issue-labeler",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  let payload;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = text;
+    }
+  }
+  if (!response.ok) {
+    const message = typeof payload === "object" && payload && payload.message
+      ? payload.message
+      : text || "unknown error";
+    throw new Error((options.method || "GET") + " " + new URL(url).pathname + " failed with " + response.status + ": " + message);
+  }
+  return payload;
+}
+
+async function fetchIssue(fetchImpl, apiBase, repository, number, token) {
+  return requestJson(
+    fetchImpl,
+    apiBase + "/repos/" + repository + "/issues/" + number,
+    { token },
+  );
+}
+
+async function addIssueLabels(fetchImpl, apiBase, repository, number, labels, token) {
+  return requestJson(
+    fetchImpl,
+    apiBase + "/repos/" + repository + "/issues/" + number + "/labels",
+    { method: "POST", token, body: { labels } },
+  );
+}
+
+async function runIssueLabeler(options = {}) {
+  const environment = options.environment || process.env;
+  const fetchImpl = options.fetchImpl || fetch;
+  const logger = options.logger || console;
+  const repository = repositoryName(requiredEnvironment("GITHUB_REPOSITORY", environment));
+  const token = requiredEnvironment("GITHUB_TOKEN", environment);
+  const apiBase = (environment.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "");
+  const payload = options.payload || JSON.parse(
+    fs.readFileSync(requiredEnvironment("GITHUB_EVENT_PATH", environment), "utf8"),
+  );
+
+  let issue = payload.issue;
+  if (!issue) {
+    const number = issueNumber(environment.ISSUE_NUMBER || (payload.inputs && payload.inputs.issue_number));
+    issue = await fetchIssue(fetchImpl, apiBase, repository, number, token);
+  }
+  if (issue.pull_request) {
+    throw new Error("#" + issue.number + " is a pull request, not an issue");
+  }
+
+  const labels = labelsForIssue(issue);
+  if (labels.length === 0) {
+    logger.log("issue-labeler: #" + issue.number + " already has all matching labels");
+    return [];
+  }
+
+  await addIssueLabels(fetchImpl, apiBase, repository, issueNumber(issue.number), labels, token);
+  logger.log("issue-labeler: added " + labels.join(", ") + " to #" + issue.number);
+  return labels;
+}
+
+if (require.main === module) {
+  runIssueLabeler().catch((error) => {
+    console.error("issue-labeler: " + error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  addIssueLabels,
+  extractAreaAnswer,
+  fetchIssue,
+  labelsForIssue,
+  runIssueLabeler,
+  typeLabelForTitle,
+};

--- a/npm/scripts/issue-labeler.test.js
+++ b/npm/scripts/issue-labeler.test.js
@@ -1,0 +1,400 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  extractAreaAnswer,
+  labelsForIssue,
+  runIssueLabeler,
+  typeLabelForTitle,
+} = require("./issue-labeler.js");
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("typeLabelForTitle classifies conventional and conservative titles", () => {
+  const cases = new Map([
+    ["fix: stop a crash", "bug"],
+    ["feat(tui): add tabs", "enhancement"],
+    ["docs!: replace the guide", "documentation"],
+    ["test: cover overlays", "type:test"],
+    ["design: define the protocol", "type:design"],
+    ["refactor(core): split modules", "type:maintenance"],
+    ["security: scope credentials", "bug"],
+    ["Make manager goals orchestrate panes", "enhancement"],
+    ["Prevent startup failures", "bug"],
+    ["How does profile detection work?", "question"],
+  ]);
+
+  for (const [title, expected] of cases) {
+    assert.equal(typeLabelForTitle(title), expected, title);
+  }
+  assert.equal(typeLabelForTitle("Investigate pane behavior"), undefined);
+});
+
+test("extractAreaAnswer reads the structured feature form response", () => {
+  const body = "### Problem\n\nHard to use.\n\n### Area\n\nProfiles/configuration\n\n### Checklist\n\n- [x] Done";
+  assert.equal(extractAreaAnswer(body), "profiles/configuration");
+});
+
+test("labelsForIssue maps form area answers without duplicating form labels", () => {
+  const labels = labelsForIssue({
+    title: "feat: improve profile setup",
+    body: "### Area\n\nProfiles/configuration",
+    labels: [{ name: "enhancement" }],
+  });
+
+  assert.deepEqual(labels, [
+    "status:needs-triage",
+    "area:profiles",
+    "area:config",
+  ]);
+});
+
+test("labelsForIssue classifies CLI-created issues from strong title signals", () => {
+  const labels = labelsForIssue({
+    title: "fix: isolate Codex SQLite state per pane",
+    body: "Shell profiles need a unique environment variable while preserving shared config.",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, [
+    "bug",
+    "status:needs-triage",
+    "area:profiles",
+  ]);
+});
+
+test("labelsForIssue ignores incidental areas mentioned only in the body", () => {
+  const labels = labelsForIssue({
+    title: "feat: add automatic PR review agent",
+    body: [
+      "## Problem",
+      "",
+      "Reviews should cover PTY behavior and config persistence.",
+      "",
+      "## Requested behavior",
+      "",
+      "Run a trusted workflow.",
+      "",
+      "## Acceptance checks",
+      "",
+      "- Update the docs.",
+    ].join("\n"),
+    labels: [],
+  });
+
+  assert.deepEqual(labels, [
+    "enhancement",
+    "status:needs-triage",
+  ]);
+});
+
+test("agent-control security issues are architecture, not TUI controls", () => {
+  const labels = labelsForIssue({
+    title: "security: scope agent-control credentials and permissions per pane",
+    body: "",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, [
+    "bug",
+    "status:needs-triage",
+    "area:architecture",
+  ]);
+});
+
+test("labelsForIssue ignores bug-form metadata when inferring areas", () => {
+  const labels = labelsForIssue({
+    title: "bug: overlay is cut off",
+    body: [
+      "### GridBash version or commit",
+      "",
+      "0.1.6",
+      "",
+      "### Windows version",
+      "",
+      "Windows 11",
+      "",
+      "### Host terminal",
+      "",
+      "PowerShell",
+      "",
+      "### Launch command",
+      "",
+      "gridbash 2x2 --profile powershell",
+      "",
+      "### Steps to reproduce",
+      "",
+      "Open the help overlay.",
+      "",
+      "### Expected behavior",
+      "",
+      "The overlay fits the layout.",
+      "",
+      "### Actual behavior",
+      "",
+      "The overlay is clipped.",
+      "",
+      "### Checklist",
+      "",
+      "- [x] I searched existing issues.",
+    ].join("\n"),
+    labels: [{ name: "bug" }],
+  });
+
+  assert.deepEqual(labels, [
+    "status:needs-triage",
+    "area:tui",
+    "platform:windows",
+  ]);
+});
+
+test("a cross-platform bug form heading does not imply Windows", () => {
+  const labels = labelsForIssue({
+    title: "bug: startup exits unexpectedly",
+    body: [
+      "### GridBash version or commit",
+      "",
+      "0.1.6",
+      "",
+      "### Windows version",
+      "",
+      "N/A - Ubuntu 24.04",
+      "",
+      "### Host terminal",
+      "",
+      "bash",
+      "",
+      "### Launch command",
+      "",
+      "gridbash 2x2",
+    ].join("\n"),
+    labels: [{ name: "bug" }],
+  });
+
+  assert.deepEqual(labels, ["status:needs-triage"]);
+});
+
+test("documentation issues do not infer product areas from prose", () => {
+  const labels = labelsForIssue({
+    title: "docs: improve the README layout",
+    body: "Update the installation guide and package examples.",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, [
+    "documentation",
+    "status:needs-triage",
+    "area:docs",
+  ]);
+});
+
+test("labelsForIssue detects packaging and Windows without incidental docs", () => {
+  const labels = labelsForIssue({
+    title: "chore: test npm installer workflow",
+    body: "Validate PowerShell package installation docs and CI.",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, [
+    "type:maintenance",
+    "status:needs-triage",
+    "area:packaging",
+    "platform:windows",
+  ]);
+});
+
+test("labelsForIssue leaves priority and resolution decisions to maintainers", () => {
+  const labels = labelsForIssue({
+    title: "Investigate an unusual report",
+    body: "No strong classification signal.",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, ["status:needs-triage"]);
+  assert.equal(labels.some((label) => label.startsWith("priority:")), false);
+});
+
+test("closed issues do not receive a needs-triage status during backfill", () => {
+  const labels = labelsForIssue({
+    title: "docs: archive an old guide",
+    body: "",
+    labels: [],
+    state: "closed",
+  });
+
+  assert.deepEqual(labels, ["documentation", "area:docs"]);
+});
+
+test("labelsForIssue preserves existing category, status, area, and platform labels", () => {
+  const labels = labelsForIssue({
+    title: "fix: change a Windows TUI layout",
+    body: "PowerShell overlay rendering.",
+    labels: [
+      { name: "enhancement" },
+      { name: "status:accepted" },
+      { name: "area:architecture" },
+      { name: "platform:windows" },
+    ],
+  });
+
+  assert.deepEqual(labels, []);
+});
+
+test("issue text is handled only as inert classifier input", () => {
+  const labels = labelsForIssue({
+    title: "Investigate report",
+    body: "$" + "{{ secrets.GITHUB_TOKEN }}; process.exit(1)",
+    labels: [],
+  });
+
+  assert.deepEqual(labels, ["status:needs-triage"]);
+});
+
+test("runIssueLabeler posts only missing labels from an issue event", async () => {
+  const requests = [];
+  const logs = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    return jsonResponse([{ name: "bug" }, { name: "status:needs-triage" }]);
+  };
+
+  const labels = await runIssueLabeler({
+    environment: {
+      GITHUB_API_URL: "https://api.example",
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_TOKEN: "token",
+    },
+    payload: {
+      issue: { number: 42, title: "fix: crash on Windows", body: "", labels: [] },
+    },
+    fetchImpl,
+    logger: { log: (message) => logs.push(message) },
+  });
+
+  assert.deepEqual(labels, ["bug", "status:needs-triage", "platform:windows"]);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "https://api.example/repos/owner/repo/issues/42/labels");
+  assert.equal(requests[0].options.method, "POST");
+  assert.deepEqual(JSON.parse(requests[0].options.body), { labels });
+  assert.match(logs[0], /added bug, status:needs-triage, platform:windows to #42/);
+});
+
+test("runIssueLabeler can classify an existing issue from manual dispatch", async () => {
+  const requests = [];
+  const fetchImpl = async (url, options) => {
+    requests.push({ url, options });
+    if (options.method === "GET") {
+      return jsonResponse({
+        number: 99,
+        title: "feat: add manager goal orchestration",
+        body: "",
+        labels: [],
+      });
+    }
+    return jsonResponse([]);
+  };
+
+  const labels = await runIssueLabeler({
+    environment: {
+      GITHUB_API_URL: "https://api.example/",
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_TOKEN: "token",
+      ISSUE_NUMBER: "99",
+    },
+    payload: { inputs: { issue_number: "99" } },
+    fetchImpl,
+    logger: { log() {} },
+  });
+
+  assert.deepEqual(labels, [
+    "enhancement",
+    "status:needs-triage",
+    "area:composer",
+  ]);
+  assert.equal(requests.length, 2);
+  assert.equal(requests[0].url, "https://api.example/repos/owner/repo/issues/99");
+  assert.equal(requests[1].url, "https://api.example/repos/owner/repo/issues/99/labels");
+});
+
+test("runIssueLabeler skips the API when every matching label exists", async () => {
+  let called = false;
+  const labels = await runIssueLabeler({
+    environment: {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_TOKEN: "token",
+    },
+    payload: {
+      issue: {
+        number: 7,
+        title: "feat: add tabs",
+        body: "",
+        labels: ["enhancement", "status:accepted", "area:tui"],
+      },
+    },
+    fetchImpl: async () => {
+      called = true;
+      return jsonResponse([]);
+    },
+    logger: { log() {} },
+  });
+
+  assert.deepEqual(labels, []);
+  assert.equal(called, false);
+});
+
+test("runIssueLabeler refuses to label pull requests during manual dispatch", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    return jsonResponse({
+      number: 12,
+      title: "feat: pull request",
+      body: "",
+      labels: [],
+      pull_request: { url: "https://api.example/pulls/12" },
+    });
+  };
+
+  await assert.rejects(
+    runIssueLabeler({
+      environment: {
+        GITHUB_REPOSITORY: "owner/repo",
+        GITHUB_TOKEN: "token",
+        ISSUE_NUMBER: "12",
+      },
+      payload: { inputs: { issue_number: "12" } },
+      fetchImpl,
+      logger: { log() {} },
+    }),
+    /is a pull request, not an issue/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("runIssueLabeler rejects malformed manual issue numbers", async () => {
+  for (const invalid of ["0", "12oops", "12.5", "12e3"]) {
+    let called = false;
+    await assert.rejects(
+      runIssueLabeler({
+        environment: {
+          GITHUB_REPOSITORY: "owner/repo",
+          GITHUB_TOKEN: "token",
+          ISSUE_NUMBER: invalid,
+        },
+        payload: { inputs: { issue_number: invalid } },
+        fetchImpl: async () => {
+          called = true;
+          return jsonResponse({});
+        },
+        logger: { log() {} },
+      }),
+      /issue number must be a positive integer/,
+    );
+    assert.equal(called, false);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "install:local": "node npm/scripts/install-local.js",
     "prepare": "node npm/scripts/prepare.js",
     "release": "node npm/scripts/release.js",
+    "test:issue-labeler": "node --test npm/scripts/issue-labeler.test.js",
     "test:launcher": "node --test npm/scripts/gridbash-launcher.test.js",
     "test:review-agent": "node --test npm/scripts/review-agent.test.js",
     "test:star-history": "node --test npm/scripts/update-star-history.test.js",


### PR DESCRIPTION
## Summary

- automatically classify newly opened issues with existing type, triage, area, and Windows-platform labels
- preserve maintainer labels and avoid guessing priority or resolution state
- add focused classifier/API tests and CI coverage

## Validation

- `npm run test:issue-labeler` (19 tests)
- `npm run test:launcher`
- `npm run test:review-agent`
- `npm run test:star-history`
- `npm run test:version`
- `actionlint .github/workflows/issue-labeler.yml`
- `git diff --check`

Refs #199

