### PR TITLE
feat: make GridBash shortcuts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ profiles, UI settings, auth defaults, manager credentials, and workload policy.
 The [configuration reference](docs/REFERENCE.md#configuration) covers file
 locations and precedence.
 
+Application shortcuts can also be remapped in `[keys]`, for example
+`zoom-pane = "ctrl+shift+k"`. Unlisted actions keep their defaults, while F1
+and `Alt+q` remain reliable help and quit fallbacks.
+
 ## Agent control API
 
 Enable GridBash's local, opt-in control API for agents inside its panes:

--- a/config.example.toml
+++ b/config.example.toml
@@ -20,6 +20,11 @@ selected = "cyan"
 quiet = "dark-gray"
 exited = "red"
 
+# Override any supported application action. Unlisted actions keep their defaults.
+[keys]
+zoom-pane = "alt+f"
+settings = "alt+o"
+
 [manager]
 endpoint = "https://api.openai.com/v1/chat/completions"
 model = "gpt-4o-mini"

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -167,6 +167,27 @@ Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal contr
 
 If the focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
 
+### Configurable shortcuts
+
+Override application controls in the top-level `[keys]` table. Action names
+use kebab case and chord values combine `ctrl`, `alt`, or `shift` with one
+letter, an arrow name, or `f2` through `f12`:
+
+```toml
+[keys]
+zoom-pane = "ctrl+shift+k"
+settings = "f8"
+```
+
+Supported actions are `quit`, `help`, `focus-left`, `focus-right`, `focus-up`,
+`focus-down`, `toggle-selection`, `select-all`, `sleep-panes`, `restart-panes`,
+`next-tab`, `new-tab`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
+`voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`,
+`pane-activity`, `rename-tab`, and `rename-pane`. Unlisted actions retain their
+defaults. Duplicate chords and unmodified terminal keys are rejected. F1 and
+`Alt+q` remain reserved help and quit recovery paths; in-app help displays the
+effective bindings.
+
 The resize picker starts from the current dimensions. Shrinking a grid deactivates live panes outside the retained upper-left rectangle; changing `3x3` to `3x2`, for example, removes the rightmost column.
 
 A pane's top border shows its latest activity summary. A configured manager goal replaces that summary across the grid until removed. A quiet marker appears after roughly three seconds without output; it indicates output followed by inactivity, not completion or process exit. Saving a blank pane name restores its default number.

--- a/docs/devlogs/2026-07-15-make-gridbash-shortcuts-configurable.md
+++ b/docs/devlogs/2026-07-15-make-gridbash-shortcuts-configurable.md
@@ -1,0 +1,34 @@
+# Make GridBash shortcuts configurable
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Made every modeless GridBash keyboard action configurable.
+
+## What Changed
+
+- Added a validated `[keys]` configuration table with stable action names and
+  normalized Ctrl/Alt/Shift chords.
+- Replaced hard-coded application dispatch with one typed action map while
+  keeping ordinary unbound keys in the child terminal.
+- Made in-app help render the effective bindings.
+- Reserved F1 and `Alt+q` as reliable help and quit recovery paths.
+- Updated the example config, README, and reference.
+
+## Why It Matters
+
+- Users can resolve host-terminal conflicts and adapt GridBash to an existing
+  muscle-memory layout without sacrificing terminal passthrough or recovery.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test keybindings`
+- `cargo test` with `GRIDBASH_INVOKING_PROFILE` removed
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Add overrides under `[keys]`; press F1 at any time to see the effective map.

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,7 @@ use crate::{
     config::{Config, PaletteColor, PaneWorkloadPolicy, UiConfig, UiPalette},
     control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
     image_preview::{self, ImagePreview},
+    keybindings::{Action, KeyBindings, is_help_recovery, is_quit_recovery},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
     process_priority::PaneWorkloadClass,
@@ -78,6 +79,7 @@ const PANE_SCROLL_ROWS: isize = 3;
 
 pub struct App {
     config: Config,
+    keybindings: KeyBindings,
     config_path: Option<PathBuf>,
     worktrees: Option<ManagedWorktreeOptions>,
     tabs: Vec<Option<GridTabSnapshot>>,
@@ -1877,7 +1879,11 @@ impl App {
         } else {
             (None, None)
         };
-        let base_status = default_status(mouse_enabled);
+        let base_status = if config.keys.is_empty() {
+            default_status(mouse_enabled)
+        } else {
+            "custom shortcuts active | F1 help | Alt+q quit fallback".into()
+        };
         let status = control_handle
             .as_ref()
             .map(|control| format!("agent API {} | {base_status}", control.endpoint()))
@@ -1938,8 +1944,11 @@ impl App {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let (goal_tx, goal_rx) = std_mpsc::channel();
 
+        let keybindings = KeyBindings::from_overrides(&init.config.keys)?;
+
         Ok(Self {
             config: init.config,
+            keybindings,
             config_path: init.config_path,
             worktrees: init.worktrees,
             tabs: vec![None],
@@ -3045,7 +3054,8 @@ impl App {
     }
 
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
-        if is_quit_shortcut(&key) {
+        let action = self.keybindings.action_for(&key);
+        if is_quit_recovery(&key) || action == Some(Action::Quit) {
             return Ok(self.request_quit());
         }
 
@@ -3058,8 +3068,33 @@ impl App {
             return Ok(self.handle_help_key(key));
         }
 
-        if is_help_shortcut(&key) {
+        if is_help_recovery(&key) || action == Some(Action::Help) {
             self.open_help();
+            return Ok(KeyOutcome::Render);
+        }
+
+        if self.grid_resizer.is_some() && action == Some(Action::ResizeGrid) {
+            self.grid_resizer = None;
+            self.status = "grid resize canceled".into();
+            return Ok(KeyOutcome::Render);
+        }
+        if self.previous_panes.open && action == Some(Action::PreviousPanes) {
+            self.close_previous_panes();
+            return Ok(KeyOutcome::Render);
+        }
+        if self.pane_settings.open && action == Some(Action::PaneActivity) {
+            self.pane_settings.close();
+            self.status = "pane activity closed".into();
+            return Ok(KeyOutcome::Render);
+        }
+        if self.settings.open && action == Some(Action::Settings) {
+            self.settings.open = false;
+            self.status = "settings closed".into();
+            return Ok(KeyOutcome::Render);
+        }
+        if self.goal_editor.is_some() && action == Some(Action::EditGoal) {
+            self.goal_editor = None;
+            self.status = "grid goal edit canceled".into();
             return Ok(KeyOutcome::Render);
         }
 
@@ -3106,14 +3141,9 @@ impl App {
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
-        if key.modifiers.contains(KeyModifiers::ALT)
-            && let Some(quit) = self.handle_app_key(terminal, key)?
-        {
-            return Ok(if quit {
-                KeyOutcome::Quit
-            } else {
-                KeyOutcome::Render
-            });
+        if let Some(action) = action {
+            self.handle_action(terminal, action)?;
+            return Ok(KeyOutcome::Render);
         }
 
         if self.command_line.focused {
@@ -3166,7 +3196,8 @@ impl App {
 
     fn handle_help_key(&mut self, key: KeyEvent) -> KeyOutcome {
         if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q'))
-            || is_help_shortcut(&key)
+            || is_help_recovery(&key)
+            || self.keybindings.action_for(&key) == Some(Action::Help)
         {
             self.help_open = false;
             self.status = "help closed".into();
@@ -3191,130 +3222,95 @@ impl App {
         }
     }
 
-    fn handle_app_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<Option<bool>> {
-        match key.code {
-            KeyCode::Char(ch) => self.handle_alt_char(terminal, ch, key.modifiers),
-            KeyCode::Left => {
+    fn handle_action(&mut self, terminal: &mut Tui, action: Action) -> Result<()> {
+        match action {
+            Action::Quit | Action::Help => {}
+            Action::FocusLeft => {
                 self.focus_previous();
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            KeyCode::Right => {
+            Action::FocusRight => {
                 self.focus_next();
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            KeyCode::Up => {
+            Action::FocusUp => {
                 self.focus_in_grid(-1);
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            KeyCode::Down => {
+            Action::FocusDown => {
                 self.focus_in_grid(1);
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            _ => Ok(None),
-        }
-    }
-
-    fn handle_alt_char(
-        &mut self,
-        terminal: &mut Tui,
-        ch: char,
-        modifiers: KeyModifiers,
-    ) -> Result<Option<bool>> {
-        let lower = ch.to_ascii_lowercase();
-        match lower {
-            'q' => Ok(Some(true)),
-            's' => {
+            Action::ToggleSelection => {
                 if self.command_line.focused {
                     self.status = "command line focused".into();
                 } else {
                     self.toggle_pane_selection(self.focus);
                 }
-                Ok(Some(false))
             }
-            'a' => {
+            Action::SelectAll => {
                 if self.selected.len() == self.panes.len() {
                     self.selected.clear();
                 } else {
                     self.selected = (0..self.panes.len()).collect();
                 }
                 self.status = format!("selected {} panes", self.selected.len());
-                Ok(Some(false))
             }
-            'z' => {
+            Action::SleepPanes => {
                 self.toggle_sleep_for_targets();
-                Ok(Some(false))
             }
-            't' if modifiers.contains(KeyModifiers::SHIFT) => {
+            Action::RestartPanes => {
                 self.restart_exited_targets();
-                Ok(Some(false))
             }
-            't' => {
+            Action::NextTab => {
                 self.next_tab();
-                Ok(Some(false))
             }
-            'n' => {
+            Action::NewTab => {
                 self.open_new_tab(terminal)?;
-                Ok(Some(false))
             }
-            'l' => {
+            Action::ResizeGrid => {
                 self.open_grid_resizer();
-                Ok(Some(false))
             }
-            'x' => {
+            Action::SwapPanes => {
                 self.swap_selected_tiles();
-                Ok(Some(false))
             }
-            'f' => {
+            Action::ZoomPane => {
                 self.toggle_zoom();
-                Ok(Some(false))
             }
-            'c' => {
+            Action::CommandLine => {
                 self.command_line.toggle_focus();
                 self.status = self.focus_status();
-                Ok(Some(false))
             }
-            'v' if is_voice_shortcut(ch, modifiers) => {
+            Action::VoiceInput => {
                 self.toggle_voice_input();
-                Ok(Some(false))
             }
-            'g' => {
+            Action::EditGoal => {
                 self.open_goal_editor_for(self.focus);
-                Ok(Some(false))
             }
-            'u' => {
+            Action::StopGoal => {
                 self.stop_pane_goal(self.focus);
-                Ok(Some(false))
             }
-            'o' => {
+            Action::Settings => {
                 self.settings.open = true;
                 if self.settings.tab == SettingsTab::Auth {
                     self.start_auth_refresh();
                 }
                 self.status = "settings open".into();
-                Ok(Some(false))
             }
-            'p' if modifiers.contains(KeyModifiers::SHIFT) => {
+            Action::PreviousPanes => {
                 self.open_previous_panes();
-                Ok(Some(false))
             }
-            'p' => {
+            Action::PaneActivity => {
                 self.toggle_pane_settings();
-                Ok(Some(false))
             }
-            'r' if modifiers.contains(KeyModifiers::SHIFT) => {
+            Action::RenameTab => {
                 self.begin_tab_rename();
-                Ok(Some(false))
             }
-            'r' => {
+            Action::RenamePane => {
                 self.begin_rename();
-                Ok(Some(false))
             }
-            _ => Ok(None),
         }
+        Ok(())
     }
 
     fn handle_exited_recovery_key(&mut self, key: KeyEvent) -> Option<KeyOutcome> {
@@ -5674,6 +5670,10 @@ impl App {
         self.help_open
     }
 
+    pub fn shortcut_help_entries(&self) -> Vec<(String, &'static str)> {
+        self.keybindings.help_entries()
+    }
+
     pub fn palette(&self) -> &GridPalette {
         &self.settings.palette
     }
@@ -7541,24 +7541,6 @@ fn pane_number_list(indices: &[usize]) -> String {
         .join(", ")
 }
 
-fn is_voice_shortcut(ch: char, modifiers: KeyModifiers) -> bool {
-    ch.eq_ignore_ascii_case(&'v')
-        && modifiers.contains(KeyModifiers::ALT)
-        && modifiers.contains(KeyModifiers::SHIFT)
-        && !modifiers.contains(KeyModifiers::CONTROL)
-}
-
-fn is_quit_shortcut(key: &KeyEvent) -> bool {
-    key.modifiers.contains(KeyModifiers::ALT)
-        && matches!(key.code, KeyCode::Char('q') | KeyCode::Char('Q'))
-}
-
-fn is_help_shortcut(key: &KeyEvent) -> bool {
-    matches!(key.code, KeyCode::F(1))
-        || (key.modifiers.contains(KeyModifiers::ALT)
-            && matches!(key.code, KeyCode::Char('h') | KeyCode::Char('H')))
-}
-
 fn control_byte(ch: char) -> Option<u8> {
     let lower = ch.to_ascii_lowercase();
     if lower.is_ascii_lowercase() {
@@ -8321,27 +8303,32 @@ mod tests {
     #[test]
     fn voice_shortcut_preserves_plain_alt_v_for_agent_image_paste() {
         let image_paste = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::ALT);
-        assert!(!is_voice_shortcut('v', KeyModifiers::ALT));
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(bindings.action_for(&image_paste), None);
         assert_eq!(terminal_key_bytes(image_paste), Some(b"\x1bv".to_vec()));
 
         let voice_modifiers = KeyModifiers::ALT | KeyModifiers::SHIFT;
-        assert!(is_voice_shortcut('V', voice_modifiers));
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('V'), voice_modifiers)),
+            Some(Action::VoiceInput)
+        );
     }
 
     #[test]
     fn help_shortcuts_are_modeless_and_plain_h_passes_through() {
-        assert!(is_help_shortcut(&KeyEvent::new(
-            KeyCode::Char('h'),
-            KeyModifiers::ALT,
-        )));
-        assert!(is_help_shortcut(&KeyEvent::new(
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('h'), KeyModifiers::ALT,)),
+            Some(Action::Help)
+        );
+        assert!(is_help_recovery(&KeyEvent::new(
             KeyCode::F(1),
-            KeyModifiers::NONE,
+            KeyModifiers::NONE
         )));
-        assert!(!is_help_shortcut(&KeyEvent::new(
-            KeyCode::Char('h'),
-            KeyModifiers::NONE,
-        )));
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE)),
+            None
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, anyhow};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
-use crate::{auth::AuthConfig, profiles::Profile};
+use crate::{auth::AuthConfig, keybindings::KeyBindings, profiles::Profile};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
@@ -22,6 +22,8 @@ pub struct Config {
     pub auth: AuthConfig,
     #[serde(default, skip_serializing_if = "ManagerConfig::is_empty")]
     pub manager: ManagerConfig,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub keys: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub profiles: BTreeMap<String, Profile>,
 }
@@ -289,7 +291,11 @@ impl Config {
 
         let raw = fs::read_to_string(path)
             .with_context(|| format!("failed to read config {}", path.display()))?;
-        toml::from_str(&raw).with_context(|| format!("failed to parse config {}", path.display()))
+        let config: Self = toml::from_str(&raw)
+            .with_context(|| format!("failed to parse config {}", path.display()))?;
+        KeyBindings::from_overrides(&config.keys)
+            .with_context(|| format!("failed to validate config {}", path.display()))?;
+        Ok(config)
     }
 
     pub fn save(&self, path: Option<&Path>) -> Result<PathBuf> {
@@ -556,5 +562,26 @@ mod tests {
         let serialized = toml::to_string(&config).expect("serialize config");
         assert!(serialized.contains("[manager]"));
         assert!(serialized.contains("api_key = \"secret\""));
+    }
+
+    #[test]
+    fn parses_and_round_trips_key_overrides() {
+        let config: Config = toml::from_str(
+            r#"
+            [keys]
+            zoom-pane = "ctrl+shift+k"
+            settings = "f8"
+            "#,
+        )
+        .expect("parse key config");
+
+        KeyBindings::from_overrides(&config.keys).expect("validate key config");
+        assert_eq!(
+            config.keys.get("zoom-pane").map(String::as_str),
+            Some("ctrl+shift+k")
+        );
+        let serialized = toml::to_string(&config).expect("serialize key config");
+        assert!(serialized.contains("[keys]"));
+        assert!(serialized.contains("zoom-pane = \"ctrl+shift+k\""));
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,0 +1,465 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Result, anyhow, bail};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Action {
+    Quit,
+    Help,
+    FocusLeft,
+    FocusRight,
+    FocusUp,
+    FocusDown,
+    ToggleSelection,
+    SelectAll,
+    SleepPanes,
+    RestartPanes,
+    NextTab,
+    NewTab,
+    ResizeGrid,
+    SwapPanes,
+    ZoomPane,
+    CommandLine,
+    VoiceInput,
+    EditGoal,
+    StopGoal,
+    Settings,
+    PreviousPanes,
+    PaneActivity,
+    RenameTab,
+    RenamePane,
+}
+
+const ACTIONS: &[Action] = &[
+    Action::FocusLeft,
+    Action::FocusRight,
+    Action::FocusUp,
+    Action::FocusDown,
+    Action::ToggleSelection,
+    Action::SelectAll,
+    Action::NewTab,
+    Action::NextTab,
+    Action::RenameTab,
+    Action::CommandLine,
+    Action::PaneActivity,
+    Action::PreviousPanes,
+    Action::ZoomPane,
+    Action::ResizeGrid,
+    Action::RenamePane,
+    Action::RestartPanes,
+    Action::SwapPanes,
+    Action::SleepPanes,
+    Action::EditGoal,
+    Action::StopGoal,
+    Action::Settings,
+    Action::VoiceInput,
+    Action::Quit,
+    Action::Help,
+];
+
+impl Action {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Quit => "quit",
+            Self::Help => "help",
+            Self::FocusLeft => "focus-left",
+            Self::FocusRight => "focus-right",
+            Self::FocusUp => "focus-up",
+            Self::FocusDown => "focus-down",
+            Self::ToggleSelection => "toggle-selection",
+            Self::SelectAll => "select-all",
+            Self::SleepPanes => "sleep-panes",
+            Self::RestartPanes => "restart-panes",
+            Self::NextTab => "next-tab",
+            Self::NewTab => "new-tab",
+            Self::ResizeGrid => "resize-grid",
+            Self::SwapPanes => "swap-panes",
+            Self::ZoomPane => "zoom-pane",
+            Self::CommandLine => "command-line",
+            Self::VoiceInput => "voice-input",
+            Self::EditGoal => "edit-goal",
+            Self::StopGoal => "stop-goal",
+            Self::Settings => "settings",
+            Self::PreviousPanes => "previous-panes",
+            Self::PaneActivity => "pane-activity",
+            Self::RenameTab => "rename-tab",
+            Self::RenamePane => "rename-pane",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Quit => "quit GridBash",
+            Self::Help => "open or close help",
+            Self::FocusLeft => "focus pane to the left",
+            Self::FocusRight => "focus pane to the right",
+            Self::FocusUp => "focus pane above",
+            Self::FocusDown => "focus pane below",
+            Self::ToggleSelection => "toggle pane selection",
+            Self::SelectAll => "select or clear all panes",
+            Self::SleepPanes => "sleep or wake panes",
+            Self::RestartPanes => "restart exited panes",
+            Self::NextTab => "switch to next tab",
+            Self::NewTab => "open a new tab",
+            Self::ResizeGrid => "resize the grid",
+            Self::SwapPanes => "swap selected panes",
+            Self::ZoomPane => "zoom or restore focused pane",
+            Self::CommandLine => "expand or close command line",
+            Self::VoiceInput => "dictate without submitting",
+            Self::EditGoal => "create or edit grid goal",
+            Self::StopGoal => "stop grid goal",
+            Self::Settings => "open settings and profiles",
+            Self::PreviousPanes => "show previous panes",
+            Self::PaneActivity => "show focused-pane activity",
+            Self::RenameTab => "rename current tab",
+            Self::RenamePane => "rename focused pane",
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        ACTIONS.iter().copied().find(|action| action.name() == name)
+    }
+
+    fn default_chord(self) -> &'static str {
+        match self {
+            Self::Quit => "alt+q",
+            Self::Help => "alt+h",
+            Self::FocusLeft => "alt+left",
+            Self::FocusRight => "alt+right",
+            Self::FocusUp => "alt+up",
+            Self::FocusDown => "alt+down",
+            Self::ToggleSelection => "alt+s",
+            Self::SelectAll => "alt+a",
+            Self::SleepPanes => "alt+z",
+            Self::RestartPanes => "alt+shift+t",
+            Self::NextTab => "alt+t",
+            Self::NewTab => "alt+n",
+            Self::ResizeGrid => "alt+l",
+            Self::SwapPanes => "alt+x",
+            Self::ZoomPane => "alt+f",
+            Self::CommandLine => "alt+c",
+            Self::VoiceInput => "alt+shift+v",
+            Self::EditGoal => "alt+g",
+            Self::StopGoal => "alt+u",
+            Self::Settings => "alt+o",
+            Self::PreviousPanes => "alt+shift+p",
+            Self::PaneActivity => "alt+p",
+            Self::RenameTab => "alt+shift+r",
+            Self::RenamePane => "alt+r",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ShortcutKey {
+    Char(char),
+    Left,
+    Right,
+    Up,
+    Down,
+    Function(u8),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Shortcut {
+    control: bool,
+    alt: bool,
+    shift: bool,
+    key: ShortcutKey,
+}
+
+impl Shortcut {
+    fn parse(value: &str) -> Result<Self> {
+        let normalized = value.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            bail!("shortcut cannot be empty");
+        }
+
+        let mut parts = normalized.split('+').collect::<Vec<_>>();
+        let key = parts.pop().ok_or_else(|| anyhow!("shortcut needs a key"))?;
+        let mut shortcut = Self {
+            control: false,
+            alt: false,
+            shift: false,
+            key: parse_key(key)?,
+        };
+
+        for modifier in parts {
+            let slot = match modifier {
+                "ctrl" | "control" => &mut shortcut.control,
+                "alt" => &mut shortcut.alt,
+                "shift" => &mut shortcut.shift,
+                "" => bail!("shortcut contains an empty '+' segment"),
+                other => bail!("unknown shortcut modifier '{other}'"),
+            };
+            if *slot {
+                bail!("shortcut repeats modifier '{modifier}'");
+            }
+            *slot = true;
+        }
+
+        if !shortcut.control
+            && !shortcut.alt
+            && !shortcut.shift
+            && !matches!(shortcut.key, ShortcutKey::Function(_))
+        {
+            bail!("unmodified characters and navigation keys belong to the terminal");
+        }
+        if shortcut == fallback_help_shortcut() {
+            bail!("F1 is reserved as the help recovery key");
+        }
+
+        Ok(shortcut)
+    }
+
+    fn matches(self, event: &KeyEvent) -> bool {
+        let modifiers = event.modifiers;
+        if self.control != modifiers.contains(KeyModifiers::CONTROL)
+            || self.alt != modifiers.contains(KeyModifiers::ALT)
+            || self.shift != modifiers.contains(KeyModifiers::SHIFT)
+        {
+            return false;
+        }
+
+        match (self.key, event.code) {
+            (ShortcutKey::Char(expected), KeyCode::Char(actual)) => {
+                expected == actual.to_ascii_lowercase()
+            }
+            (ShortcutKey::Left, KeyCode::Left)
+            | (ShortcutKey::Right, KeyCode::Right)
+            | (ShortcutKey::Up, KeyCode::Up)
+            | (ShortcutKey::Down, KeyCode::Down) => true,
+            (ShortcutKey::Function(expected), KeyCode::F(actual)) => expected == actual,
+            _ => false,
+        }
+    }
+
+    fn label(self) -> String {
+        let mut parts = Vec::new();
+        if self.control {
+            parts.push("Ctrl".to_string());
+        }
+        if self.alt {
+            parts.push("Alt".to_string());
+        }
+        if self.shift {
+            parts.push("Shift".to_string());
+        }
+        parts.push(match self.key {
+            ShortcutKey::Char(ch) => ch.to_ascii_uppercase().to_string(),
+            ShortcutKey::Left => "Left".into(),
+            ShortcutKey::Right => "Right".into(),
+            ShortcutKey::Up => "Up".into(),
+            ShortcutKey::Down => "Down".into(),
+            ShortcutKey::Function(number) => format!("F{number}"),
+        });
+        parts.join("+")
+    }
+}
+
+fn parse_key(value: &str) -> Result<ShortcutKey> {
+    match value {
+        "left" => Ok(ShortcutKey::Left),
+        "right" => Ok(ShortcutKey::Right),
+        "up" => Ok(ShortcutKey::Up),
+        "down" => Ok(ShortcutKey::Down),
+        value if value.len() == 1 => Ok(ShortcutKey::Char(
+            value.chars().next().expect("one-character shortcut"),
+        )),
+        value if value.starts_with('f') => {
+            let number = value[1..]
+                .parse::<u8>()
+                .map_err(|_| anyhow!("unknown shortcut key '{value}'"))?;
+            if (1..=12).contains(&number) {
+                Ok(ShortcutKey::Function(number))
+            } else {
+                bail!("function key must be between F1 and F12");
+            }
+        }
+        other => bail!("unknown shortcut key '{other}'"),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct KeyBindings {
+    bindings: BTreeMap<Action, Shortcut>,
+}
+
+impl KeyBindings {
+    pub fn from_overrides(overrides: &BTreeMap<String, String>) -> Result<Self> {
+        let mut bindings = ACTIONS
+            .iter()
+            .copied()
+            .map(|action| {
+                Shortcut::parse(action.default_chord()).map(|shortcut| (action, shortcut))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+
+        for (name, chord) in overrides {
+            let normalized = name.trim().to_ascii_lowercase();
+            let action = Action::from_name(&normalized).ok_or_else(|| {
+                anyhow!(
+                    "unknown [keys] action '{name}'; supported actions: {}",
+                    ACTIONS
+                        .iter()
+                        .map(|action| action.name())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?;
+            let shortcut = Shortcut::parse(chord)
+                .map_err(|error| anyhow!("invalid [keys].{name} shortcut '{chord}': {error}"))?;
+            if shortcut == fallback_quit_shortcut() && action != Action::Quit {
+                bail!("Alt+Q is reserved as the quit recovery key");
+            }
+            bindings.insert(action, shortcut);
+        }
+
+        let mut seen = BTreeMap::new();
+        for (action, shortcut) in &bindings {
+            if let Some(previous) = seen.insert(*shortcut, *action) {
+                bail!(
+                    "shortcut {} is assigned to both '{}' and '{}'",
+                    shortcut.label(),
+                    previous.name(),
+                    action.name()
+                );
+            }
+        }
+
+        Ok(Self { bindings })
+    }
+
+    pub fn action_for(&self, event: &KeyEvent) -> Option<Action> {
+        ACTIONS.iter().copied().find(|action| {
+            self.bindings
+                .get(action)
+                .is_some_and(|shortcut| shortcut.matches(event))
+        })
+    }
+
+    pub fn help_entries(&self) -> Vec<(String, &'static str)> {
+        ACTIONS
+            .iter()
+            .copied()
+            .map(|action| {
+                let shortcut = self.bindings[&action];
+                let label = match action {
+                    Action::Quit if shortcut != fallback_quit_shortcut() => {
+                        format!("{} / Alt+Q", shortcut.label())
+                    }
+                    Action::Help => format!("{} / F1", shortcut.label()),
+                    _ => shortcut.label(),
+                };
+                (label, action.description())
+            })
+            .collect()
+    }
+}
+
+pub fn is_quit_recovery(event: &KeyEvent) -> bool {
+    fallback_quit_shortcut().matches(event)
+}
+
+pub fn is_help_recovery(event: &KeyEvent) -> bool {
+    fallback_help_shortcut().matches(event)
+}
+
+fn fallback_quit_shortcut() -> Shortcut {
+    Shortcut {
+        control: false,
+        alt: true,
+        shift: false,
+        key: ShortcutKey::Char('q'),
+    }
+}
+
+fn fallback_help_shortcut() -> Shortcut {
+    Shortcut {
+        control: false,
+        alt: false,
+        shift: false,
+        key: ShortcutKey::Function(1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn overrides(values: &[(&str, &str)]) -> BTreeMap<String, String> {
+        values
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn normalizes_and_dispatches_custom_shortcuts() {
+        let bindings = KeyBindings::from_overrides(&overrides(&[("zoom-pane", "Ctrl+Shift+K")]))
+            .expect("custom bindings");
+
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(
+                KeyCode::Char('K'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )),
+            Some(Action::ZoomPane)
+        );
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('f'), KeyModifiers::ALT)),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_and_unknown_bindings() {
+        let duplicate = KeyBindings::from_overrides(&overrides(&[("zoom-pane", "alt+l")]))
+            .expect_err("duplicate binding");
+        assert!(duplicate.to_string().contains("resize-grid"));
+
+        let unknown = KeyBindings::from_overrides(&overrides(&[("warp-pane", "alt+w")]))
+            .expect_err("unknown action");
+        assert!(unknown.to_string().contains("unknown [keys] action"));
+    }
+
+    #[test]
+    fn preserves_terminal_input_and_recovery_keys() {
+        let plain = KeyBindings::from_overrides(&overrides(&[("zoom-pane", "k")]))
+            .expect_err("plain terminal key");
+        assert!(plain.to_string().contains("belong to the terminal"));
+
+        let f1 = KeyBindings::from_overrides(&overrides(&[("zoom-pane", "f1")]))
+            .expect_err("help recovery key");
+        assert!(f1.to_string().contains("F1 is reserved"));
+
+        let alt_q =
+            KeyBindings::from_overrides(&overrides(&[("quit", "ctrl+q"), ("zoom-pane", "alt+q")]))
+                .expect_err("quit recovery key");
+        assert!(alt_q.to_string().contains("Alt+Q is reserved"));
+    }
+
+    #[test]
+    fn help_entries_show_effective_and_recovery_bindings() {
+        let bindings = KeyBindings::from_overrides(&overrides(&[
+            ("help", "ctrl+shift+h"),
+            ("quit", "ctrl+q"),
+        ]))
+        .expect("custom recovery actions");
+        let entries = bindings.help_entries();
+
+        assert!(entries.iter().any(|entry| entry.0 == "Ctrl+Shift+H / F1"));
+        assert!(entries.iter().any(|entry| entry.0 == "Ctrl+Q / Alt+Q"));
+    }
+
+    #[test]
+    fn action_names_are_unique() {
+        let names = ACTIONS
+            .iter()
+            .map(|action| action.name())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(names.len(), ACTIONS.len());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod composer;
 mod config;
 mod control;
 mod image_preview;
+mod keybindings;
 mod layout;
 mod manager;
 mod onboarding;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -234,9 +234,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Span::raw(format!("{} selected", app.selected().len())),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
-        Span::raw(
-            " | Alt+h help | Alt+f zoom | Alt+l resize | Alt+n new | Alt+t tab | Alt+Shift+t restart | Alt+c CLI | Alt+Shift+V voice | Alt+p summary | Alt+Shift+p panes | Alt+x swap | Alt+z sleep | Alt+q quit",
-        ),
+        Span::raw(" | F1 help | Alt+q quit fallback"),
     ]);
     frame.render_widget(
         Paragraph::new(status).style(Style::default().bg(APP_BG)),
@@ -279,7 +277,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         picker.draw(frame, GridPickerMode::Resize, None);
     }
     if help_open {
-        render_help(frame, area, palette);
+        render_help(frame, area, app, palette);
     }
 
     DrawState {
@@ -2483,31 +2481,8 @@ fn settings_panel_style() -> Style {
     Style::default().fg(SETTINGS_TEXT).bg(SETTINGS_BG)
 }
 
-fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
-    const CONTROLS: &[(&str, &str)] = &[
-        ("Alt+arrows", "move pane focus"),
-        ("Alt+s", "toggle pane selection"),
-        ("Alt+a", "select or clear all panes"),
-        ("type/paste", "send to focused or selected panes"),
-        ("right-click", "toggle one selected pane"),
-        ("Alt+n", "open a new tab"),
-        ("Alt+t", "switch to next tab"),
-        ("Alt+Shift+r", "rename current tab"),
-        ("Alt+c", "expand or close the command line"),
-        ("Alt+p", "show focused-pane activity summary"),
-        ("Alt+Shift+p", "show previous panes"),
-        ("Alt+f", "zoom or restore focused pane"),
-        ("Alt+l", "resize the grid"),
-        ("Alt+r", "rename focused pane"),
-        ("Alt+Shift+t", "restart exited panes"),
-        ("Alt+z", "sleep or wake panes"),
-        ("Alt+g / Alt+u", "start or stop grid goal"),
-        ("Alt+o", "open global settings/profiles"),
-        ("Alt+Shift+V", "dictate without submitting"),
-        ("Alt+q", "quit GridBash"),
-        ("Alt+h / F1", "close this help"),
-    ];
-
+fn render_help(frame: &mut Frame<'_>, area: Rect, app: &App, palette: &GridPalette) {
+    let controls = app.shortcut_help_entries();
     let modal = help_modal_rect(area);
     frame.render_widget(Clear, modal);
     let inner_width = modal.width.saturating_sub(4) as usize;
@@ -2523,22 +2498,22 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
     ];
 
     if inner_width >= 62 {
-        let rows = CONTROLS.len().div_ceil(2);
+        let rows = controls.len().div_ceil(2);
         let column_width = inner_width.saturating_sub(3) / 2;
-        for (row, control) in CONTROLS.iter().take(rows).enumerate() {
-            let left = help_control(*control, column_width);
-            let right = CONTROLS
+        for (row, control) in controls.iter().take(rows).enumerate() {
+            let left = help_control(&control.0, control.1, column_width);
+            let right = controls
                 .get(row + rows)
-                .map(|control| help_control(*control, column_width))
+                .map(|control| help_control(&control.0, control.1, column_width))
                 .unwrap_or_default();
             lines.push(Line::from(format!("{left:<column_width$}   {right}")));
         }
     } else {
         let available = modal.height.saturating_sub(7) as usize;
-        for control in CONTROLS.iter().take(available) {
-            lines.push(Line::from(help_control(*control, inner_width)));
+        for control in controls.iter().take(available) {
+            lines.push(Line::from(help_control(&control.0, control.1, inner_width)));
         }
-        if available < CONTROLS.len() {
+        if available < controls.len() {
             lines.push(Line::from(
                 "More controls: enlarge the terminal or see README.md",
             ));
@@ -2558,7 +2533,7 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
     );
 }
 
-fn help_control((key, action): (&str, &str), width: usize) -> String {
+fn help_control(key: &str, action: &str, width: usize) -> String {
     truncate_text(&format!("{key:<13} {action}"), width)
 }
 
@@ -2567,7 +2542,7 @@ fn help_modal_rect(area: Rect) -> Rect {
     let height = area
         .height
         .saturating_sub(2)
-        .min(18)
+        .min(22)
         .max(area.height.min(1));
     Rect {
         x: area.x + area.width.saturating_sub(width) / 2,


### PR DESCRIPTION
## Summary

- add a validated `[keys]` action-to-chord map
- route modeless app controls through typed configurable actions while preserving unmatched terminal input
- render effective shortcuts in help and retain F1 / Alt+Q recovery controls
- document the configuration and release note

## Validation

- `git diff --check`
- compiler-bearing checks deferred to the automatic integration lease and combined batch validation

Closes #223