### PR TITLE
feat: show pane summaries in resize preview

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -166,7 +166,7 @@ Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal contr
 
 If the focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
 
-The resize picker starts from the current dimensions. Shrinking a grid deactivates live panes outside the retained upper-left rectangle; changing `3x3` to `3x2`, for example, removes the rightmost column.
+The resize picker starts from the current dimensions and shows each existing pane's latest activity summary when one is available. Shrinking a grid deactivates live panes outside the retained upper-left rectangle; changing `3x3` to `3x2`, for example, removes the rightmost column.
 
 A pane's top border shows its latest activity summary. A configured manager goal replaces that summary across the grid until removed. A quiet marker appears after roughly three seconds without output; it indicates output followed by inactivity, not completion or process exit. Saving a blank pane name restores its default number.
 

--- a/docs/devlogs/2026-07-15-show-activity-summaries-in-resize-preview.md
+++ b/docs/devlogs/2026-07-15-show-activity-summaries-in-resize-preview.md
@@ -1,0 +1,30 @@
+# Show activity summaries in resize preview
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added current pane activity summaries to the `Alt+l` resize preview.
+
+## What Changed
+
+- Captured available activity summaries when the resize picker opens.
+- Rendered summaries inside their matching blue preview cells while leaving panes without a summary unlabeled.
+- Preserved row-and-column mappings as the proposed grid dimensions change, so retained panes keep the correct summary.
+
+## Why It Matters
+
+- Pane content is now identifiable before applying a resize, making it clearer which panes will be retained or removed.
+
+## Validation
+
+- `cargo test composer::tests`
+- `cargo test`
+- `cargo fmt -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `git diff --check`
+
+## Release Notes
+
+- The `Alt+l` grid resize preview now shows available activity summaries inside existing pane cells.

--- a/src/app.rs
+++ b/src/app.rs
@@ -3323,7 +3323,9 @@ impl App {
 
     fn open_grid_resizer(&mut self) {
         self.close_tab_modals();
-        self.grid_resizer = Some(GridPicker::new(self.layout.size()));
+        let pane_summaries = self.panes.iter().map(pane_activity_summary).collect();
+        self.grid_resizer =
+            Some(GridPicker::new(self.layout.size()).with_pane_summaries(pane_summaries));
         self.status = "grid resizer open".into();
     }
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -13,7 +13,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
 use crate::worktrees::ManagedWorktreeOptions;
@@ -67,6 +67,7 @@ pub struct GridPicker {
     rows: usize,
     columns: usize,
     active_field: DimensionField,
+    pane_summaries: Vec<Option<String>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -160,7 +161,13 @@ impl GridPicker {
             rows: grid.rows,
             columns: grid.columns,
             active_field: DimensionField::Rows,
+            pane_summaries: Vec::new(),
         }
+    }
+
+    pub fn with_pane_summaries(mut self, pane_summaries: Vec<Option<String>>) -> Self {
+        self.pane_summaries = pane_summaries;
+        self
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> GridPickerAction {
@@ -322,7 +329,34 @@ impl GridPicker {
             let inner = block.inner(rect);
             frame.render_widget(block, rect);
             frame.render_widget(dithered_fill(index, inner, palette), inner);
+            if mode == GridPickerMode::Resize
+                && let Some(summary) = self.preview_summary(index)
+            {
+                frame.render_widget(
+                    Paragraph::new(summary)
+                        .alignment(Alignment::Center)
+                        .wrap(Wrap { trim: true })
+                        .style(
+                            Style::default()
+                                .fg(Color::White)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    inner,
+                );
+            }
         }
+    }
+
+    fn preview_summary(&self, index: usize) -> Option<&str> {
+        let row = index / self.columns;
+        let column = index % self.columns;
+        let old_index = (row < self.initial.rows && column < self.initial.columns)
+            .then_some(row * self.initial.columns + column)?;
+
+        self.pane_summaries
+            .get(old_index)
+            .and_then(Option::as_deref)
+            .filter(|summary| !summary.trim().is_empty())
     }
 
     fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect, mode: GridPickerMode) {
@@ -567,5 +601,78 @@ mod tests {
                 .iter()
                 .any(|cell| cell.bg == STARTUP_PREVIEW.light)
         );
+    }
+
+    #[test]
+    fn resize_picker_renders_available_activity_summaries() {
+        let picker = GridPicker::new(GridSize {
+            rows: 1,
+            columns: 2,
+        })
+        .with_pane_summaries(vec![Some("reviewing code".into()), None]);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame, GridPickerMode::Resize, None))
+            .expect("draw picker");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("reviewing code"));
+        assert!(!rendered.contains("waiting for output"));
+    }
+
+    #[test]
+    fn resize_picker_keeps_summaries_at_retained_coordinates() {
+        let mut picker = GridPicker::new(GridSize {
+            rows: 2,
+            columns: 3,
+        })
+        .with_pane_summaries(vec![
+            Some("zero".into()),
+            Some("one".into()),
+            Some("removed two".into()),
+            Some("three".into()),
+            Some("four".into()),
+            Some("removed five".into()),
+        ]);
+
+        picker.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        picker.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+
+        assert_eq!(picker.preview_summary(0), Some("zero"));
+        assert_eq!(picker.preview_summary(1), Some("one"));
+        assert_eq!(picker.preview_summary(2), Some("three"));
+        assert_eq!(picker.preview_summary(3), Some("four"));
+    }
+
+    #[test]
+    fn startup_picker_does_not_render_activity_summaries() {
+        let picker = GridPicker::new(GridSize {
+            rows: 1,
+            columns: 1,
+        })
+        .with_pane_summaries(vec![Some("resize only".into())]);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame, GridPickerMode::Startup, None))
+            .expect("draw picker");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!rendered.contains("resize only"));
     }
 }


### PR DESCRIPTION
## Summary
- show available pane activity summaries inside the Alt+L resize preview
- preserve summary-to-pane coordinates while proposed grid dimensions change
- keep blank/new cells unlabeled and leave the startup picker unchanged
- document the resize-preview behavior and add a devlog

## Validation
- `cargo test composer::tests` (6 passed)
- `cargo test` (170 passed, 1 ignored; `GRIDBASH_INVOKING_PROFILE` removed for the test process)
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Related to #227