### PR TITLE
feat: add searchable command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ agents and shells.
 | --- | --- |
 | Drag mouse | Select and copy text inside one pane |
 | Right-click pane | Add or remove the pane from the selected set |
+| `Alt+k` | Search and run GridBash commands |
 | `Alt` + arrow keys | Move focus between panes |
 | `Alt+s` / `Alt+a` | Toggle the focused pane / select or clear all panes |
 | `Alt+c` | Open or close the command line |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -135,6 +135,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Drag mouse | Select terminal text inside the pane where the drag began and copy it on release. |
 | Right-click pane | Add or remove that pane from the selected set. |
 | Mouse wheel | Scroll only the pane under the pointer; selected panes use GridBash scrollback. |
+| Alt+k | Open the searchable command palette. Type to filter, use Up/Down to select, and press Enter to run an action. |
 | Alt+Left / Alt+Right | Focus the previous or next pane in the row, wrapping at the edge. |
 | Alt+Up / Alt+Down | Focus the pane above or below, wrapping at the edge. |
 | Alt+l | Resize the current grid. |
@@ -161,6 +162,8 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
+
+The command palette lists the available pane, tab, grid, manager, settings, help, and quit actions together with their shortcuts. Its query supports tolerant subsequence matching, pasted Unicode text, and cursor editing. Palette input is never sent to a child terminal; press Esc or Alt+k to close it without running anything.
 
 Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+o switches to overall settings.
 

--- a/docs/devlogs/2026-07-15-add-searchable-command-palette.md
+++ b/docs/devlogs/2026-07-15-add-searchable-command-palette.md
@@ -1,0 +1,28 @@
+# Add searchable command palette
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added a searchable, keyboard-first action palette inspired by Zed's command surface.
+
+## What Changed
+
+- `Alt+k` opens a modal list of GridBash pane, tab, grid, manager, settings, help, and quit actions.
+- Typing or pasting filters actions with tolerant subsequence matching; Up/Down and Enter navigate and execute.
+- Moved the modeless shortcut definitions into a typed action registry shared by direct keyboard dispatch and the palette.
+
+## Why It Matters
+
+- GridBash has grown beyond a handful of shortcuts. The palette makes existing capabilities discoverable without sending search text into a live PTY.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Open the new command palette with `Alt+k`, search by action or intent, and press Enter to run the selected command.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,297 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    OpenCommandPalette,
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
+    TogglePaneSelection,
+    ToggleSelectAll,
+    ToggleSleep,
+    RestartExited,
+    NewTab,
+    NextTab,
+    RenameTab,
+    ResizeGrid,
+    SwapSelected,
+    ToggleCommandLine,
+    TogglePaneSummary,
+    TogglePreviousPanes,
+    RenamePane,
+    ToggleVoiceInput,
+    EditGridGoal,
+    StopGridGoal,
+    OpenSettings,
+    OpenHelp,
+    Quit,
+}
+
+impl Action {
+    pub const PALETTE: [Self; 23] = [
+        Self::FocusLeft,
+        Self::FocusRight,
+        Self::FocusUp,
+        Self::FocusDown,
+        Self::TogglePaneSelection,
+        Self::ToggleSelectAll,
+        Self::ToggleSleep,
+        Self::RestartExited,
+        Self::NewTab,
+        Self::NextTab,
+        Self::RenameTab,
+        Self::ResizeGrid,
+        Self::SwapSelected,
+        Self::ToggleCommandLine,
+        Self::TogglePaneSummary,
+        Self::TogglePreviousPanes,
+        Self::RenamePane,
+        Self::ToggleVoiceInput,
+        Self::EditGridGoal,
+        Self::StopGridGoal,
+        Self::OpenSettings,
+        Self::OpenHelp,
+        Self::Quit,
+    ];
+
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::OpenCommandPalette => "open-command-palette",
+            Self::FocusLeft => "focus-left",
+            Self::FocusRight => "focus-right",
+            Self::FocusUp => "focus-up",
+            Self::FocusDown => "focus-down",
+            Self::TogglePaneSelection => "toggle-pane-selection",
+            Self::ToggleSelectAll => "toggle-select-all",
+            Self::ToggleSleep => "toggle-sleep",
+            Self::RestartExited => "restart-exited",
+            Self::NewTab => "new-tab",
+            Self::NextTab => "next-tab",
+            Self::RenameTab => "rename-tab",
+            Self::ResizeGrid => "resize-grid",
+            Self::SwapSelected => "swap-selected",
+            Self::ToggleCommandLine => "toggle-command-line",
+            Self::TogglePaneSummary => "toggle-pane-summary",
+            Self::TogglePreviousPanes => "toggle-previous-panes",
+            Self::RenamePane => "rename-pane",
+            Self::ToggleVoiceInput => "toggle-voice-input",
+            Self::EditGridGoal => "edit-grid-goal",
+            Self::StopGridGoal => "stop-grid-goal",
+            Self::OpenSettings => "open-settings",
+            Self::OpenHelp => "open-help",
+            Self::Quit => "quit",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::OpenCommandPalette => "Grid: Open command palette",
+            Self::FocusLeft => "Pane: Focus left",
+            Self::FocusRight => "Pane: Focus right",
+            Self::FocusUp => "Pane: Focus up",
+            Self::FocusDown => "Pane: Focus down",
+            Self::TogglePaneSelection => "Pane: Toggle selection",
+            Self::ToggleSelectAll => "Pane: Select or clear all",
+            Self::ToggleSleep => "Pane: Sleep or wake",
+            Self::RestartExited => "Pane: Restart exited targets",
+            Self::NewTab => "Tab: New tab",
+            Self::NextTab => "Tab: Switch to next tab",
+            Self::RenameTab => "Tab: Rename current tab",
+            Self::ResizeGrid => "Grid: Resize",
+            Self::SwapSelected => "Grid: Swap selected panes",
+            Self::ToggleCommandLine => "Grid: Toggle command line",
+            Self::TogglePaneSummary => "Pane: Toggle activity summary",
+            Self::TogglePreviousPanes => "Pane: Toggle previous panes",
+            Self::RenamePane => "Pane: Rename focused pane",
+            Self::ToggleVoiceInput => "Input: Toggle voice dictation",
+            Self::EditGridGoal => "Manager: Edit grid goal",
+            Self::StopGridGoal => "Manager: Stop grid goal",
+            Self::OpenSettings => "Grid: Open settings",
+            Self::OpenHelp => "Grid: Open help",
+            Self::Quit => "Grid: Quit",
+        }
+    }
+
+    pub fn search_text(self) -> &'static str {
+        match self {
+            Self::OpenCommandPalette => "grid open command palette actions search",
+            Self::FocusLeft => "pane focus left previous move navigation",
+            Self::FocusRight => "pane focus right next move navigation",
+            Self::FocusUp => "pane focus up move navigation",
+            Self::FocusDown => "pane focus down move navigation",
+            Self::TogglePaneSelection => "pane toggle select selection target",
+            Self::ToggleSelectAll => "pane select clear all selection targets",
+            Self::ToggleSleep => "pane sleep wake pause resume targets",
+            Self::RestartExited => "pane restart exited dead targets",
+            Self::NewTab => "tab new open grid",
+            Self::NextTab => "tab switch next cycle grid",
+            Self::RenameTab => "tab rename title name",
+            Self::ResizeGrid => "grid resize rows columns layout",
+            Self::SwapSelected => "grid swap selected panes reorder",
+            Self::ToggleCommandLine => "grid cli command line shell output",
+            Self::TogglePaneSummary => "pane activity summary details usage",
+            Self::TogglePreviousPanes => "pane previous list switch history",
+            Self::RenamePane => "pane rename title name",
+            Self::ToggleVoiceInput => "input voice dictate microphone speech",
+            Self::EditGridGoal => "manager edit create grid goal orchestrate",
+            Self::StopGridGoal => "manager stop cancel grid goal orchestrate",
+            Self::OpenSettings => "grid open settings config profiles auth",
+            Self::OpenHelp => "grid open help shortcuts controls",
+            Self::Quit => "grid quit exit close",
+        }
+    }
+
+    pub fn default_shortcut(self) -> &'static str {
+        match self {
+            Self::OpenCommandPalette => "Alt+k",
+            Self::FocusLeft => "Alt+Left",
+            Self::FocusRight => "Alt+Right",
+            Self::FocusUp => "Alt+Up",
+            Self::FocusDown => "Alt+Down",
+            Self::TogglePaneSelection => "Alt+s",
+            Self::ToggleSelectAll => "Alt+a",
+            Self::ToggleSleep => "Alt+z",
+            Self::RestartExited => "Alt+Shift+t",
+            Self::NewTab => "Alt+n",
+            Self::NextTab => "Alt+t",
+            Self::RenameTab => "Alt+Shift+r",
+            Self::ResizeGrid => "Alt+l",
+            Self::SwapSelected => "Alt+x",
+            Self::ToggleCommandLine => "Alt+c",
+            Self::TogglePaneSummary => "Alt+p",
+            Self::TogglePreviousPanes => "Alt+Shift+p",
+            Self::RenamePane => "Alt+r",
+            Self::ToggleVoiceInput => "Alt+Shift+v",
+            Self::EditGridGoal => "Alt+g",
+            Self::StopGridGoal => "Alt+u",
+            Self::OpenSettings => "Alt+o",
+            Self::OpenHelp => "Alt+h / F1",
+            Self::Quit => "Alt+q",
+        }
+    }
+
+    pub fn from_key(key: &KeyEvent) -> Option<Self> {
+        if matches!(key.code, KeyCode::F(1)) {
+            return Some(Self::OpenHelp);
+        }
+        if !key.modifiers.contains(KeyModifiers::ALT)
+            || key.modifiers.contains(KeyModifiers::CONTROL)
+        {
+            return None;
+        }
+
+        match key.code {
+            KeyCode::Left => Some(Self::FocusLeft),
+            KeyCode::Right => Some(Self::FocusRight),
+            KeyCode::Up => Some(Self::FocusUp),
+            KeyCode::Down => Some(Self::FocusDown),
+            KeyCode::Char(ch) => {
+                let shifted = key.modifiers.contains(KeyModifiers::SHIFT);
+                match (ch.to_ascii_lowercase(), shifted) {
+                    ('k', false) => Some(Self::OpenCommandPalette),
+                    ('s', false) => Some(Self::TogglePaneSelection),
+                    ('a', false) => Some(Self::ToggleSelectAll),
+                    ('z', false) => Some(Self::ToggleSleep),
+                    ('t', true) => Some(Self::RestartExited),
+                    ('t', false) => Some(Self::NextTab),
+                    ('n', false) => Some(Self::NewTab),
+                    ('l', false) => Some(Self::ResizeGrid),
+                    ('x', false) => Some(Self::SwapSelected),
+                    ('c', false) => Some(Self::ToggleCommandLine),
+                    ('v', true) => Some(Self::ToggleVoiceInput),
+                    ('g', false) => Some(Self::EditGridGoal),
+                    ('u', false) => Some(Self::StopGridGoal),
+                    ('o', false) => Some(Self::OpenSettings),
+                    ('p', true) => Some(Self::TogglePreviousPanes),
+                    ('p', false) => Some(Self::TogglePaneSummary),
+                    ('r', true) => Some(Self::RenameTab),
+                    ('r', false) => Some(Self::RenamePane),
+                    ('h', false) => Some(Self::OpenHelp),
+                    ('q', false) => Some(Self::Quit),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+pub fn fuzzy_match_score(query: &str, action: Action) -> Option<usize> {
+    let mut query = query.chars().flat_map(char::to_lowercase).peekable();
+    if query.peek().is_none() {
+        return Some(0);
+    }
+
+    let haystack = format!(
+        "{} {} {}",
+        action.label(),
+        action.id(),
+        action.search_text()
+    );
+    let mut score = 0usize;
+    let mut last_match = None;
+    for (index, ch) in haystack.chars().flat_map(char::to_lowercase).enumerate() {
+        if query.peek().is_some_and(|next| *next == ch) {
+            if let Some(previous) = last_match {
+                score = score.saturating_add(index.saturating_sub(previous + 1));
+            } else {
+                score = score.saturating_add(index);
+            }
+            last_match = Some(index);
+            query.next();
+            if query.peek().is_none() {
+                return Some(score);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alt(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::ALT)
+    }
+
+    #[test]
+    fn maps_existing_modeless_shortcuts_to_actions() {
+        assert_eq!(
+            Action::from_key(&alt(KeyCode::Left)),
+            Some(Action::FocusLeft)
+        );
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(
+                KeyCode::Char('T'),
+                KeyModifiers::ALT | KeyModifiers::SHIFT,
+            )),
+            Some(Action::RestartExited)
+        );
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE)),
+            Some(Action::OpenHelp)
+        );
+    }
+
+    #[test]
+    fn leaves_plain_and_control_keys_for_the_terminal() {
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE)),
+            None
+        );
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL,)),
+            None
+        );
+    }
+
+    #[test]
+    fn fuzzy_matching_accepts_labels_ids_and_keywords() {
+        assert!(fuzzy_match_score("rn pane", Action::RenamePane).is_some());
+        assert!(fuzzy_match_score("orchestrate", Action::EditGridGoal).is_some());
+        assert!(fuzzy_match_score("tab next", Action::NextTab).is_some());
+        assert!(fuzzy_match_score("unrelated", Action::NextTab).is_none());
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,7 @@ use tokio::sync::mpsc;
 use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 
 use crate::{
+    actions::{Action, fuzzy_match_score},
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
     codex_sqlite::{CodexSqlitePool, PaneCodexSqlite},
@@ -102,6 +103,7 @@ pub struct App {
     rects: Vec<Rect>,
     mouse_enabled: bool,
     command_line: CommandLineState,
+    command_palette: CommandPaletteState,
     command_tx: mpsc::UnboundedSender<CommandRunEvent>,
     command_rx: mpsc::UnboundedReceiver<CommandRunEvent>,
     voice: VoiceInput,
@@ -687,6 +689,20 @@ pub struct RenameTabView {
 }
 
 #[derive(Debug, Clone)]
+pub struct CommandPaletteView {
+    pub query: String,
+    pub cursor_chars: usize,
+    pub selected: usize,
+    pub items: Vec<CommandPaletteItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandPaletteItem {
+    pub label: &'static str,
+    pub shortcut: &'static str,
+}
+
+#[derive(Debug, Clone)]
 pub struct PreviousPanesView {
     pub cursor: usize,
     pub panes: Vec<PreviousPaneView>,
@@ -1072,6 +1088,115 @@ struct CommandLineState {
     cursor: usize,
     output_lines: Vec<String>,
     running: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CommandPaletteState {
+    open: bool,
+    input: String,
+    cursor: usize,
+    selected: usize,
+}
+
+impl CommandPaletteState {
+    fn open(&mut self) {
+        self.open = true;
+        self.input.clear();
+        self.cursor = 0;
+        self.selected = 0;
+    }
+
+    fn close(&mut self) {
+        self.open = false;
+        self.input.clear();
+        self.cursor = 0;
+        self.selected = 0;
+    }
+
+    fn insert_text(&mut self, text: &str) {
+        for ch in text.chars().filter(|ch| !ch.is_control()) {
+            self.input.insert(self.cursor, ch);
+            self.cursor += ch.len_utf8();
+        }
+        self.selected = 0;
+    }
+
+    fn backspace(&mut self) -> bool {
+        let Some(previous) = previous_char_boundary(&self.input, self.cursor) else {
+            return false;
+        };
+        self.input.replace_range(previous..self.cursor, "");
+        self.cursor = previous;
+        self.selected = 0;
+        true
+    }
+
+    fn delete(&mut self) -> bool {
+        if self.cursor >= self.input.len() {
+            return false;
+        }
+        let next = next_char_boundary(&self.input, self.cursor);
+        self.input.replace_range(self.cursor..next, "");
+        self.selected = 0;
+        true
+    }
+
+    fn clear(&mut self) -> bool {
+        if self.input.is_empty() {
+            return false;
+        }
+        self.input.clear();
+        self.cursor = 0;
+        self.selected = 0;
+        true
+    }
+
+    fn move_cursor(&mut self, delta: isize) -> bool {
+        let next = if delta.is_negative() {
+            previous_char_boundary(&self.input, self.cursor).unwrap_or(self.cursor)
+        } else {
+            next_char_boundary(&self.input, self.cursor)
+        };
+        let changed = next != self.cursor;
+        self.cursor = next;
+        changed
+    }
+
+    fn move_to_start(&mut self) -> bool {
+        let changed = self.cursor != 0;
+        self.cursor = 0;
+        changed
+    }
+
+    fn move_to_end(&mut self) -> bool {
+        let changed = self.cursor != self.input.len();
+        self.cursor = self.input.len();
+        changed
+    }
+
+    fn matches(&self) -> Vec<Action> {
+        let mut actions = Action::PALETTE
+            .into_iter()
+            .filter_map(|action| {
+                fuzzy_match_score(&self.input, action).map(|score| (score, action))
+            })
+            .collect::<Vec<_>>();
+        actions.sort_by_key(|(score, action)| (*score, action.label()));
+        actions.into_iter().map(|(_, action)| action).collect()
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let count = self.matches().len();
+        if count == 0 {
+            self.selected = 0;
+            return;
+        }
+        self.selected = (self.selected as isize + delta).rem_euclid(count as isize) as usize;
+    }
+
+    fn selected_action(&self) -> Option<Action> {
+        self.matches().get(self.selected).copied()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1834,10 +1959,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+k commands | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -1962,6 +2087,7 @@ impl App {
             rects: Vec::new(),
             mouse_enabled: init.mouse_enabled,
             command_line: CommandLineState::new(init.command_cwd),
+            command_palette: CommandPaletteState::default(),
             command_tx,
             command_rx,
             voice: VoiceInput::new(),
@@ -2127,6 +2253,7 @@ impl App {
     }
 
     fn close_tab_modals(&mut self) {
+        self.command_palette.close();
         self.rename.close();
         self.tab_rename.close();
         self.previous_panes.close();
@@ -2351,6 +2478,10 @@ impl App {
                 *needs_render = true;
             }
             Event::FocusLost => self.terminal_focused = false,
+            Event::Paste(text) if self.command_palette.open => {
+                self.command_palette.insert_text(&text);
+                *needs_render = true;
+            }
             Event::Paste(text) if self.tab_rename.open => {
                 self.tab_rename.insert_text(&text);
                 *needs_render = true;
@@ -2373,7 +2504,8 @@ impl App {
                 }
             }
             Event::Paste(text)
-                if !self.settings.open
+                if !self.command_palette.open
+                    && !self.settings.open
                     && self.grid_resizer.is_none()
                     && !self.rename.open
                     && !self.previous_panes.open
@@ -2391,6 +2523,7 @@ impl App {
             }
             Event::Mouse(mouse)
                 if (self.mouse_enabled || !self.sleeping.is_empty())
+                    && !self.command_palette.open
                     && !self.settings.open
                     && self.grid_resizer.is_none()
                     && self.follow_up.is_none()
@@ -3039,7 +3172,8 @@ impl App {
     }
 
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
-        if is_quit_shortcut(&key) {
+        let action = Action::from_key(&key);
+        if action == Some(Action::Quit) {
             return Ok(self.request_quit());
         }
 
@@ -3048,11 +3182,15 @@ impl App {
             self.status = "quit canceled".into();
         }
 
+        if self.command_palette.open {
+            return self.handle_command_palette_key(terminal, key);
+        }
+
         if self.help_open {
             return Ok(self.handle_help_key(key));
         }
 
-        if is_help_shortcut(&key) {
+        if action == Some(Action::OpenHelp) {
             self.open_help();
             return Ok(KeyOutcome::Render);
         }
@@ -3100,14 +3238,8 @@ impl App {
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
-        if key.modifiers.contains(KeyModifiers::ALT)
-            && let Some(quit) = self.handle_app_key(terminal, key)?
-        {
-            return Ok(if quit {
-                KeyOutcome::Quit
-            } else {
-                KeyOutcome::Render
-            });
+        if let Some(action) = action {
+            return self.execute_action(terminal, action);
         }
 
         if self.command_line.focused {
@@ -3160,7 +3292,7 @@ impl App {
 
     fn handle_help_key(&mut self, key: KeyEvent) -> KeyOutcome {
         if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q'))
-            || is_help_shortcut(&key)
+            || Action::from_key(&key) == Some(Action::OpenHelp)
         {
             self.help_open = false;
             self.status = "help closed".into();
@@ -3185,126 +3317,138 @@ impl App {
         }
     }
 
-    fn handle_app_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<Option<bool>> {
-        match key.code {
-            KeyCode::Char(ch) => self.handle_alt_char(terminal, ch, key.modifiers),
-            KeyCode::Left => {
-                self.focus_previous();
-                self.status = self.focus_status();
-                Ok(Some(false))
-            }
-            KeyCode::Right => {
-                self.focus_next();
-                self.status = self.focus_status();
-                Ok(Some(false))
-            }
-            KeyCode::Up => {
-                self.focus_in_grid(-1);
-                self.status = self.focus_status();
-                Ok(Some(false))
-            }
-            KeyCode::Down => {
-                self.focus_in_grid(1);
-                self.status = self.focus_status();
-                Ok(Some(false))
-            }
-            _ => Ok(None),
-        }
+    fn open_command_palette(&mut self) {
+        self.close_tab_modals();
+        self.settings.open = false;
+        self.image_overlay = None;
+        self.help_open = false;
+        self.command_palette.open();
+        self.status = "command palette open".into();
     }
 
-    fn handle_alt_char(
+    fn handle_command_palette_key(
         &mut self,
         terminal: &mut Tui,
-        ch: char,
-        modifiers: KeyModifiers,
-    ) -> Result<Option<bool>> {
-        let lower = ch.to_ascii_lowercase();
-        match lower {
-            'q' => Ok(Some(true)),
-            's' => {
+        key: KeyEvent,
+    ) -> Result<KeyOutcome> {
+        if Action::from_key(&key) == Some(Action::OpenCommandPalette) {
+            self.command_palette.close();
+            self.status = "command palette closed".into();
+            return Ok(KeyOutcome::Render);
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.command_palette.close();
+                self.status = "command palette closed".into();
+            }
+            KeyCode::Enter => {
+                let action = self.command_palette.selected_action();
+                self.command_palette.close();
+                let Some(action) = action else {
+                    self.status = "no matching command".into();
+                    return Ok(KeyOutcome::Render);
+                };
+                return self.execute_action(terminal, action);
+            }
+            KeyCode::Up => self.command_palette.move_selection(-1),
+            KeyCode::Down => self.command_palette.move_selection(1),
+            KeyCode::Backspace => {
+                self.command_palette.backspace();
+            }
+            KeyCode::Delete => {
+                self.command_palette.delete();
+            }
+            KeyCode::Left => {
+                self.command_palette.move_cursor(-1);
+            }
+            KeyCode::Right => {
+                self.command_palette.move_cursor(1);
+            }
+            KeyCode::Home => {
+                self.command_palette.move_to_start();
+            }
+            KeyCode::End => {
+                self.command_palette.move_to_end();
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.command_palette.clear();
+            }
+            KeyCode::Char(ch)
+                if !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.command_palette.insert_text(&ch.to_string());
+            }
+            _ => return Ok(KeyOutcome::Continue),
+        }
+        Ok(KeyOutcome::Render)
+    }
+
+    fn execute_action(&mut self, terminal: &mut Tui, action: Action) -> Result<KeyOutcome> {
+        match action {
+            Action::OpenCommandPalette => {
+                self.open_command_palette();
+            }
+            Action::FocusLeft => {
+                self.focus_previous();
+                self.status = self.focus_status();
+            }
+            Action::FocusRight => {
+                self.focus_next();
+                self.status = self.focus_status();
+            }
+            Action::FocusUp => {
+                self.focus_in_grid(-1);
+                self.status = self.focus_status();
+            }
+            Action::FocusDown => {
+                self.focus_in_grid(1);
+                self.status = self.focus_status();
+            }
+            Action::TogglePaneSelection => {
                 if self.command_line.focused {
                     self.status = "command line focused".into();
                 } else {
                     self.toggle_pane_selection(self.focus);
                 }
-                Ok(Some(false))
             }
-            'a' => {
+            Action::ToggleSelectAll => {
                 if self.selected.len() == self.panes.len() {
                     self.selected.clear();
                 } else {
                     self.selected = (0..self.panes.len()).collect();
                 }
                 self.status = format!("selected {} panes", self.selected.len());
-                Ok(Some(false))
             }
-            'z' => {
-                self.toggle_sleep_for_targets();
-                Ok(Some(false))
-            }
-            't' if modifiers.contains(KeyModifiers::SHIFT) => {
-                self.restart_exited_targets();
-                Ok(Some(false))
-            }
-            't' => {
-                self.next_tab();
-                Ok(Some(false))
-            }
-            'n' => {
-                self.open_new_tab(terminal)?;
-                Ok(Some(false))
-            }
-            'l' => {
-                self.open_grid_resizer();
-                Ok(Some(false))
-            }
-            'x' => {
-                self.swap_selected_tiles();
-                Ok(Some(false))
-            }
-            'c' => {
+            Action::ToggleSleep => self.toggle_sleep_for_targets(),
+            Action::RestartExited => self.restart_exited_targets(),
+            Action::NewTab => self.open_new_tab(terminal)?,
+            Action::NextTab => self.next_tab(),
+            Action::RenameTab => self.begin_tab_rename(),
+            Action::ResizeGrid => self.open_grid_resizer(),
+            Action::SwapSelected => self.swap_selected_tiles(),
+            Action::ToggleCommandLine => {
                 self.command_line.toggle_focus();
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            'v' if is_voice_shortcut(ch, modifiers) => {
-                self.toggle_voice_input();
-                Ok(Some(false))
-            }
-            'g' => {
-                self.open_goal_editor_for(self.focus);
-                Ok(Some(false))
-            }
-            'u' => {
-                self.stop_pane_goal(self.focus);
-                Ok(Some(false))
-            }
-            'o' => {
+            Action::TogglePaneSummary => self.toggle_pane_settings(),
+            Action::TogglePreviousPanes => self.open_previous_panes(),
+            Action::RenamePane => self.begin_rename(),
+            Action::ToggleVoiceInput => self.toggle_voice_input(),
+            Action::EditGridGoal => self.open_goal_editor_for(self.focus),
+            Action::StopGridGoal => self.stop_pane_goal(self.focus),
+            Action::OpenSettings => {
                 self.settings.open = true;
                 if self.settings.tab == SettingsTab::Auth {
                     self.start_auth_refresh();
                 }
                 self.status = "settings open".into();
-                Ok(Some(false))
             }
-            'p' if modifiers.contains(KeyModifiers::SHIFT) => {
-                self.open_previous_panes();
-                Ok(Some(false))
-            }
-            'p' => {
-                self.toggle_pane_settings();
-                Ok(Some(false))
-            }
-            'r' if modifiers.contains(KeyModifiers::SHIFT) => {
-                self.begin_tab_rename();
-                Ok(Some(false))
-            }
-            'r' => {
-                self.begin_rename();
-                Ok(Some(false))
-            }
-            _ => Ok(None),
+            Action::OpenHelp => self.open_help(),
+            Action::Quit => return Ok(self.request_quit()),
         }
+        Ok(KeyOutcome::Render)
     }
 
     fn handle_exited_recovery_key(&mut self, key: KeyEvent) -> Option<KeyOutcome> {
@@ -5571,6 +5715,30 @@ impl App {
         self.image_overlay.as_ref()
     }
 
+    pub fn command_palette_view(&self) -> Option<CommandPaletteView> {
+        self.command_palette.open.then(|| {
+            let actions = self.command_palette.matches();
+            let selected = self
+                .command_palette
+                .selected
+                .min(actions.len().saturating_sub(1));
+            CommandPaletteView {
+                query: self.command_palette.input.clone(),
+                cursor_chars: self.command_palette.input[..self.command_palette.cursor]
+                    .chars()
+                    .count(),
+                selected,
+                items: actions
+                    .into_iter()
+                    .map(|action| CommandPaletteItem {
+                        label: action.label(),
+                        shortcut: action.default_shortcut(),
+                    })
+                    .collect(),
+            }
+        })
+    }
+
     pub fn exited_recovery_view(&self) -> Option<ExitedPaneRecoveryView> {
         let pane = self.panes.get(self.focus)?;
         if !pane.exited || self.sleeping.contains(&self.focus) {
@@ -7494,24 +7662,6 @@ fn pane_number_list(indices: &[usize]) -> String {
         .join(", ")
 }
 
-fn is_voice_shortcut(ch: char, modifiers: KeyModifiers) -> bool {
-    ch.eq_ignore_ascii_case(&'v')
-        && modifiers.contains(KeyModifiers::ALT)
-        && modifiers.contains(KeyModifiers::SHIFT)
-        && !modifiers.contains(KeyModifiers::CONTROL)
-}
-
-fn is_quit_shortcut(key: &KeyEvent) -> bool {
-    key.modifiers.contains(KeyModifiers::ALT)
-        && matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q'))
-}
-
-fn is_help_shortcut(key: &KeyEvent) -> bool {
-    matches!(key.code, KeyCode::F(1))
-        || (key.modifiers.contains(KeyModifiers::ALT)
-            && matches!(key.code, KeyCode::Char('h') | KeyCode::Char('H')))
-}
-
 fn control_byte(ch: char) -> Option<u8> {
     let lower = ch.to_ascii_lowercase();
     if lower.is_ascii_lowercase() {
@@ -8256,27 +8406,62 @@ mod tests {
     #[test]
     fn voice_shortcut_preserves_plain_alt_v_for_agent_image_paste() {
         let image_paste = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT);
-        assert!(!is_voice_shortcut('v', KeyModifiers::ALT));
+        assert_eq!(Action::from_key(&image_paste), None);
         assert_eq!(terminal_key_bytes(image_paste), Some(b"\x1bv".to_vec()));
 
         let voice_modifiers = KeyModifiers::ALT | KeyModifiers::SHIFT;
-        assert!(is_voice_shortcut('V', voice_modifiers));
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::Char('V'), voice_modifiers)),
+            Some(Action::ToggleVoiceInput)
+        );
     }
 
     #[test]
     fn help_shortcuts_are_modeless_and_plain_h_passes_through() {
-        assert!(is_help_shortcut(&KeyEvent::new(
-            KeyCode::Char('h'),
-            KeyModifiers::ALT,
-        )));
-        assert!(is_help_shortcut(&KeyEvent::new(
-            KeyCode::F(1),
-            KeyModifiers::NONE,
-        )));
-        assert!(!is_help_shortcut(&KeyEvent::new(
-            KeyCode::Char('h'),
-            KeyModifiers::NONE,
-        )));
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::Char('h'), KeyModifiers::ALT)),
+            Some(Action::OpenHelp)
+        );
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::F(1), KeyModifiers::NONE)),
+            Some(Action::OpenHelp)
+        );
+        assert_eq!(
+            Action::from_key(&KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE)),
+            None
+        );
+    }
+
+    #[test]
+    fn command_palette_edits_unicode_at_character_boundaries() {
+        let mut palette = CommandPaletteState::default();
+        palette.open();
+        palette.insert_text("pane 東京");
+        assert!(palette.move_cursor(-1));
+        assert!(palette.delete());
+        palette.insert_text("京");
+
+        assert_eq!(palette.input, "pane 東京");
+        assert_eq!(palette.cursor, "pane 東京".len());
+    }
+
+    #[test]
+    fn command_palette_filters_and_wraps_selection() {
+        let mut palette = CommandPaletteState::default();
+        palette.open();
+        palette.insert_text("rename");
+        let matches = palette.matches();
+        assert!(matches.contains(&Action::RenamePane));
+        assert!(matches.contains(&Action::RenameTab));
+
+        palette.move_selection(-1);
+        assert_eq!(palette.selected, matches.len() - 1);
+        assert_eq!(palette.selected_action(), matches.last().copied());
+
+        palette.clear();
+        palette.insert_text("not a real action zzzz");
+        assert!(palette.matches().is_empty());
+        assert_eq!(palette.selected_action(), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod actions;
 mod app;
 mod auth;
 mod cli;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,9 +9,10 @@ use vt100::Cell;
 
 use crate::{
     app::{
-        App, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView, GridPalette, PaneSelection,
-        PaneSettingsTarget, PaneSettingsView, PreviousPaneView, PreviousPanesView, RenamePaneView,
-        RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind, TabLabel,
+        App, CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView,
+        GridPalette, PaneSelection, PaneSettingsTarget, PaneSettingsView, PreviousPaneView,
+        PreviousPanesView, RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab,
+        SettingsValueKind, TabLabel,
     },
     auth::{AgentKind, AuthProfile},
     composer::GridPickerMode,
@@ -85,11 +86,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let follow_up_dialog = app.follow_up_dialog();
     let goal_editor_view = app.goal_editor_view();
     let pane_settings_view = app.pane_settings_view();
+    let command_palette_view = app.command_palette_view();
     let pane_settings_open = pane_settings_view.is_some();
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let help_open = app.help_open();
-    let exited_recovery = if help_open
+    let exited_recovery = if command_palette_view.is_some()
+        || help_open
         || app.settings_open()
         || previous_panes_view.is_some()
         || pane_settings_open
@@ -104,7 +107,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     } else {
         app.exited_recovery_view()
     };
-    let modal_open = help_open
+    let modal_open = command_palette_view.is_some()
+        || help_open
         || app.settings_open()
         || previous_panes_view.is_some()
         || pane_settings_open
@@ -226,7 +230,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+k commands | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -271,6 +275,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
     if help_open {
         render_help(frame, area, palette);
+    }
+    if let Some(view) = command_palette_view.as_ref() {
+        render_command_palette(frame, area, view, palette);
     }
 
     DrawState {
@@ -2477,6 +2484,7 @@ fn settings_panel_style() -> Style {
 fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
     const CONTROLS: &[(&str, &str)] = &[
         ("Alt+arrows", "move pane focus"),
+        ("Alt+k", "open searchable commands"),
         ("Alt+s", "toggle pane selection"),
         ("Alt+a", "select or clear all panes"),
         ("type/paste", "send to focused or selected panes"),
@@ -2546,6 +2554,92 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
             .style(Style::default().fg(SETTINGS_TEXT).bg(SETTINGS_BG)),
         modal,
     );
+}
+
+fn render_command_palette(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    view: &CommandPaletteView,
+    palette: &GridPalette,
+) {
+    let width = area.width.saturating_sub(2).min(86).max(area.width.min(1));
+    let desired_height = (view.items.len() as u16).saturating_add(4).clamp(6, 18);
+    let height = desired_height
+        .min(area.height.saturating_sub(2))
+        .max(area.height.min(1));
+    let modal = Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 3,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(palette.accent()))
+        .title(" GridBash Commands ")
+        .title_bottom(" Enter runs | Up/Down selects | Esc closes ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let input_width = inner.width.saturating_sub(3) as usize;
+    let (query, cursor_offset) = visible_input(&view.query, view.cursor_chars, input_width);
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            "> ",
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(query, Style::default().fg(SETTINGS_TEXT)),
+    ])];
+
+    let item_count = inner.height.saturating_sub(1) as usize;
+    if view.items.is_empty() && item_count > 0 {
+        lines.push(Line::from(Span::styled(
+            "  No matching commands",
+            Style::default().fg(SETTINGS_MUTED),
+        )));
+    } else {
+        let start = view.selected.saturating_sub(item_count.saturating_sub(1));
+        for (index, item) in view.items.iter().enumerate().skip(start).take(item_count) {
+            let marker = if index == view.selected { ">" } else { " " };
+            let shortcut_width = item.shortcut.chars().count().min(18);
+            let label_width = inner
+                .width
+                .saturating_sub(shortcut_width as u16)
+                .saturating_sub(4) as usize;
+            let label = truncate_text(item.label, label_width);
+            let padding = " ".repeat(label_width.saturating_sub(label.chars().count()));
+            let style = if index == view.selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(palette.focus())
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SETTINGS_TEXT).bg(SETTINGS_BG)
+            };
+            lines.push(
+                Line::from(format!(
+                    "{marker} {label}{padding}  {}",
+                    truncate_text(item.shortcut, shortcut_width)
+                ))
+                .style(style),
+            );
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), inner);
+    let cursor_x = inner
+        .x
+        .saturating_add(2)
+        .saturating_add(cursor_offset.min(input_width) as u16)
+        .min(inner.x.saturating_add(inner.width.saturating_sub(1)));
+    frame.set_cursor_position((cursor_x, inner.y));
 }
 
 fn help_control((key, action): (&str, &str), width: usize) -> String {
@@ -2964,6 +3058,39 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn command_palette_renders_at_narrow_sizes_and_handles_no_matches() {
+        let backend = TestBackend::new(24, 8);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = CommandPaletteView {
+            query: "missing 東京".into(),
+            cursor_chars: 10,
+            selected: 0,
+            items: Vec::new(),
+        };
+
+        terminal
+            .draw(|frame| {
+                render_command_palette(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render palette");
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("GridBash Commands"));
+        assert!(rendered.contains("No matching"));
+    }
 
     #[test]
     fn idle_pane_has_no_state_badges() {


### PR DESCRIPTION
## Summary
- add an `Alt+k` searchable command palette for pane, tab, grid, manager, settings, help, and quit actions
- route direct modeless shortcuts and palette execution through one typed action registry
- protect child PTYs from palette typing/paste and keep the modal usable on narrow terminals
- document the control and add a devlog

## Validation
- `cargo fmt --check`
- `cargo test -j 1` (173 passed, 1 intentionally ignored; inherited `GRIDBASH_INVOKING_PROFILE` cleared for the clean-onboarding test)
- `cargo clippy -j 1 --all-targets -- -D warnings`

Closes #226