### PR TITLE
docs: streamline readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,14 @@ xcode-select --install
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+On Debian or Ubuntu, install the native build dependencies before Rust:
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential pkg-config libasound2-dev cmake clang
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
 Clone and build:
 
 ```powershell
@@ -49,15 +57,18 @@ cargo build
 Run from source:
 
 ```powershell
-cargo run -- 2x3 --profile powershell
+cargo run
 ```
 
-Install the npm shim from a local checkout:
+Install the npm command from a local checkout:
 
 ```powershell
-npm install -g .
+npm run install:local
 gridbash --list-profiles
 ```
+
+This installs from a packed copy so the global command does not point at a
+temporary worktree checkout.
 
 ## Validation
 
@@ -102,7 +113,7 @@ Please coordinate first before working on:
 Use the bug report issue template. A strong report includes:
 
 - GridBash version or commit.
-- Windows version.
+- OS and version.
 - Host terminal.
 - Shell or agent profile used.
 - Exact command that launched GridBash.

--- a/README.md
+++ b/README.md
@@ -1,543 +1,152 @@
 # GridBash
 
 [![CI](https://github.com/jasonsuhari/gridbash/actions/workflows/ci.yml/badge.svg)](https://github.com/jasonsuhari/gridbash/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/gridbash?label=npm)](https://www.npmjs.com/package/gridbash)
-[![npm downloads](https://img.shields.io/npm/dm/gridbash?label=npm%20downloads)](https://www.npmjs.com/package/gridbash)
-[![GitHub release](https://img.shields.io/github/v/release/jasonsuhari/gridbash?label=github)](https://github.com/jasonsuhari/gridbash/releases)
+[![npm](https://img.shields.io/npm/v/gridbash?label=npm)](https://www.npmjs.com/package/gridbash)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Platforms: Windows, Linux, macOS](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-0078D4.svg)](https://github.com/jasonsuhari/gridbash)
+[![Platforms](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-0078D4.svg)](https://github.com/jasonsuhari/gridbash)
 
 **The sexiest way to tokenmaxx.**
 
-GridBash by Jason Suhari is a cross-platform Rust TUI for agent-heavy development. Launch Codex, Claude, Gemini, Aider, OpenCode, Goose, Amp, Cursor, Copilot, your native shell, or any custom command into a real PTY grid, then select exactly which panes receive your prompt. Spawn manager agents that can do the prompting for you, or talk to your agents via Voice Mode.
+GridBash is a cross-platform Rust TUI for running CLI agents and shells side by
+side in real PTY panes. Send input to one pane, selected panes, or the whole
+grid without juggling terminal windows.
 
-Official site: [jasonsuhari.github.io/gridbash](https://jasonsuhari.github.io/gridbash/)
+[Website](https://jasonsuhari.github.io/gridbash/) |
+[npm](https://www.npmjs.com/package/gridbash) |
+[Releases](https://github.com/jasonsuhari/gridbash/releases) |
+[Full reference](docs/REFERENCE.md)
 
-[![GridBash launch teaser showing six CLI coding agents in one terminal grid](https://raw.githubusercontent.com/jasonsuhari/gridbash/main/docs/assets/gridbash-launch-teaser-poster.png)](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-launch-teaser.mp4)
+[![GridBash running six CLI coding agents in one terminal grid](https://raw.githubusercontent.com/jasonsuhari/gridbash/main/docs/assets/gridbash-launch-teaser-poster.png)](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-launch-teaser.mp4)
 
-GridBash is built for developers who want parallel CLI-agent work without juggling terminal windows, browser tabs, or accidental cross-pane input.
+## Quick start
 
-> V1 is intentionally single-process. Closing GridBash closes its child agents. Daemon detach/reattach is the next major frontier.
+Requires Node.js 18+. Published binaries support Windows x64, glibc-based Linux
+x64/arm64, and macOS 13+ on Apple Silicon or Intel.
 
-## Quickstart
-
-Install the published package on Windows x64, Linux x64/arm64, or macOS 13+
-(Apple Silicon or Intel):
-
-```powershell
+```sh
 npm install -g gridbash
 gridbash
 ```
 
-Open a focused CLI-agent grid:
+Or launch a six-pane Codex grid directly:
 
-```powershell
+```sh
 gridbash 2x3 --profile codex
 ```
 
-Launch every pane in a separate repo-local git worktree:
+The npm package installs only the native binary for your current platform.
 
-```powershell
-gridbash 2x3 --profile codex --worktrees
-```
+## Why GridBash
 
-## Why Developers Try It
+- **Precise input routing.** Type into the focused pane, a selected set, or the
+  entire grid.
+- **Real terminals.** Run up to 100 PTY-backed panes across tabbed grids.
+- **Safer parallel work.** Give every pane an isolated repo-local git worktree.
+- **Agent-first profiles.** Launch Codex, Claude, Gemini, Aider, OpenCode, Goose,
+  Amp, Cursor, Copilot, shells, or custom commands.
+- **Built-in workflow tools.** Resize grids, restore sessions, dictate prompts,
+  inspect pane activity, and let a manager route targeted follow-ups.
 
-- Run up to 100 PTY-backed panes from one terminal process.
-- Send input to one pane, selected panes, or every pane in the grid.
-- Start panes in isolated repo-local git worktrees for safer parallel agent work.
-- Use modeless Alt shortcuts and mouse selection without leaving normal terminal mode.
-- Launch common CLI agents with built-in profiles for Codex, Claude, Gemini, Aider, OpenCode, Goose, Amp, Cursor, and Copilot.
+## Common commands
 
-## What GridBash Is For
+| Command | Result |
+| --- | --- |
+| `gridbash` | Open the interactive grid picker |
+| `gridbash 2x3 --profile codex` | Launch a 2-by-3 Codex grid |
+| `gridbash --count 12 --layout auto --profile claude` | Auto-arrange 12 Claude panes |
+| `gridbash 2x3 --profile codex --worktrees` | Isolate every pane in a git worktree |
+| `gridbash resume` | Choose a saved session to reopen |
+| `gridbash resume --latest` | Reopen the latest saved session |
+| `gridbash --list-profiles` | Show detected profiles and resolved commands |
+| `gridbash --help` | Show every CLI option |
 
-GridBash is for CLI agent orchestration in the terminal: compare ideas from multiple coding agents, run review/build/test loops in parallel, keep shells visible, and send a prompt only to the panes that should receive it.
+`--worktrees` requires a git repository with at least one commit and no tracked
+modifications. See the [reference](docs/REFERENCE.md#managed-git-worktrees) for
+its folder, branch, and reuse behavior.
 
-Its niche is PTY-backed, agent-first terminal grids on Windows, Linux, and
-macOS. Traditional terminal multiplexers are still great; GridBash focuses on
-the workflows that appear when Codex, Claude, Gemini, Aider, and other CLI
-agents are all part of the same development session.
+## Essential controls
 
-## Release Status & Devlogs
+GridBash shortcuts are modeless, so normal terminal keys continue to reach your
+agents and shells.
 
-- Latest npm version is shown by the npm badge above and on the npm package page.
-- Latest GitHub release is shown by the GitHub release badge above and on the GitHub Releases page.
-- Devlogs live in `docs/devlogs/`.
-- Versioned release notes live in `docs/releases/` and are used for GitHub release notes.
-- npm packages include `docs/devlogs/` and `docs/releases/` so published package contents carry the logs too.
-- The [v1.0 acceptance checklist](docs/V1_ACCEPTANCE.md) defines the stable-release gates.
-- The [daemon architecture proposal](docs/DAEMON_ARCHITECTURE.md) defines the detach/reattach direction beyond v1.
+| Input | Action |
+| --- | --- |
+| Drag mouse | Select and copy text inside one pane |
+| Right-click pane | Add or remove the pane from the selected set |
+| `Alt` + arrow keys | Move focus between panes |
+| `Alt+s` / `Alt+a` | Toggle the focused pane / select or clear all panes |
+| `Alt+c` | Open or close the command line |
+| `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
+| `Alt+p` | Open focused-pane activity |
+| `Alt+g` / `Alt+u` | Start or stop the grid manager goal |
+| `Alt+Shift+V` | Dictate one prompt without submitting it |
+| `Alt+o` | Open settings |
+| `Alt+h` or `F1` | Open the full in-app shortcut guide |
+| `Alt+q` | Quit |
 
-## Star History
+See the [full controls reference](docs/REFERENCE.md#controls) for resizing,
+renaming, sleeping, restarting, scrolling, settings, and recovery actions.
 
-[![GridBash GitHub star history chart](docs/assets/gridbash-star-history.svg)](https://github.com/jasonsuhari/gridbash/stargazers)
+## Profiles and configuration
 
-_Refreshed daily by the [Star History workflow](https://github.com/jasonsuhari/gridbash/actions/workflows/star-history.yml). Click the chart to see the current stargazers._
+Agent profiles are available on every platform: `codex`, `claude`, `gemini`,
+`opencode`, `aider`, `amp`, `goose`, `copilot`, and `cursor`.
+Profiles invoke CLIs already installed on your system; GridBash does not bundle
+the agents themselves.
 
-## Highlights
-
-- Real PTY-backed panes through Windows ConPTY or Unix PTYs via `portable-pty`.
-- Up to 100 panes in one terminal process.
-- Multiple tabbed grids in one terminal process.
-- Configurable default terminal profile: Git Bash, PowerShell, cmd, agents, or custom.
-- Pane-contained drag selection that copies selected terminal text without crossing into sibling panes.
-- Sleeping panes stay visually hidden until hovered, then wake without crossing input into other panes.
-- Normal terminal keys pass through to the focused pane, or to selected panes when multiple panes are selected.
-- Modeless Alt shortcuts for pane focus, selection, rename, settings, grid manager goals, and quit.
-- Grid manager goals review live pane output and route targeted follow-ups across the current grid.
-- Compact dark theme with focus, selection, sleep, exit, usage, and quiet-output cues.
-- Pane headers show live terminal activity, with a configured manager goal taking priority.
-- Built-in launch profiles for common CLI coding agents.
-- Startup dimension picker with a live grid preview.
-- `gridbash resume` for reopening prior grids with per-pane command and output context.
-- Optional managed git worktrees so every pane can work in an isolated checkout.
-
-## Demo Assets
-
-- Watch the 13-second launch teaser: [`docs/assets/gridbash-launch-teaser.mp4`](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-launch-teaser.mp4).
-- Watch the OpenVid-style demo: [`docs/assets/gridbash-openvid-demo.mp4`](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-openvid-demo.mp4).
-- Rebuild the teaser from its HyperFrames source in [`docs/demo/gridbash-launch-teaser/`](docs/demo/gridbash-launch-teaser/).
-- See the source scene and OpenVid recreation recipe in [`docs/demo/openvid-gridbash-demo.md`](https://github.com/jasonsuhari/gridbash/blob/main/docs/demo/openvid-gridbash-demo.md).
-- Use [`docs/assets/gridbash-social-preview.png`](docs/assets/gridbash-social-preview.png) as the GitHub social preview image.
-- Use the ready-to-post copy and publication sequence in [`docs/LAUNCH_KIT.md`](docs/LAUNCH_KIT.md).
-
-## Install From This Repo
-
-For local development installs:
-
-```powershell
-npm run install:local
-```
-
-Then run GridBash from anywhere:
-
-```powershell
-gridbash
-```
-
-Build a publishable npm tarball:
-
-```powershell
-npm pack
-```
-
-The package ships a small Node command shim and downloads only the native package for the current OS and architecture.
-
-Release automation and devlog workflow are documented in `docs/RELEASING.md`.
-
-Use `npm run install:local` for local development installs. It installs from a packed tarball so the global `gridbash` command points at a stable package copy, not whichever `.worktrees/` checkout last ran `npm install -g .`.
-
-## PR Workflow
-
-Pull requests can be merged directly after they have been reviewed. Before merging, check the diff, confirm the intent is clear, and make sure the relevant validation has passed.
-
-## Install From Source
-
-Install Rust first. On Windows:
-
-```powershell
-winget install --id Rustlang.Rustup -e
-```
-
-On macOS:
-
-```bash
-xcode-select --install
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-On Debian or Ubuntu Linux, install the native build prerequisites before Rust:
-
-```bash
-sudo apt-get install build-essential pkg-config libasound2-dev cmake clang
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-Build GridBash:
-
-```powershell
-git clone https://github.com/jasonsuhari/gridbash
-cd gridbash
-cargo build --release
-```
-
-The executable is `target\release\gridbash.exe` on Windows or
-`target/release/gridbash` on Linux and macOS. On Windows:
+Terminal profiles are platform-specific:
 
 ```text
-target\release\gridbash.exe
+Windows:      git-bash pwsh powershell cmd
+macOS/Linux:  zsh bash fish sh pwsh
 ```
 
-## Use
+Run `gridbash --list-profiles` to see what is available on your machine. Direct
+launches resolve profiles in this order: `--profile`, `GRIDBASH_PROFILE`, the
+invoking Windows shell, the configured default, then the platform default.
 
-Open the startup grid picker:
+Start from [`config.example.toml`](config.example.toml) to define custom
+profiles, UI settings, auth defaults, manager credentials, and workload policy.
+The [configuration reference](docs/REFERENCE.md#configuration) covers file
+locations and precedence.
 
-```powershell
-gridbash
-```
+## Agent control API
 
-When launched through the npm command on Windows, GridBash inherits the invoking
-shell for new panes: PowerShell launches PowerShell, PowerShell 7 launches
-`pwsh`, cmd launches cmd, and Git Bash launches Git Bash. Linux defaults to bash
-and macOS defaults to zsh. Use `--profile` or `GRIDBASH_PROFILE` to override the
-platform default.
+Enable GridBash's local, opt-in control API for agents inside its panes:
 
-If the invoking shell cannot be detected and no default profile is configured, GridBash opens an animated setup screen and asks you to choose from the detected terminal profiles. The choice is saved to:
-
-```text
-%APPDATA%\GridBash\config.toml
-```
-
-The startup picker asks for rows and columns, updates the preview grid as you change them, and launches every pane in the directory where you started `gridbash`.
-
-Set the fallback terminal profile used when shell inheritance is unavailable:
-
-```powershell
-gridbash --set-default powershell
-```
-
-Open a specific grid:
-
-```powershell
-gridbash 2x3 --profile git-bash
-```
-
-Open 12 panes and auto-arrange them:
-
-```powershell
-gridbash --count 12 --layout auto --profile claude
-```
-
-List detected profiles:
-
-```powershell
-gridbash --list-profiles
-```
-
-Resume a prior grid:
-
-```powershell
-gridbash resume
-```
-
-Resume the latest saved grid without prompting:
-
-```powershell
-gridbash resume --latest
-```
-
-List saved sessions or resume a specific id:
-
-```powershell
-gridbash resume --list
-gridbash resume <session-id>
-```
-
-Start in a repo:
-
-```powershell
-gridbash 3x4 --profile codex --cwd C:\Users\Jason\Documents\GitHub\fluent
-```
-
-Passing grid, count, profile, or cwd arguments bypasses the startup picker and uses the direct launch path.
-
-GridBash saves bounded session snapshots to local app data as you launch and exit grids. A resumed session restores the grid dimensions, pane profiles, working directories, labels, worktree names, and a pane-local history view with recent submitted commands and output. It relaunches child terminals; it does not reattach still-running processes or replay old commands into shells.
-
-Launch every pane in a separate repo-local git worktree:
-
-```powershell
-gridbash 2x3 --profile codex --worktrees
-```
-
-With `--worktrees`, GridBash creates or reuses `.worktrees/gridbash-<base>-NN` folders and `gridbash/<base>-pane-NN` branches. Panes keep the same relative folder as the directory where you launched GridBash, so starting from `repo\app` opens each terminal in the matching `app` folder inside its managed worktree. GridBash refuses this mode outside a git repo or when tracked changes are present in the base checkout.
-
-You can also run `gridbash --worktrees` and choose the grid dimensions in the startup picker.
-
-## Agent Control MCP
-
-GridBash can expose a local, opt-in control API for agents running inside its panes:
-
-```powershell
+```sh
 gridbash --agent-api 2x3 --profile codex
 ```
 
-When enabled, child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`, and `GRIDBASH_PANE_INDEX`. Configure an agent MCP server command to run:
+Configure an agent MCP server to run `gridbash --mcp`. It can show local images,
+send commands to specific panes, and update the GridBash status bar. The API is
+localhost-only, token-authenticated, and off by default.
 
-```powershell
-gridbash --mcp
-```
+## Compatibility and current limits
 
-The MCP server exposes:
+- GridBash targets modern UTF-8, ANSI/xterm-compatible terminals and works over
+  SSH or tmux when the remote session advertises a color-capable `TERM`.
+- Use `--no-mouse` when a terminal or multiplexer does not forward mouse input.
+  `TERM=dumb` and Linux kernel consoles are not supported.
+- GridBash v1 is single-process: quitting it closes its child agents. Session
+  resume restores layout, pane metadata, and recent context by relaunching
+  terminals; it does not reattach live processes or replay commands.
 
-- `gridbash_show_image` to display a local png, jpg, gif, or webp in a GridBash overlay.
-- `gridbash_send_command` to send command text to one or more 1-based pane numbers.
-- `gridbash_set_status` to update the GridBash status bar.
+## Development
 
-The control API binds to localhost, uses a per-session token, and is off by default.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and pull request
+guidance. Use `npm run install:local` for a local GridBash command; it installs a
+packed copy instead of linking the command to a worktree.
 
-## Startup Picker Controls
+Release maintainers should follow [docs/RELEASING.md](docs/RELEASING.md).
 
-| Input | Action |
-| --- | --- |
-| Left / Right | Switch between rows and columns |
-| Up / Down | Increase or decrease the active dimension |
-| r / c | Select rows or columns |
-| 1-9 / 0 | Set the active dimension directly, with 0 meaning 10 |
-| Enter | Launch the grid |
-| Esc / q | Quit |
+## Project links
 
-## Controls
+- [User reference](docs/REFERENCE.md)
+- [Roadmap](docs/ROADMAP.md)
+- [Devlogs](docs/devlogs/)
+- [Support](SUPPORT.md)
+- [Contributing](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
 
-GridBash captures drag selection so selected text stays inside the pane where the drag started. Releasing the drag sends the selected terminal text to the host clipboard through the standard OSC 52 terminal clipboard sequence. App controls use Alt shortcuts and do not require switching modes.
-
-| Input | Action |
-| --- | --- |
-| Drag mouse | Select/copy terminal text within the source pane |
-| Right-click pane | Toggle that pane in or out of the selected set |
-| Mouse wheel | Scroll only the pane under the pointer; selected panes use GridBash scrollback |
-| Alt+Left / Alt+Right | Focus previous / next pane in the row, wrapping at row edges |
-| Alt+Up / Alt+Down | Focus pane above / below in the column, wrapping at column edges |
-| Alt+l | Open the grid resizer; Enter applies the chosen dimensions and Esc cancels |
-| Alt+n | Open the startup picker and launch a new tab |
-| Alt+t | Switch to the next tab |
-| Alt+s | Toggle focused pane selection |
-| Alt+a | Select all panes, or clear selection when all panes are selected |
-| Alt+c | Expand and focus the command line, or close it when focused |
-| Alt+Shift+V | Listen for one dictated utterance; press again to cancel |
-| Alt+h or F1 | Open or close the in-app help and shortcut legend |
-| Alt+p | Open the focused-pane activity summary; use Up/Down and Enter to navigate its controls |
-| Alt+Shift+p | Open the previous panes list |
-| Alt+r | Rename the focused pane |
-| Alt+Shift+r | Rename the current tab |
-| Alt+Shift+t | Restart exited focused pane; when multiple panes are selected, restart exited selected panes |
-| Alt+z | Put the focused pane to sleep; when multiple panes are selected, sleep the selected panes |
-| Alt+g | Create or edit the current grid's manager goal |
-| Alt+u | Stop the current grid's manager goal |
-| Hover sleeping pane | Wake the pane and make its terminal contents visible again |
-| Alt+o | Open settings |
-| Alt+q | Quit |
-
-The focused-pane activity summary includes auth, rename, refresh, sleep/wake,
-and manager-goal controls for the current grid. Use `Up`/`Down` to select a
-control and `Enter` or `Space` to use it. The direct shortcuts remain available:
-`n` renames, `r` refreshes the activity snapshot, `z` sleeps or wakes the pane,
-`g` creates or edits the grid goal, and `u` stops it. The grid manager reviews
-relevant live panes and sends each follow-up only to its validated awake,
-running targets.
-
-Each pane's top border shows its latest activity summary instead of repeating
-the folder, branch, and launch profile. When a grid manager goal is set, its
-objective takes that spot across the grid until the goal is removed.
-
-Press `Esc`, `q`, or `Alt+p` to close the activity summary, or `Alt+o` to switch
-to overall settings.
-
-When the focused pane has exited, GridBash shows a recovery dialog. Press `Enter`,
-`r`, or `t` to restart it, or press `z` to put it to sleep. `Alt+Shift+t` restarts
-exited target panes directly.
-
-Typing goes to selected panes whenever multiple panes are selected. With zero or one pane selected, input goes to the focused pane. Alt+C expands and focuses the command line with its captured output visible; typing stays in the command bar, and Enter runs the command from the cwd shown in the prompt. Press Alt+C again to close it and return input to the pane grid.
-
-The grid resizer uses the same row-and-column picker as startup, with active cells
-shown in blue. Shrinking removes live panes outside the retained upper-left
-rectangle. For example, changing 3x3 to 3x2 deactivates the full rightmost column.
-
-Voice mode uses modern Windows dictation on Windows, Apple Speech on macOS, and
-offline Whisper transcription on Linux.
-`Alt+Shift+V` to listen for one utterance; GridBash waits up to 15 seconds for speech.
-The transcript is inserted into the command bar or the panes that were targeted
-when listening started. GridBash never presses Enter for dictated text, so you can
-review or edit it before submitting. Press `Alt+Shift+V` while listening to cancel.
-
-Voice audio is processed by Microsoft's online speech service. Enable **Online
-speech recognition** in Windows Settings under **Privacy & security > Speech**,
-allow desktop apps to access the microphone, and install the Windows speech
-language pack matching the desired dictation language. If any requirement is
-missing, GridBash reports the Windows dictation error instead of inserting text.
-
-On macOS, GridBash asks for Speech Recognition and Microphone permission on
-first use. It prefers on-device recognition and uses Apple's authorized speech
-service when the current locale does not support local recognition.
-
-On Linux, the first voice shortcut explains that a 57 MiB offline model is
-required; press the shortcut again to approve the one-time download. The model
-is checksum-verified and stored in the local XDG data directory. Audio remains
-on the machine. Set `GRIDBASH_VOICE_MODEL` to use another local Whisper model,
-or `GRIDBASH_SPEECH_HELPER` to override the packaged helper. Microphone capture
-uses ALSA and may require granting device access in containers or remote sessions.
-
-## Terminal Compatibility
-
-GridBash targets modern UTF-8, ANSI/xterm-compatible terminals, including
-Windows Terminal, Apple Terminal, iTerm2, GNOME Terminal, Konsole, Kitty,
-WezTerm, and Alacritty. It also works through SSH and tmux when the remote
-session advertises a color-capable `TERM`. `TERM=dumb` and Linux kernel consoles
-are not supported. Use `--no-mouse` when a terminal, serial link, or multiplexer
-does not forward mouse reporting; keyboard navigation remains available.
-
-Renamed pane headers replace the numeric prefix for the current session. Saving a blank name restores the default number.
-
-Settings includes a General tab for local runtime display controls and an Auth tab for GridBash-wide Claude/Codex auth defaults and launch policy. Pane Activity lets each Claude or Codex pane select its own compatible auth account; applying a different account restarts only that pane.
-
-Pane titles add a small quiet-output marker after roughly three seconds without output. The marker means a pane produced output and then went idle; it does not mean the process exited or completed its task.
-
-Settings persist compact titles, activity badges, quit confirmation, scrollback
-for newly launched panes, refresh delay, workload policy, todo prompts, and the
-accent/focus/selected/quiet/exited palette. Changes apply immediately when the
-runtime supports it and remain active after restart.
-
-## Auth Profiles
-
-GridBash can launch Claude and Codex with isolated auth/config directories. It discovers profiles from:
-
-```text
-GRIDBASH_AUTH_HOME > [auth].home > CLAUDE_PROFILES_HOME (legacy) > %USERPROFILE%\.gridbash-auth
-```
-
-Claude profiles launch with `CLAUDE_CONFIG_DIR=<profile-dir>`. Codex profiles launch with `CODEX_HOME=<profile-dir>`.
-
-GridBash also leases every pane a unique persistent `CODEX_SQLITE_HOME`, including
-terminal profiles where you start `codex` manually. Lanes are separated by
-`CODEX_HOME`, protected by cross-process file locks, and reused only after the
-previous pane releases its lease. This keeps concurrent Codex processes from
-contending for the same SQLite databases while shared auth, config, skills, and
-rollout files remain under `CODEX_HOME`. The first use of a new lane can take
-longer while Codex indexes existing rollouts; SQLite-only state such as goals,
-memories, and thread relationships remains local to that lane.
-
-A non-empty `CODEX_SQLITE_HOME` exported before GridBash starts opts out of
-automatic isolation and is left unchanged. Codex's `sqlite_home` config setting
-also keeps its normal precedence. Do not point concurrent panes at the same
-override, or the original lock contention can return.
-
-The default home changed from `%USERPROFILE%\.claude-profiles` to `%USERPROFILE%\.gridbash-auth`. Existing profiles are not moved automatically. Move them to the new directory, set `[auth].home` to the old directory, or keep using the legacy `CLAUDE_PROFILES_HOME` override.
-
-Auth assignment is manual by default. In manual mode, new panes use the configured default for their agent kind and keep any per-pane selection. When auto-cycle is enabled, new compatible panes are assigned round-robin across ready auth profiles of the matching kind. Changing the policy does not restart panes that are already running.
-
-Auth settings controls:
-
-| Input | Action |
-| --- | --- |
-| Tab | Switch Settings tabs |
-| Up / Down | Move through auth profiles |
-| d | Set selected profile as the GridBash-wide default for its kind |
-| c | Toggle manual assignment / auto-cycle for new panes |
-| n | Create a profile directory |
-| l | Open the selected profile's login command |
-| r | Refresh local account and usage status |
-| Esc / q | Close settings |
-
-For a Claude or Codex pane, open Pane Activity with `Alt+p`, use Up/Down to select the auth control, use Left/Right to choose a compatible auth profile, and press Enter to apply it and restart that pane. Press `r` there to refresh the activity snapshot.
-
-Usage status is best-effort. GridBash reads local auth metadata, masks account emails, and uses short-timeout `curl.exe` (Windows) or `curl` (macOS) requests only while the Auth settings view is refreshed.
-
-## Profiles
-
-Built-in terminal profile keys are platform-specific:
-
-```text
-Windows: git-bash pwsh powershell cmd
-macOS:  zsh bash fish sh pwsh
-Linux:  zsh bash fish sh pwsh
-```
-
-Run `gridbash --list-profiles` for a diagnostic table showing the selected
-default, built-in versus custom source, availability, resolved executable, or an
-actionable missing-command reason. This command never prints profile environment
-values, auth tokens, or manager credentials.
-
-Agent profile keys remain available on every platform: `codex`, `claude`,
-`gemini`, `opencode`, `aider`, `amp`, `goose`, `copilot`, and `cursor`.
-
-GridBash resolves Windows `.exe` and `.cmd` shims before extensionless npm shims, so common Node-based CLIs launch correctly.
-
-Optional config file:
-
-```text
-%APPDATA%\GridBash\config\config.toml
-```
-
-Example:
-
-```toml
-[defaults]
-profile = "powershell"
-# Use "normal" to opt out of GridBash's desktop-responsiveness safeguard.
-pane_priority = "below-normal"
-# Use "unrestricted" to disable adaptive CPU sharing between pane workloads.
-pane_workload = "adaptive"
-
-[manager]
-endpoint = "https://api.openai.com/v1/chat/completions"
-model = "gpt-4o-mini"
-api_key = "sk-..."
-
-[auth]
-home = "C:\\Users\\Jason\\.gridbash-auth"
-auto_cycle = false
-usage_status = true
-
-[auth.defaults]
-claude = "claude-1"
-codex = "codex-2"
-
-[profiles.review]
-command = "codex"
-args = ["--model", "gpt-5.5"]
-title = "Codex Review"
-agent_kind = "codex"
-```
-
-Then run:
-
-```powershell
-gridbash 2x4 --profile review
-```
-
-Default profile resolution order:
-
-```text
---profile > GRIDBASH_PROFILE > [defaults].profile > platform default
-```
-
-The platform default is Git Bash on Windows, zsh on macOS, and bash on other
-Unix systems. In Apple Terminal or iTerm2, configure Option as the Meta/Alt key
-so GridBash's Alt shortcuts reach the TUI.
-
-GridBash keeps its own interface at normal Windows process priority, while pane
-processes default to `below-normal`. Child workloads such as parallel compilers
-normally inherit that priority, which keeps input and other desktop apps responsive
-when many panes are busy. On Windows, the default `adaptive` pane workload policy
-also gives focused and selected panes more CPU time than hidden or sleeping panes
-when the system is contested; every pane continues running. Set
-`[defaults].pane_workload = "unrestricted"` to disable adaptive sharing, or change
-the Workload policy under Performance settings while GridBash is running.
-
-The grid manager uses the OpenAI-compatible chat-completions endpoint, model, and
-API key under `[manager]`. These values can also be edited from the Manager tab in
-GridBash settings; the key is masked in the UI and stored in the local GridBash
-config. Press `Alt+g` or use focused-pane activity controls to create a goal for
-the current grid. Reviews include pane-numbered output, and validated follow-ups
-remain bound to their intended PTYs when panes are reordered.
-
-Starting a grid goal sends pane role/folder metadata and bounded recent output
-from every awake pane in that grid to the configured manager API. Sleeping and
-exited panes are never command targets, and their output is omitted from reviews.
-
-## Design Goals
-
-GridBash is inspired by agent-first multiplexers such as Mato and terminal workspaces such as Zellij, but takes a different path: native PTYs, visual selection, scoped multi-pane input, and a hard bias toward fast multi-agent grids.
-
-## Community
-
-- Read `CONTRIBUTING.md` before opening a pull request.
-- See [`docs/AUTOMATED_REVIEW.md`](docs/AUTOMATED_REVIEW.md) for the automatic
-  pull request review agent, security model, and optional managed alternatives.
-- See `docs/ROADMAP.md` for the release roadmap.
-- Use GitHub Issues for actionable bugs, tasks, and feature requests.
-- Use GitHub Discussions for questions, ideas, and longer design conversation.
-- Follow `SECURITY.md` for private vulnerability reports.
-
-## Legacy Launcher
-
-The old Windows Terminal launcher is still useful for quick split-pane grids, but it cannot support true subset pane input because Windows Terminal does not expose subset pane selection. The Rust app is the path forward.
+GridBash is available under the [MIT License](LICENSE).

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,6 @@
 [defaults]
-profile = "git-bash"
+# Set this to a key reported by `gridbash --list-profiles`.
+# profile = "git-bash"
 # Keeps compilers and other pane workloads from starving interactive desktop apps.
 pane_priority = "below-normal"
 # Shares CPU fairly under contention while keeping every pane process running.
@@ -32,7 +33,8 @@ prompts = [
 ]
 
 [auth]
-home = "C:\\Users\\Jason\\.gridbash-auth"
+# Optional absolute directory for isolated Claude and Codex profiles.
+# home = "C:\\Users\\you\\.gridbash-auth"
 auto_cycle = false
 usage_status = true
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,343 @@
+# GridBash Reference
+
+This guide covers launch options, sessions, managed worktrees, controls, profiles,
+configuration, and platform-specific behavior. See the [project
+README](../README.md) for installation and a shorter introduction.
+
+## Launch grids
+
+Run `gridbash` with no arguments to open the row-and-column picker. The picker launches panes in the directory where GridBash was started.
+
+Common direct launches:
+
+```powershell
+# Fixed grid
+gridbash 2x3 --profile codex
+
+# Auto-arrange a pane count
+gridbash --count 12 --layout auto --profile claude
+
+# Start elsewhere
+gridbash 3x4 --profile codex --cwd C:\path\to\repo
+
+# Use a custom config file
+gridbash 2x3 --config C:\path\to\gridbash.toml
+```
+
+The main launch options are:
+
+| Option | Behavior |
+| --- | --- |
+| `ROWSxCOLS` | Set an explicit grid, such as `2x3`. |
+| `--count N` | Launch `N` panes, up to 100. |
+| `--layout auto` | Derive the grid dimensions from the pane count. |
+| `--profile NAME` | Use one built-in or custom profile for all panes. |
+| `--cwd PATH` | Set the panes' starting directory. |
+| `--worktrees` | Give each pane a managed git worktree. |
+| `--worktree-prefix NAME` | Change the managed folder and branch prefix from `gridbash`. |
+| `--config PATH` | Load and save an alternate TOML configuration file. |
+| `--no-mouse` | Leave mouse handling to the host terminal. |
+| `--agent-api` | Enable the local agent control API. |
+| `--agent-api-port PORT` | Choose the port for the enabled API; `0` selects a free port. A nonzero value also enables the API. |
+
+Grid, count, profile, cwd, or auto-layout arguments use the direct launch path and bypass the startup picker. `gridbash --worktrees` by itself still opens the picker.
+
+On first launch without a CLI profile, environment override, detected invoking shell, or configured default, GridBash asks you to choose from the terminal profiles it can find. The choice is saved to `%APPDATA%\GridBash\config\config.toml` on Windows. Change it later with:
+
+```powershell
+gridbash --set-default powershell
+```
+
+### Startup picker
+
+| Input | Action |
+| --- | --- |
+| Left / Right | Switch between rows and columns. |
+| Up / Down | Increase or decrease the active dimension. |
+| `r` / `c` | Select rows or columns. |
+| `1`-`9` / `0` | Set the active dimension; `0` means 10. |
+| Enter | Launch the grid. |
+| Esc / `q` | Quit. |
+
+## Sessions and resume
+
+GridBash writes bounded session snapshots to local app data when grids launch and exit. Resume interactively, resume the latest snapshot, list snapshots, or select a session by its full ID or unique prefix:
+
+```powershell
+gridbash resume
+gridbash resume --latest
+gridbash resume --list
+gridbash resume <session-id>
+```
+
+A snapshot restores grid dimensions, pane profiles, working directories,
+worktree names, auth assignments, and a pane-local view of recent submitted
+commands and output. Resume starts new child terminals. It does not reattach old
+processes or replay commands into a shell.
+
+GridBash is currently single-process: closing it closes its child agents. Session resume is recovery context, not detach and reattach.
+
+## Managed git worktrees
+
+Use `--worktrees` to isolate every pane in a repo-local checkout:
+
+```powershell
+gridbash 2x3 --profile codex --worktrees
+gridbash 2x3 --profile codex --worktrees --worktree-prefix review
+```
+
+With the default prefix, GridBash creates or reuses:
+
+```text
+.worktrees/gridbash-<base>-NN
+gridbash/<base>-pane-NN
+```
+
+The first pattern is the folder and the second is its branch. A custom prefix replaces `gridbash` in both.
+
+GridBash preserves the launch directory relative to the repository root. Starting from `repo\app`, for example, opens each pane in the matching `app` directory inside its worktree.
+
+Managed mode requires a git repository with at least one commit and refuses to
+start when the base checkout has tracked changes. Untracked files do not block
+launch. Existing branches and worktrees are reused only when they match the
+expected repository and branch.
+
+## Agent control API
+
+The opt-in agent API lets tools running in a pane control the current GridBash session:
+
+```powershell
+gridbash --agent-api 2x3 --profile codex
+```
+
+Child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`, and the 1-based `GRIDBASH_PANE_INDEX`. Configure an agent's MCP client to run this stdio server from a pane:
+
+```powershell
+gridbash --mcp
+```
+
+The MCP server exposes:
+
+| Tool | Behavior |
+| --- | --- |
+| `gridbash_show_image` | Display a local PNG, JPEG, GIF, or WebP file in an overlay. |
+| `gridbash_send_command` | Send text to one or more 1-based pane numbers; submitting with Enter is optional. |
+| `gridbash_set_status` | Replace the current session's status-bar message. |
+
+The API binds only to localhost, authenticates with a per-session token, and is disabled by default.
+
+## Controls
+
+GridBash is modeless: ordinary terminal input continues to the active target, while application commands use Alt shortcuts.
+
+| Input | Action |
+| --- | --- |
+| Drag mouse | Select terminal text inside the pane where the drag began and copy it on release. |
+| Right-click pane | Add or remove that pane from the selected set. |
+| Mouse wheel | Scroll only the pane under the pointer; selected panes use GridBash scrollback. |
+| Alt+Left / Alt+Right | Focus the previous or next pane in the row, wrapping at the edge. |
+| Alt+Up / Alt+Down | Focus the pane above or below, wrapping at the edge. |
+| Alt+l | Resize the current grid. |
+| Alt+x | Swap the two selected panes. |
+| Alt+n | Open the startup picker and launch a new tab. |
+| Alt+t | Switch to the next tab. |
+| Alt+s | Toggle selection of the focused pane. |
+| Alt+a | Select all panes, or clear the set when all are selected. |
+| Alt+c | Open or close the expanded command line. |
+| Alt+Shift+V | Dictate one utterance, or cancel active listening. |
+| Alt+h / F1 | Open or close help. |
+| Alt+p | Open the focused-pane activity summary. |
+| Alt+Shift+P | Open the previous-panes list. |
+| Alt+r | Rename the focused pane. |
+| Alt+Shift+R | Rename the current tab. |
+| Alt+Shift+T | Restart the exited focused pane, or all exited selected panes. |
+| Alt+z | Sleep the focused pane, or all selected panes. |
+| Hover sleeping pane | Wake it and reveal its terminal. |
+| Alt+g | Create or edit the current grid's manager goal. |
+| Alt+u | Stop the current grid's manager goal. |
+| Alt+o | Open settings. |
+| Alt+q | Quit. |
+
+Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
+
+When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
+
+Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+o switches to overall settings.
+
+If the focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
+
+The resize picker starts from the current dimensions. Shrinking a grid deactivates live panes outside the retained upper-left rectangle; changing `3x3` to `3x2`, for example, removes the rightmost column.
+
+A pane's top border shows its latest activity summary. A configured manager goal replaces that summary across the grid until removed. A quiet marker appears after roughly three seconds without output; it indicates output followed by inactivity, not completion or process exit. Saving a blank pane name restores its default number.
+
+## Voice mode
+
+Press Alt+Shift+V to listen for one utterance, for up to 15 seconds. The transcript goes to the command line or to the panes targeted when listening began. GridBash never presses Enter for dictated text, so it can be reviewed before submission. Press the shortcut again to cancel.
+
+### Windows
+
+Windows dictation uses Microsoft's online speech service. Enable **Online speech recognition** under **Privacy & security > Speech**, allow desktop applications to use the microphone, and install the speech language pack for the desired dictation language. GridBash reports the platform error when a requirement is missing.
+
+### macOS
+
+GridBash asks for Speech Recognition and Microphone access on first use. It prefers on-device recognition and uses Apple's authorized speech service when the current locale does not support local recognition.
+
+### Linux
+
+Linux voice mode uses offline Whisper. The first shortcut explains that a 57 MiB model is required; press it again to approve the one-time download. GridBash checksum-verifies the model and stores it in the local XDG data directory, and audio stays on the machine.
+
+Set `GRIDBASH_VOICE_MODEL` to use another local Whisper model or `GRIDBASH_SPEECH_HELPER` to replace the packaged helper. Capture uses ALSA and may need explicit device access in containers or remote sessions.
+
+## Terminal compatibility
+
+GridBash targets modern UTF-8, ANSI/xterm-compatible terminals, including Windows Terminal, Apple Terminal, iTerm2, GNOME Terminal, Konsole, Kitty, WezTerm, and Alacritty.
+
+SSH and tmux work when the remote session advertises a color-capable `TERM`. `TERM=dumb` and Linux kernel consoles are unsupported. In Apple Terminal and iTerm2, configure Option as Meta/Alt so GridBash receives its shortcuts.
+
+## Launch profiles
+
+Built-in terminal profiles are platform-specific:
+
+| Platform | Profile keys |
+| --- | --- |
+| Windows | `git-bash`, `pwsh`, `powershell`, `cmd` |
+| macOS | `zsh`, `bash`, `fish`, `sh`, `pwsh` |
+| Linux | `zsh`, `bash`, `fish`, `sh`, `pwsh` |
+
+Agent profiles available on every platform are `codex`, `claude`, `gemini`, `opencode`, `aider`, `amp`, `goose`, `copilot`, and `cursor`.
+
+Inspect every built-in and custom profile with:
+
+```powershell
+gridbash --list-profiles
+```
+
+The diagnostic table identifies the selected default, source, availability, resolved executable, or missing-command reason. It never prints profile environment values, auth tokens, or manager credentials. On Windows, GridBash resolves `.exe` and `.cmd` shims before extensionless npm shims.
+
+Profile selection uses this precedence:
+
+1. `--profile`
+2. `GRIDBASH_PROFILE`
+3. The invoking Windows shell detected by the npm launcher
+4. `[defaults].profile`
+5. The platform default
+
+The platform default is Git Bash on Windows, zsh on macOS, and bash on other Unix systems. On Windows, the npm launcher can inherit PowerShell, PowerShell 7 (`pwsh`), cmd, or Git Bash from the shell that invoked `gridbash`.
+
+Define custom profiles under `[profiles.<name>]`:
+
+```toml
+[profiles.review]
+command = "codex"
+args = ["--model", "gpt-5.5"]
+title = "Codex Review"
+agent_kind = "codex"
+```
+
+Then launch it by key:
+
+```powershell
+gridbash 2x4 --profile review
+```
+
+`agent_kind` is optional. Set it to `claude` or `codex` when the profile should participate in that agent's auth handling.
+
+## Configuration
+
+The default configuration file is platform-specific:
+
+| Platform | Path |
+| --- | --- |
+| Windows | `%APPDATA%\GridBash\config\config.toml` |
+| macOS | `$HOME/Library/Application Support/GridBash/config.toml` |
+| Linux | `${XDG_CONFIG_HOME:-$HOME/.config}/gridbash/config.toml` |
+
+Use `--config PATH` to load and save another file. A representative configuration is:
+
+```toml
+[defaults]
+profile = "powershell"
+pane_priority = "below-normal" # or "normal"
+pane_workload = "adaptive"     # or "unrestricted"
+
+[ui]
+compact_titles = false
+activity_badges = true
+confirm_quit = false
+scrollback_rows = 10000
+refresh_ms = 16
+
+[manager]
+endpoint = "https://api.openai.com/v1/chat/completions"
+model = "gpt-4o-mini"
+api_key = "sk-..."
+
+[todos]
+idle_seconds = 90
+prompts = [
+  "Review the latest changes and summarize anything risky.",
+  "Run the fastest relevant validation and report failures.",
+]
+
+[auth]
+home = "C:\\Users\\you\\.gridbash-auth"
+auto_cycle = false
+usage_status = true
+
+[auth.defaults]
+claude = "claude-1"
+codex = "codex-2"
+```
+
+Settings persist compact titles, activity badges, quit confirmation, new-pane scrollback, refresh delay, todo prompts, auth and workload policy, and the interface palette. Supported runtime changes apply immediately.
+
+### Grid manager
+
+The manager uses the OpenAI-compatible chat-completions endpoint, model, and API key under `[manager]`. These values can also be edited in Settings > Manager. The UI masks the API key, but the key is stored in the local TOML file.
+
+Alt+G creates a goal for the current grid. Each review sends pane role and folder metadata plus bounded recent output from every awake pane to the configured API. Sleeping and exited panes are omitted from reviews and are never command targets. Reviews label output by pane, and validated follow-ups remain bound to their intended PTYs if panes are reordered.
+
+### Pane priority and workload
+
+On Windows, the GridBash interface remains at normal process priority while pane processes default to `below-normal`; child workloads normally inherit the pane priority. Set `[defaults].pane_priority = "normal"` to opt out.
+
+The default `adaptive` workload policy gives focused and selected panes more CPU time than hidden or sleeping panes when Windows is contested, while every pane keeps running. Set `[defaults].pane_workload = "unrestricted"` or change Workload policy in Performance settings to disable adaptive sharing.
+
+## Auth profiles
+
+GridBash can isolate Claude and Codex accounts in named directories. The auth home is resolved in this order:
+
+```text
+GRIDBASH_AUTH_HOME > [auth].home > CLAUDE_PROFILES_HOME (legacy) > ~/.gridbash-auth
+```
+
+Claude panes receive `CLAUDE_CONFIG_DIR=<profile-dir>` and Codex panes receive `CODEX_HOME=<profile-dir>`.
+
+The old default was `~/.claude-profiles`; profiles are not moved automatically. Move them to `~/.gridbash-auth`, point `[auth].home` at the old location, or keep the legacy `CLAUDE_PROFILES_HOME` override.
+
+Assignment is manual by default: a new pane uses the configured default for its agent kind, while an explicit per-pane selection is retained. With `auto_cycle = true`, new compatible panes are assigned round-robin across ready profiles of the same kind. Changing the policy does not restart panes already running.
+
+### Auth settings controls
+
+| Input | Action |
+| --- | --- |
+| Tab | Switch Settings tabs. |
+| Up / Down | Move through profiles. |
+| `d` | Make the selected profile the GridBash-wide default for its kind. |
+| `c` | Toggle manual assignment and auto-cycle for new panes. |
+| `n` | Create a profile directory. |
+| `l` | Open the selected profile's login command. |
+| `r` | Refresh local account and usage status. |
+| Esc / `q` | Close settings. |
+
+For a Claude or Codex pane, open Pane Activity with Alt+p, select the auth control with Up/Down, choose a compatible profile with Left/Right, and press Enter. Applying a different account restarts only that pane. Press `r` in Pane Activity to refresh its snapshot.
+
+Usage reporting is best-effort. GridBash reads local auth metadata, masks account email addresses, and makes short-timeout requests with `curl.exe` on Windows or `curl` on macOS only when the Auth view is refreshed. Disable it with `usage_status = false`.
+
+### Codex SQLite isolation
+
+GridBash leases each pane a unique, persistent `CODEX_SQLITE_HOME`, including terminal-profile panes where Codex is started manually. Lanes are separated by `CODEX_HOME`, protected by cross-process file locks, and reused only after their previous pane releases the lease. This prevents concurrent Codex processes from contending for the same SQLite databases while auth, configuration, skills, and rollout files remain shared within `CODEX_HOME`.
+
+The first use of a new lane can be slower while Codex indexes existing rollouts. SQLite-only state, including goals, memories, and thread relationships, remains local to that lane.
+
+A non-empty `CODEX_SQLITE_HOME` inherited by GridBash opts out of automatic isolation and is preserved. Codex's `sqlite_home` configuration keeps its normal precedence. Do not point concurrent panes at the same override, or SQLite lock contention can return.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "docs/devlogs/",
     "docs/releases/",
     "docs/AUTOMATED_REVIEW.md",
+    "docs/REFERENCE.md",
     "docs/assets/gridbash-star-history.svg",
     "docs/RELEASING.md",
     "README.md",


### PR DESCRIPTION
## Summary
- cut the README from about 3,500 words to about 800
- move advanced usage, controls, auth, voice, and configuration details into a focused reference
- correct cross-platform setup, config, and local-install guidance
- include the new reference in the npm package

## Validation
- internal Markdown link and anchor check
- `git diff --check`
- `node --test npm/scripts/version.test.js`
- `npm pack --dry-run --json --ignore-scripts`