### PR TITLE
feat: add focused pane zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ agents and shells.
 | `Alt+c` | Open or close the command line |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
+| `Alt+f` | Zoom or restore the focused pane |
 | `Alt+g` / `Alt+u` | Start or stop the grid manager goal |
 | `Alt+Shift+V` | Dictate one prompt without submitting it |
 | `Alt+o` | Open settings |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -144,6 +144,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+s | Toggle selection of the focused pane. |
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
+| Alt+f | Zoom the focused pane to the full grid area, or restore the grid. |
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
 | Alt+p | Open the focused-pane activity summary. |

--- a/docs/devlogs/2026-07-15-zoom-the-focused-terminal-pane.md
+++ b/docs/devlogs/2026-07-15-zoom-the-focused-terminal-pane.md
@@ -1,0 +1,34 @@
+# Zoom the focused terminal pane
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added a reversible focused-pane zoom for dense terminal grids.
+
+## What Changed
+
+- Added `Alt+f` to toggle between the full grid and a single focused pane.
+- Preserved zoom independently in every tab without changing pane processes,
+  selections, divider weights, or launch metadata.
+- Kept hidden pane PTY sizes stable while the visible pane fills the grid.
+- Updated in-app help, the README, and the user reference.
+
+## Why It Matters
+
+- A busy agent can temporarily use the whole terminal for review and then
+  return to the exact same multi-agent overview.
+- Focus navigation remains available while zoomed and predictably retargets
+  the full-size view to the newly focused pane.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test zoomed_geometry`
+- `cargo test`
+
+## Release Notes
+
+- Press `Alt+f` to zoom the focused terminal pane; press it again to restore
+  the grid.

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,6 +85,7 @@ pub struct App {
     tab_title: String,
     launch_plan: Option<LaunchPlan>,
     layout: GridLayout,
+    zoomed: bool,
     grid_area: Rect,
     panes: Vec<PtyPane>,
     codex_sqlite: CodexSqlitePool,
@@ -168,6 +169,7 @@ struct GridTabSnapshot {
     title: String,
     launch_plan: Option<LaunchPlan>,
     layout: GridLayout,
+    zoomed: bool,
     panes: Vec<PtyPane>,
     pane_idle: Vec<PaneIdleState>,
     focus: usize,
@@ -1834,10 +1836,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -1945,6 +1947,7 @@ impl App {
             tab_title: "Grid 1".into(),
             launch_plan: init.launch_plan,
             layout: GridLayout::new(init.grid),
+            zoomed: false,
             grid_area: Rect::default(),
             panes: Vec::new(),
             codex_sqlite: CodexSqlitePool::new()?,
@@ -2091,6 +2094,7 @@ impl App {
             title: mem::take(&mut self.tab_title),
             launch_plan: self.launch_plan.take(),
             layout: mem::replace(&mut self.layout, placeholder_layout),
+            zoomed: self.zoomed,
             panes: mem::take(&mut self.panes),
             pane_idle: mem::take(&mut self.pane_idle),
             focus: self.focus,
@@ -2107,6 +2111,7 @@ impl App {
         self.tab_title = tab.title;
         self.launch_plan = tab.launch_plan;
         self.layout = tab.layout;
+        self.zoomed = tab.zoomed;
         self.panes = tab.panes;
         self.pane_idle = tab.pane_idle;
         self.focus = tab.focus.min(self.panes.len().saturating_sub(1));
@@ -2143,6 +2148,7 @@ impl App {
         self.tab_title = title.clone();
         self.launch_plan = Some(plan.clone());
         self.layout = GridLayout::new(plan.grid);
+        self.zoomed = false;
         self.panes.clear();
         self.pane_idle.clear();
         self.focus = 0;
@@ -3262,6 +3268,10 @@ impl App {
                 self.swap_selected_tiles();
                 Ok(Some(false))
             }
+            'f' => {
+                self.toggle_zoom();
+                Ok(Some(false))
+            }
             'c' => {
                 self.command_line.toggle_focus();
                 self.status = self.focus_status();
@@ -3325,6 +3335,24 @@ impl App {
         self.close_tab_modals();
         self.grid_resizer = Some(GridPicker::new(self.layout.size()));
         self.status = "grid resizer open".into();
+    }
+
+    fn toggle_zoom(&mut self) {
+        if self.panes.is_empty() {
+            self.status = "no pane to zoom".into();
+            return;
+        }
+
+        self.zoomed = !self.zoomed;
+        self.clear_text_selection();
+        self.status = if self.zoomed {
+            format!(
+                "zoomed pane {}; move focus to inspect another pane",
+                self.focus + 1
+            )
+        } else {
+            "restored grid layout".into()
+        };
     }
 
     fn handle_grid_resizer_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -5484,7 +5512,15 @@ impl App {
     }
 
     pub fn pane_rects(&self, area: Rect) -> Vec<Rect> {
-        self.layout.rects(area, self.panes.len())
+        if self.zoomed {
+            zoomed_pane_rects(area, self.panes.len(), self.focus)
+        } else {
+            self.layout.rects(area, self.panes.len())
+        }
+    }
+
+    pub fn zoomed(&self) -> bool {
+        self.zoomed
     }
 
     pub fn panes(&self) -> &[PtyPane] {
@@ -5932,6 +5968,9 @@ impl App {
 
     pub fn sync_pane_sizes(&mut self) {
         for (index, rect) in self.rects.iter().enumerate() {
+            if rect.width == 0 || rect.height == 0 {
+                continue;
+            }
             let Some(pane) = self.panes.get_mut(index) else {
                 continue;
             };
@@ -7199,6 +7238,14 @@ fn input_targets_for(focus: usize, selected: &BTreeSet<usize>, pane_count: usize
     }
 }
 
+fn zoomed_pane_rects(area: Rect, pane_count: usize, focus: usize) -> Vec<Rect> {
+    let mut rects = vec![Rect::default(); pane_count];
+    if let Some(rect) = rects.get_mut(focus.min(pane_count.saturating_sub(1))) {
+        *rect = area;
+    }
+    rects
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct RestartTargets {
     indices: Vec<usize>,
@@ -8041,6 +8088,24 @@ mod tests {
     fn input_targets_clamps_focus_to_available_panes() {
         assert_eq!(input_targets_for(8, &selected(&[]), 4), vec![3]);
         assert!(input_targets_for(0, &selected(&[]), 0).is_empty());
+    }
+
+    #[test]
+    fn zoomed_geometry_only_exposes_the_focused_pane() {
+        let area = Rect::new(2, 3, 120, 40);
+        let rects = zoomed_pane_rects(area, 4, 2);
+
+        assert_eq!(
+            rects,
+            vec![Rect::default(), Rect::default(), area, Rect::default()]
+        );
+    }
+
+    #[test]
+    fn zoomed_geometry_clamps_a_stale_focus() {
+        let area = Rect::new(0, 0, 80, 24);
+        assert_eq!(zoomed_pane_rects(area, 2, 9), vec![Rect::default(), area]);
+        assert!(zoomed_pane_rects(area, 0, 0).is_empty());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -126,6 +126,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let Some(rect) = rects.get(index).copied() else {
             continue;
         };
+        if rect.width == 0 || rect.height == 0 {
+            continue;
+        }
 
         let focused = app.focused_pane() == Some(index);
         let selected = app.selected().contains(&index);
@@ -201,7 +204,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         ),
         Span::raw(" "),
         Span::styled(
-            if app.voice_listening() { "MIC" } else { "LIVE" },
+            if app.voice_listening() {
+                "MIC"
+            } else if app.zoomed() {
+                "ZOOM"
+            } else {
+                "LIVE"
+            },
             Style::default()
                 .fg(if app.voice_listening() {
                     palette.accent()
@@ -226,7 +235,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+h help | Alt+f zoom | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -2487,6 +2496,7 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+c", "expand or close the command line"),
         ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
+        ("Alt+f", "zoom or restore focused pane"),
         ("Alt+l", "resize the grid"),
         ("Alt+r", "rename focused pane"),
         ("Alt+Shift+t", "restart exited panes"),


### PR DESCRIPTION
## Summary
- add reversible focused-pane zoom on Alt+f
- preserve zoom state independently across tabs
- keep hidden PTY sizes stable and retarget zoom when focus moves
- document the control and release note

## Validation
- `cargo fmt -- --check`
- `cargo test zoomed_geometry`
- `cargo test` with `GRIDBASH_INVOKING_PROFILE` removed (169 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`

Closes #219