### PR TITLE
docs: add creator attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,4 +150,6 @@ Release maintainers should follow [docs/RELEASING.md](docs/RELEASING.md).
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
 
+Created and maintained by [Jason Matthew Suhari](https://www.jasonsuhari.com).
+
 GridBash is available under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- add a concise creator/maintainer attribution to the product-first README
- link the canonical Jason Matthew Suhari portfolio for project and name discovery

## Validation
- `git diff --check`

Closes #241