### PR TITLE
fix: automate stable latest releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
           - nightly
         default: release
       version:
-        description: "For releases: patch, minor, major, or an exact version. macOS previews use x.y.z-macos.N."
+        description: "For releases: patch, minor, major, or an exact version. Plain versions update GitHub and npm latest."
         required: false
         default: "patch"
       notes:
@@ -59,14 +59,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-
-      - name: Require a prerelease until macOS signing is configured
-        shell: pwsh
-        run: |
-          $requested = "${{ inputs.version }}"
-          if ($requested -notmatch "^\d+\.\d+\.\d+-.+$") {
-            throw "macOS is preview-only. Use an exact prerelease such as 0.2.0-macos.1 until Developer ID signing and notarization are configured."
-          }
 
       - name: Create release commit and tag
         id: release
@@ -216,12 +208,6 @@ jobs:
       - name: Install Linux voice build dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev cmake clang
-
-      - name: Block unsigned stable macOS artifacts
-        if: startsWith(matrix.platform_key, 'darwin-') && !contains(env.RELEASE_TAG, '-')
-        run: |
-          echo "Stable macOS artifacts require Developer ID signing and notarization."
-          exit 1
 
       - run: cargo fmt --check
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,9 +51,9 @@ After the change is merged to `main`:
 
 1. Open the `Release` workflow in GitHub Actions.
 2. Select `Run workflow` and leave `channel` set to `release`.
-3. Set `version` to an exact prerelease such as `0.2.0-macos.1` while macOS
-   signing is not configured. `patch`, `minor`, and `major` are available after
-   the stable macOS gate is opened.
+3. Set `version` to `patch`, `minor`, `major`, or an exact version. A plain
+   version such as `0.2.0` becomes GitHub's Latest release and npm's `latest`
+   dist-tag. A hyphenated prerelease uses npm's `next` dist-tag instead.
 4. Optionally set `notes` to a devlog path such as `docs/devlogs/YYYY-MM-DD-title.md`.
 5. Run the workflow.
 
@@ -63,10 +63,19 @@ same workflow run then builds Windows x64, Linux x64/arm64, and macOS arm64/x64
 native packages, publishes those packages before the platform-neutral npm
 launcher, and creates or updates one GitHub release.
 
-macOS releases are preview-only until real-hardware testing and Developer ID
-signing/notarization are complete. Dispatch an exact prerelease such as
-`0.2.0-macos.1`; prereleases publish under npm's `next` dist-tag. Stable release
-requests fail before creating a tag while this gate is active.
+Stable releases publish unsigned macOS artifacts until Developer ID signing and
+notarization are configured. macOS users may therefore see Gatekeeper warnings.
+This packaging limitation no longer prevents Windows and Linux users from
+receiving stable releases through the shared GitHub and npm release workflow.
+
+The channel mapping is automatic:
+
+- plain versions such as `0.2.0`: GitHub Latest and npm `latest`
+- prereleases such as `0.3.0-beta.1`: GitHub prerelease and npm `next`
+- scheduled nightlies: GitHub prerelease and npm `nightly`
+
+Promoting an existing GitHub prerelease manually does not change npm dist-tags.
+Run the workflow with a plain stable version to update both release channels.
 
 Before creating the release commit, the script fetches origin branch refs and
 fails if any unmerged task branches remain under `chore/`, `docs/`, `feat/`,

--- a/docs/devlogs/2026-07-14-automate-stable-latest-releases.md
+++ b/docs/devlogs/2026-07-14-automate-stable-latest-releases.md
@@ -1,0 +1,28 @@
+# automate stable latest releases
+
+Date: 2026-07-14
+Release target: unreleased
+
+## Summary
+
+- Make a plain stable release update both GitHub Latest and npm `latest` through one workflow run.
+
+## What Changed
+
+- Removed the workflow restriction that forced every cross-platform macOS build to use a prerelease version.
+- Documented the automatic stable, prerelease, and nightly channel mapping.
+- Kept npm publication ahead of GitHub release creation while retaining the GitHub fallback when registry publication fails.
+
+## Why It Matters
+
+- A stable tag such as `v0.2.0` now has one predictable outcome across both public release surfaces.
+- Unsigned macOS packages remain clearly documented without holding back stable Windows and Linux distribution.
+
+## Validation
+
+- Release workflow structure and channel-selection conditions reviewed.
+- Targeted version tests, formatting, and workflow diff validation.
+
+## Release Notes
+
+- Stable releases now automatically update GitHub Latest and npm `latest` from the same workflow.

--- a/npm/scripts/version.test.js
+++ b/npm/scripts/version.test.js
@@ -91,7 +91,7 @@ test("nightlyVersion reuses a prerelease core and advances a stable patch", () =
   );
 });
 
-test("release workflow keeps local tarballs and GitHub fallback available", () => {
+test("release workflow maps stable versions to both latest channels", () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, "..", "..", ".github", "workflows", "release.yml"),
     "utf8",
@@ -102,6 +102,9 @@ test("release workflow keeps local tarballs and GitHub fallback available", () =
     /npm publish "\.\/\$tarball" --access public --provenance --tag "\$dist_tag"/,
   );
   assert.doesNotMatch(workflow, /npm publish "\$tarball"/);
+  assert.match(workflow, /dist_tag="latest"/);
+  assert.match(workflow, /else\r?\n\s+release_flags\+=\(--latest\)/);
+  assert.doesNotMatch(workflow, /Require a prerelease|Block unsigned stable macOS artifacts/);
   assert.match(
     workflow,
     /- name: Create or update GitHub release\r?\n\s+if: \$\{\{ !cancelled\(\) \}\}/,


### PR DESCRIPTION
## Summary\n- allow plain stable versions to run the full five-platform release matrix\n- map stable releases to GitHub Latest and npm latest in one workflow\n- retain 
ext for prereleases and 
ightly for scheduled builds\n- document unsigned macOS Gatekeeper warnings instead of blocking stable Windows/Linux distribution\n- add a regression test for both stable latest mappings\n\n## Validation\n- 
ode --test npm/scripts/version.test.js\n- cargo fmt --check\n- git diff --check\n\nTracks #192. npm publication still requires the one-time native-package token bootstrap described there.