### PR TITLE
feat: add dedicated Auth Profiles command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ agents and shells.
 | `Alt+c` | Open or close the command line |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
+| `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |
 | `Alt+g` / `Alt+u` | Start or stop the grid manager goal |
 | `Alt+Shift+V` | Dictate one prompt without submitting it |
 | `Alt+o` | Open settings |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -148,6 +148,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+h / F1 | Open or close help. |
 | Alt+p | Open the focused-pane activity summary. |
 | Alt+Shift+P | Open the previous-panes list. |
+| Alt+Shift+A | Open Auth Profiles to manage accounts or assign one to the focused pane. |
 | Alt+r | Rename the focused pane. |
 | Alt+Shift+R | Rename the current tab. |
 | Alt+Shift+T | Restart the exited focused pane, or all exited selected panes. |
@@ -162,7 +163,7 @@ Drag selection is contained to its source pane and copies through the standard O
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
 
-Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+o switches to overall settings.
+Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+Shift+A opens Auth Profiles and Alt+o switches to overall settings.
 
 If the focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
 
@@ -317,20 +318,26 @@ The old default was `~/.claude-profiles`; profiles are not moved automatically. 
 
 Assignment is manual by default: a new pane uses the configured default for its agent kind, while an explicit per-pane selection is retained. With `auto_cycle = true`, new compatible panes are assigned round-robin across ready profiles of the same kind. Changing the policy does not restart panes already running.
 
+Press Alt+Shift+A to open the dedicated Auth Profiles view. A managed profile is an isolated Claude or Codex home: it keeps that account's login, agent settings, sessions, and usage separate from the normal agent home and from other profiles. The view keeps two actions distinct:
+
+- **Focused pane:** highlighting a compatible profile and pressing Enter assigns it immediately, which restarts that pane.
+- **New pane policy:** per-agent defaults or round-robin assignment apply only when compatible panes start. They do not change panes already running.
+
 ### Auth settings controls
 
 | Input | Action |
 | --- | --- |
 | Tab | Switch Settings tabs. |
 | Up / Down | Move through profiles. |
+| Enter | Assign the selected compatible profile to the focused pane and restart that pane. |
 | `d` | Make the selected profile the GridBash-wide default for its kind. |
-| `c` | Toggle manual assignment and auto-cycle for new panes. |
+| `c` | Toggle per-agent defaults and round-robin assignment for new panes. |
 | `n` | Create a profile directory. |
 | `l` | Open the selected profile's login command. |
 | `r` | Refresh local account and usage status. |
 | Esc / `q` | Close settings. |
 
-For a Claude or Codex pane, open Pane Activity with Alt+p, select the auth control with Up/Down, choose a compatible profile with Left/Right, and press Enter. Applying a different account restarts only that pane. Press `r` in Pane Activity to refresh its snapshot.
+The focused pane can also be switched from Pane Activity: press Alt+p, select the auth control with Up/Down, choose a compatible profile with Left/Right, and press Enter. Applying a different account restarts only that pane. Press `r` in Pane Activity to refresh its snapshot.
 
 Usage reporting is best-effort. GridBash reads local auth metadata, masks account email addresses, and makes short-timeout requests with `curl.exe` on Windows or `curl` on macOS only when the Auth view is refreshed. Disable it with `usage_status = false`.
 

--- a/docs/devlogs/2026-07-15-dedicated-auth-profiles-command.md
+++ b/docs/devlogs/2026-07-15-dedicated-auth-profiles-command.md
@@ -1,0 +1,34 @@
+# dedicated auth profiles command
+
+Date: 2026-07-15
+Release target: unreleased
+
+Issue: [#232](https://github.com/jasonsuhari/gridbash/issues/232)
+
+## Summary
+
+- Added a dedicated Auth Profiles command that makes managed accounts, focused-pane assignment, and new-pane launch policy understandable in one place.
+
+## What Changed
+
+- Added Alt+Shift+A as a direct Auth Profiles shortcut while preserving Alt+A for select-all.
+- Reworked the Auth view around three explicit concepts: the focused pane's current account, the policy for future panes, and the isolated profile list.
+- Added Enter-to-assign for the highlighted compatible profile. Assignment reuses the existing safe pane restart/session-save path and leaves other panes running.
+- Renamed user-facing auto-cycle copy to round-robin and clarified that defaults and round-robin only affect panes when they start.
+- Updated in-app help, status guidance, README controls, and the auth reference.
+
+## Why It Matters
+
+- Managed auth previously existed across global Settings and Pane Activity, but the entry point and scope of each control were easy to miss.
+- The dedicated view now explains that profiles are isolated Claude/Codex homes and shows the restart consequence before a current pane is switched.
+
+## Validation
+
+- `cargo test auth -- --test-threads=1` (15 passed)
+- `cargo test` with `GRIDBASH_INVOKING_PROFILE` removed from the child test environment (169 passed, 1 ignored)
+- `cargo clippy --all-targets -- -D warnings`
+- `npm test` with `GRIDBASH_INVOKING_PROFILE` removed from the child test environment (169 passed, 1 ignored)
+
+## Release Notes
+
+- Press Alt+Shift+A to manage isolated Claude/Codex auth profiles, assign one to the focused pane, or choose defaults versus round-robin assignment for new panes.

--- a/src/app.rs
+++ b/src/app.rs
@@ -885,6 +885,14 @@ pub struct AuthCreateState {
     pub name: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct AuthPaneView {
+    pub index: usize,
+    pub label: String,
+    pub kind: Option<AgentKind>,
+    pub current_profile: Option<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct RenamePaneState {
     open: bool,
@@ -1834,10 +1842,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+arrows move | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+arrows move | Alt+l resize | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+arrows move | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -3229,6 +3237,10 @@ impl App {
                 }
                 Ok(Some(false))
             }
+            'a' if modifiers.contains(KeyModifiers::SHIFT) => {
+                self.open_auth_profiles();
+                Ok(Some(false))
+            }
             'a' => {
                 if self.selected.len() == self.panes.len() {
                     self.selected.clear();
@@ -3325,6 +3337,21 @@ impl App {
         self.close_tab_modals();
         self.grid_resizer = Some(GridPicker::new(self.layout.size()));
         self.status = "grid resizer open".into();
+    }
+
+    fn open_auth_profiles(&mut self) {
+        self.close_tab_modals();
+        self.settings.todo_edit = None;
+        self.settings.manager_edit = None;
+        self.settings.open = true;
+        self.settings.tab = SettingsTab::Auth;
+        if self.auth_profiles.is_empty()
+            && let Ok(profiles) = auth::discover_profiles(&self.config.auth)
+        {
+            self.auth_profiles = profiles;
+        }
+        self.align_auth_cursor_to_focused_pane();
+        self.start_auth_refresh();
     }
 
     fn handle_grid_resizer_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -3635,6 +3662,10 @@ impl App {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return Ok(KeyOutcome::Quit);
         }
+        if is_auth_profiles_shortcut(&key) {
+            self.open_auth_profiles();
+            return Ok(KeyOutcome::Render);
+        }
         if let Some(shortcut) = pane_overlay_shortcut(&key) {
             match shortcut {
                 PaneOverlayShortcut::Summary => self.close_pane_settings(),
@@ -3807,6 +3838,53 @@ impl App {
             self.status = "no compatible auth profile selected".into();
             return Ok(());
         };
+        self.apply_auth_profile_to_pane(pane_index, profile)
+    }
+
+    fn apply_selected_auth_to_focused_pane(&mut self) -> Result<()> {
+        let Some(profile) = self.selected_auth_profile().cloned() else {
+            self.status = "no auth profile selected".into();
+            return Ok(());
+        };
+        let pane_index = self.focus;
+        let Some(spec) = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(pane_index))
+        else {
+            self.status = "focused pane has no launch settings".into();
+            return Ok(());
+        };
+        let Some(kind) = spec.command.agent_kind else {
+            self.status = format!(
+                "pane {} is not a Claude or Codex pane; managed auth was not changed",
+                pane_index + 1
+            );
+            return Ok(());
+        };
+        if kind != profile.kind {
+            self.status = format!(
+                "pane {} needs a {} profile; {} is {}",
+                pane_index + 1,
+                kind.display_name(),
+                profile.name,
+                profile.kind.display_name()
+            );
+            return Ok(());
+        }
+        if spec.auth_name.as_deref() == Some(profile.name.as_str()) {
+            self.status = format!("pane {} already uses auth {}", pane_index + 1, profile.name);
+            return Ok(());
+        }
+
+        self.apply_auth_profile_to_pane(pane_index, profile)
+    }
+
+    fn apply_auth_profile_to_pane(
+        &mut self,
+        pane_index: usize,
+        profile: AuthProfile,
+    ) -> Result<()> {
         let auth_env = auth::env_for_profile(&self.config.auth, profile.kind, &profile.name)?;
         let mut spec = self
             .launch_plan
@@ -3825,8 +3903,10 @@ impl App {
             *idle = PaneIdleState::new(Instant::now());
         }
         self.sleeping.remove(&pane_index);
-        self.pane_settings
-            .refresh_history("waiting for output".into());
+        if self.pane_settings.open && self.pane_settings.pane_index == pane_index {
+            self.pane_settings
+                .refresh_history("waiting for output".into());
+        }
         self.start_usage_for_active_tab();
         self.save_session_snapshot()?;
         self.status = format!(
@@ -3984,6 +4064,10 @@ impl App {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return Ok(KeyOutcome::Quit);
         }
+        if is_auth_profiles_shortcut(&key) {
+            self.open_auth_profiles();
+            return Ok(KeyOutcome::Render);
+        }
 
         if self.settings.editing_todo() {
             return self.handle_todo_edit_key(key);
@@ -4063,6 +4147,10 @@ impl App {
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.move_auth_cursor(1);
+                true
+            }
+            KeyCode::Enter => {
+                self.apply_selected_auth_to_focused_pane()?;
                 true
             }
             KeyCode::Char('r') | KeyCode::Char('R') => {
@@ -5612,6 +5700,20 @@ impl App {
         self.settings.create_auth.as_ref()
     }
 
+    pub fn auth_pane_view(&self) -> Option<AuthPaneView> {
+        self.panes.get(self.focus)?;
+        let spec = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(self.focus));
+        Some(AuthPaneView {
+            index: self.focus,
+            label: self.pane_label(self.focus),
+            kind: spec.and_then(|spec| spec.command.agent_kind),
+            current_profile: spec.and_then(|spec| spec.auth_name.clone()),
+        })
+    }
+
     pub fn auth_default(&self, kind: AgentKind) -> Option<&str> {
         self.config.auth.defaults.get(kind)
     }
@@ -6059,6 +6161,34 @@ impl App {
         self.auth_profiles.get(self.settings.auth_cursor)
     }
 
+    fn align_auth_cursor_to_focused_pane(&mut self) {
+        let Some(spec) = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(self.focus))
+        else {
+            return;
+        };
+        let Some(kind) = spec.command.agent_kind else {
+            return;
+        };
+        let current = spec.auth_name.as_deref();
+        if let Some(index) = current
+            .and_then(|name| {
+                self.auth_profiles
+                    .iter()
+                    .position(|profile| profile.kind == kind && profile.name.as_str() == name)
+            })
+            .or_else(|| {
+                self.auth_profiles
+                    .iter()
+                    .position(|profile| profile.kind == kind)
+            })
+        {
+            self.settings.auth_cursor = index;
+        }
+    }
+
     fn set_selected_auth_default(&mut self) -> Result<()> {
         let Some(profile) = self.selected_auth_profile().cloned() else {
             self.status = "no auth profile selected".into();
@@ -6070,8 +6200,13 @@ impl App {
             .defaults
             .set(profile.kind, profile.name.clone());
         let path = self.config.save(self.config_path.as_deref())?;
+        let cycle_note = if self.config.auth.auto_cycle {
+            "; round-robin is currently on"
+        } else {
+            ""
+        };
         self.status = format!(
-            "{} default auth: {} ({})",
+            "{} new-pane default: {}{cycle_note} ({})",
             profile.kind.display_name(),
             profile.name,
             path.display()
@@ -6083,11 +6218,11 @@ impl App {
         self.config.auth.auto_cycle = !self.config.auth.auto_cycle;
         let path = self.config.save(self.config_path.as_deref())?;
         let mode = if self.config.auth.auto_cycle {
-            "auto-cycle ready profiles"
+            "round-robin ready profiles for new panes"
         } else {
-            "manual profile selection"
+            "use per-agent defaults for new panes"
         };
-        self.status = format!("auth launch mode: {mode} ({})", path.display());
+        self.status = format!("auth new-pane policy: {mode} ({})", path.display());
         Ok(())
     }
 
@@ -8524,6 +8659,12 @@ fn pane_overlay_shortcut(key: &KeyEvent) -> Option<PaneOverlayShortcut> {
     })
 }
 
+fn is_auth_profiles_shortcut(key: &KeyEvent) -> bool {
+    key.modifiers.contains(KeyModifiers::ALT)
+        && key.modifiers.contains(KeyModifiers::SHIFT)
+        && matches!(key.code, KeyCode::Char('a') | KeyCode::Char('A'))
+}
+
 fn pane_activity_summary(pane: &PtyPane) -> Option<String> {
     output_tail_summary(pane.output_tail()).or_else(|| conversation_summary(pane.screen()))
 }
@@ -9205,6 +9346,26 @@ mod selection_tests {
             &targets,
             &after_forwarded_mouse_input
         ));
+    }
+
+    #[test]
+    fn auth_profiles_shortcut_keeps_plain_alt_a_available() {
+        assert!(is_auth_profiles_shortcut(&KeyEvent::new(
+            KeyCode::Char('A'),
+            KeyModifiers::ALT | KeyModifiers::SHIFT,
+        )));
+        assert!(is_auth_profiles_shortcut(&KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers::ALT | KeyModifiers::SHIFT,
+        )));
+        assert!(!is_auth_profiles_shortcut(&KeyEvent::new(
+            KeyCode::Char('a'),
+            KeyModifiers::ALT,
+        )));
+        assert!(!is_auth_profiles_shortcut(&KeyEvent::new(
+            KeyCode::Char('A'),
+            KeyModifiers::SHIFT,
+        )));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -226,7 +226,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(
-            " | Alt+h help | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
+            " | Alt+h help | Alt+l resize | Alt+Shift+A auth | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
         ),
     ]);
     frame.render_widget(
@@ -1411,6 +1411,11 @@ fn render_settings(frame: &mut Frame<'_>, area: Rect, app: &App, palette: &GridP
 
     frame.render_widget(Clear, modal);
 
+    let title = if app.settings_tab() == SettingsTab::Auth {
+        " Auth Profiles | Alt+Shift+A "
+    } else {
+        " GridBash Settings "
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(
@@ -1419,7 +1424,7 @@ fn render_settings(frame: &mut Frame<'_>, area: Rect, app: &App, palette: &GridP
                 .add_modifier(Modifier::BOLD),
         )
         .style(settings_panel_style())
-        .title(" GridBash Settings ");
+        .title(title);
     let inner = block.inner(modal);
     frame.render_widget(block, modal);
     frame.render_widget(
@@ -1978,46 +1983,26 @@ fn auth_settings_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     let mut lines = vec![
         settings_tabs(SettingsTab::Auth),
         Line::from(""),
-        settings_section("LAUNCH POLICY", "applies to new compatible panes", width),
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled("Auth assignment", Style::default().fg(SETTINGS_TEXT)),
-            Span::raw("  "),
-            Span::styled(
-                if app.auth_auto_cycle() {
-                    "[ auto-cycle ]"
-                } else {
-                    "[ manual ]"
-                },
-                if app.auth_auto_cycle() {
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(SETTINGS_BORDER)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                        .fg(Color::LightCyan)
-                        .bg(SETTINGS_SURFACE)
-                        .add_modifier(Modifier::BOLD)
-                },
-            ),
-            Span::raw("  "),
-            Span::styled(
-                if app.auth_auto_cycle() {
-                    "round-robin across ready accounts"
-                } else {
-                    "pane choices stay explicit"
-                },
-                Style::default().fg(SETTINGS_MUTED),
-            ),
-        ]),
+        settings_section(
+            "FOCUSED PANE",
+            "Enter applies the highlighted compatible profile and restarts this pane",
+            width,
+        ),
+        auth_focused_pane_line(app, width),
+        Line::from(""),
+        settings_section(
+            "NEW PANE POLICY",
+            "only affects panes when they start; running panes keep their current profile",
+            width,
+        ),
+        auth_new_pane_policy_line(app, width),
         Line::from(""),
         settings_section(
             "AUTH PROFILES",
             if app.auth_refreshing() {
                 "refreshing local account and usage status"
             } else {
-                "Claude and Codex defaults"
+                "isolated Claude/Codex homes; each keeps its own login and usage"
             },
             width,
         ),
@@ -2070,8 +2055,105 @@ fn auth_settings_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::from(""));
-    lines.push(auth_command_bar(width));
+    lines.extend(auth_command_bar(width));
     lines
+}
+
+fn auth_focused_pane_line(app: &App, width: u16) -> Line<'static> {
+    let Some(pane) = app.auth_pane_view() else {
+        return Line::from(vec![
+            Span::raw("  "),
+            Span::styled("No focused pane.", Style::default().fg(SETTINGS_MUTED)),
+        ]);
+    };
+    let Some(kind) = pane.kind else {
+        return Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                truncate_text(
+                    &format!(
+                        "pane {} ({}) | managed auth only applies to Claude and Codex panes",
+                        pane.index + 1,
+                        pane.label
+                    ),
+                    width.saturating_sub(2) as usize,
+                ),
+                Style::default().fg(SETTINGS_MUTED),
+            ),
+        ]);
+    };
+
+    let current = pane.current_profile.as_deref().unwrap_or("normal login");
+    let action = app
+        .auth_profiles()
+        .get(app.auth_cursor())
+        .map(|profile| {
+            if profile.kind != kind {
+                format!("select a {} profile", kind.display_name())
+            } else if pane.current_profile.as_deref() == Some(profile.name.as_str()) {
+                "highlighted profile is current".into()
+            } else {
+                format!("Enter uses {} + restarts", profile.name)
+            }
+        })
+        .unwrap_or_else(|| "create or select a profile below".into());
+    let summary = format!(
+        "pane {} ({}) | {} | current: {} | {}",
+        pane.index + 1,
+        pane.label,
+        kind.display_name(),
+        current,
+        action
+    );
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            truncate_text(&summary, width.saturating_sub(2) as usize),
+            Style::default()
+                .fg(kind_color(kind))
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn auth_new_pane_policy_line(app: &App, width: u16) -> Line<'static> {
+    let (mode, detail) = if app.auth_auto_cycle() {
+        (
+            "[ round-robin ]",
+            "rotate through every ready profile of the matching agent kind".to_string(),
+        )
+    } else {
+        let claude = app
+            .auth_default(AgentKind::Claude)
+            .unwrap_or("normal login");
+        let codex = app.auth_default(AgentKind::Codex).unwrap_or("normal login");
+        (
+            "[ per-agent defaults ]",
+            format!("Claude: {claude} | Codex: {codex}"),
+        )
+    };
+    let summary = truncate_text(
+        &format!("{mode}  {detail}"),
+        width.saturating_sub(2) as usize,
+    );
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            summary,
+            Style::default()
+                .fg(if app.auth_auto_cycle() {
+                    Color::Black
+                } else {
+                    Color::LightCyan
+                })
+                .bg(if app.auth_auto_cycle() {
+                    SETTINGS_BORDER
+                } else {
+                    SETTINGS_SURFACE
+                })
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])
 }
 
 fn manager_settings_lines(app: &App, width: u16) -> Vec<Line<'static>> {
@@ -2146,38 +2228,61 @@ fn auth_profile_row(
     ])
 }
 
-fn auth_command_bar(width: u16) -> Line<'static> {
+fn auth_command_bar(width: u16) -> Vec<Line<'static>> {
     if width < 58 {
-        return Line::from(vec![
+        return vec![
+            Line::from(vec![
+                Span::raw("  "),
+                command_key("Up/Down"),
+                Span::styled(" move  ", Style::default().fg(Color::Gray)),
+                command_key("Enter"),
+                Span::styled(" assign", Style::default().fg(Color::Gray)),
+            ]),
+            Line::from(vec![
+                Span::raw("  "),
+                command_key("d"),
+                Span::styled(" default  ", Style::default().fg(Color::Gray)),
+                command_key("c"),
+                Span::styled(" policy  ", Style::default().fg(Color::Gray)),
+                command_key("Esc"),
+                Span::styled(" close", Style::default().fg(Color::Gray)),
+            ]),
+            Line::from(vec![
+                Span::raw("  "),
+                command_key("n"),
+                Span::styled(" new  ", Style::default().fg(Color::Gray)),
+                command_key("l"),
+                Span::styled(" login  ", Style::default().fg(Color::Gray)),
+                command_key("r"),
+                Span::styled(" refresh", Style::default().fg(Color::Gray)),
+            ]),
+        ];
+    }
+
+    vec![
+        Line::from(vec![
             Span::raw("  "),
             command_key("Up/Down"),
             Span::styled(" move  ", Style::default().fg(Color::Gray)),
+            command_key("Enter"),
+            Span::styled(" assign  ", Style::default().fg(Color::Gray)),
+            command_key("Esc"),
+            Span::styled(" close", Style::default().fg(Color::Gray)),
+        ]),
+        Line::from(vec![
+            Span::raw("  "),
             command_key("d"),
             Span::styled(" default  ", Style::default().fg(Color::Gray)),
             command_key("c"),
-            Span::styled(" cycle  ", Style::default().fg(Color::Gray)),
-            command_key("Esc"),
-            Span::styled(" close", Style::default().fg(Color::Gray)),
-        ]);
-    }
-
-    Line::from(vec![
-        Span::raw("  "),
-        command_key("Up/Down"),
-        Span::styled(" move  ", Style::default().fg(Color::Gray)),
-        command_key("d"),
-        Span::styled(" default  ", Style::default().fg(Color::Gray)),
-        command_key("c"),
-        Span::styled(" cycle  ", Style::default().fg(Color::Gray)),
-        command_key("n"),
-        Span::styled(" new  ", Style::default().fg(Color::Gray)),
-        command_key("l"),
-        Span::styled(" login  ", Style::default().fg(Color::Gray)),
-        command_key("r"),
-        Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
-        command_key("Esc"),
-        Span::styled(" close", Style::default().fg(Color::Gray)),
-    ])
+            Span::styled(" policy  ", Style::default().fg(Color::Gray)),
+            command_key("n"),
+            Span::styled(" new  ", Style::default().fg(Color::Gray)),
+            command_key("l"),
+            Span::styled(" login  ", Style::default().fg(Color::Gray)),
+            command_key("r"),
+            Span::styled(" refresh", Style::default().fg(Color::Gray)),
+        ]),
+    ]
 }
 
 fn auth_create_command_bar() -> Line<'static> {
@@ -2488,11 +2593,12 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+l", "resize the grid"),
+        ("Alt+Shift+A", "manage and assign auth profiles"),
         ("Alt+r", "rename focused pane"),
         ("Alt+Shift+t", "restart exited panes"),
         ("Alt+z", "sleep or wake panes"),
         ("Alt+g / Alt+u", "start or stop grid goal"),
-        ("Alt+o", "open global settings/profiles"),
+        ("Alt+o", "open global settings"),
         ("Alt+Shift+V", "dictate without submitting"),
         ("Alt+q", "quit GridBash"),
         ("Alt+h / F1", "close this help"),
@@ -3208,6 +3314,20 @@ mod tests {
             .map(|span| span.content.as_ref())
             .collect::<String>();
         assert!(!no_auth.contains("Left/Right"));
+    }
+
+    #[test]
+    fn auth_command_bar_distinguishes_pane_assignment_and_new_pane_policy() {
+        let text = auth_command_bar(100)
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(text.contains("Enter"));
+        assert!(text.contains("assign"));
+        assert!(text.contains("default"));
+        assert!(text.contains("policy"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Alt+Shift+A as a dedicated Auth Profiles command while preserving Alt+A select-all
- explain focused-pane assignment separately from defaults/round-robin policy for new panes
- allow Enter to assign the highlighted compatible profile through the existing pane restart/session-save path
- update help, reference docs, tests, and devlog

## Validation
- `cargo test auth -- --test-threads=1` (15 passed)
- `cargo test` with `GRIDBASH_INVOKING_PROFILE` removed (169 passed, 1 ignored)
- `cargo clippy --all-targets -- -D warnings`
- `npm test` with `GRIDBASH_INVOKING_PROFILE` removed (169 passed, 1 ignored)

Tracks #232.