### PR TITLE
perf: optimize high-load runtime paths

### DIFF
--- a/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
+++ b/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
@@ -35,7 +35,7 @@ Release target: unreleased
 
 - `cargo fmt --all -- --check`
 - `cargo check --tests`
-- `cargo test --release` (171 passed, 3 intentionally ignored)
+- `cargo test --release` (174 passed, 3 intentionally ignored)
 - `cargo clippy --all-targets -- -D warnings`
 - `npm run test:launcher` (11 passed)
 - `cargo build --release`

--- a/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
+++ b/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
@@ -35,9 +35,10 @@ Release target: unreleased
 
 - `cargo fmt --all -- --check`
 - `cargo check --tests`
-- `cargo test --release` (168 passed, 3 intentionally ignored)
+- `cargo test --release` (171 passed, 3 intentionally ignored)
 - `cargo clippy --all-targets -- -D warnings`
 - `npm run test:launcher` (11 passed)
+- `cargo build --release`
 - `cargo test --release benchmark_ -- --ignored --nocapture --test-threads=1`
 
 ## Release Notes

--- a/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
+++ b/docs/devlogs/2026-07-15-optimize-high-load-runtime-throughput-and-latency.md
@@ -1,0 +1,46 @@
+# Optimize high-load runtime throughput and latency
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Removed more avoidable CPU and allocation work from GridBash's busy-grid
+  event, output-processing, and redraw paths.
+
+## What Changed
+
+- Cached fully rendered pane cell buffers instead of cloning and rebuilding
+  styled terminal lines for every unchanged pane on every frame.
+- Skipped idle PTY routing maps and per-pane workload scans until an event or
+  visible state change actually requires them.
+- Kept PTY output batches in arrival order while replacing tree-based batching
+  with constant-time hash lookups.
+- Added an ASCII-run fast path for terminal history text, tracked its character
+  count during filtering, and avoided duplicate control-sequence allocations.
+- Replaced sleeping-pane text allocation with direct frame-buffer clearing.
+- Added correctness coverage and opt-in release-mode microbenchmarks for the
+  optimized text and screen-cache paths.
+
+## Why It Matters
+
+- Large grids spend most of their UI time revisiting panes that did not change.
+  Reusing final cell buffers and avoiding idle whole-grid scans leaves more CPU
+  for the agents and reduces input latency while output is flowing.
+- In the release-mode probes, unchanged 120x40 pane rendering improved from
+  273.6 to 75.3 microseconds per frame (3.6x faster), and ANSI-to-history text
+  filtering improved from 26.1 to 14.4 microseconds (45% faster).
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo check --tests`
+- `cargo test --release` (168 passed, 3 intentionally ignored)
+- `cargo clippy --all-targets -- -D warnings`
+- `npm run test:launcher` (11 passed)
+- `cargo test --release benchmark_ -- --ignored --nocapture --test-threads=1`
+
+## Release Notes
+
+- GridBash now uses substantially less work to redraw unchanged terminal panes
+  and process sustained agent output, especially in large, busy grids.

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use ratatui::{Terminal, backend::CrosstermBackend, layout::Rect, style::Color, text::Line};
+use ratatui::{Frame, Terminal, backend::CrosstermBackend, layout::Rect, style::Color};
 use tokio::sync::mpsc;
 use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 
@@ -2294,7 +2294,9 @@ impl App {
             immediate_render |= self.decay_activity();
             immediate_render |= self.update_follow_up_prompt();
             immediate_render |= self.schedule_goal_reviews();
-            immediate_render |= self.refresh_workload_classes();
+            if immediate_render {
+                immediate_render |= self.refresh_workload_classes();
+            }
 
             if immediate_render || (output_render && last_render.elapsed() >= frame_interval) {
                 terminal.draw(|frame| {
@@ -2350,7 +2352,10 @@ impl App {
                 self.terminal_focused = true;
                 *needs_render = true;
             }
-            Event::FocusLost => self.terminal_focused = false,
+            Event::FocusLost => {
+                self.terminal_focused = false;
+                *needs_render = true;
+            }
             Event::Paste(text) if self.tab_rename.open => {
                 self.tab_rename.insert_text(&text);
                 *needs_render = true;
@@ -2477,15 +2482,26 @@ impl App {
     }
 
     fn drain_pty_events(&mut self) -> bool {
+        let should_poll_exits = self.last_exit_poll.elapsed() >= EXIT_POLL_INTERVAL;
+        let Ok(first_event) = self.event_rx.try_recv() else {
+            return should_poll_exits && self.poll_exited_panes();
+        };
+
         let mut changed = false;
         let routes = self.pane_routes();
-        let mut pending_output = BTreeMap::<(PaneId, u64), Vec<u8>>::new();
+        let mut pending_output = HashMap::<(PaneId, u64), Vec<u8>>::new();
+        let mut pending_output_order = Vec::new();
         let mut exited = Vec::new();
         let mut budget = PtyDrainBudget::new();
+        let mut next_event = Some(first_event);
 
         while budget.allows_more() {
-            let Ok(event) = self.event_rx.try_recv() else {
-                break;
+            let event = match next_event.take() {
+                Some(event) => event,
+                None => match self.event_rx.try_recv() {
+                    Ok(event) => event,
+                    Err(_) => break,
+                },
             };
             match event {
                 PtyEvent::Output {
@@ -2494,10 +2510,16 @@ impl App {
                     bytes,
                 } => {
                     budget.record(bytes.len());
-                    pending_output
-                        .entry((pane, generation))
-                        .or_default()
-                        .extend(bytes);
+                    let key = (pane, generation);
+                    match pending_output.entry(key) {
+                        std::collections::hash_map::Entry::Occupied(mut output) => {
+                            output.get_mut().extend(bytes);
+                        }
+                        std::collections::hash_map::Entry::Vacant(output) => {
+                            pending_output_order.push(key);
+                            output.insert(bytes);
+                        }
+                    }
                 }
                 PtyEvent::Exited { pane, generation } => {
                     budget.record(0);
@@ -2533,7 +2555,10 @@ impl App {
             }
         }
 
-        for ((pane, generation), bytes) in pending_output {
+        for (pane, generation) in pending_output_order {
+            let bytes = pending_output
+                .remove(&(pane, generation))
+                .expect("pending output order and batches stay in sync");
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
                     let target = &mut self.panes[index];
@@ -2585,26 +2610,32 @@ impl App {
             }
         }
 
-        if self.last_exit_poll.elapsed() >= EXIT_POLL_INTERVAL {
-            for (index, pane) in self.panes.iter_mut().enumerate() {
-                if pane.poll_exit() {
-                    if self
-                        .follow_up
-                        .is_some_and(|prompt| prompt.pane_index == index)
-                    {
-                        self.follow_up = None;
-                    }
-                    changed = true;
-                }
-            }
-            for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
-                for pane in &mut tab.panes {
-                    changed |= pane.poll_exit();
-                }
-            }
-            self.last_exit_poll = Instant::now();
+        if should_poll_exits {
+            changed |= self.poll_exited_panes();
         }
 
+        changed
+    }
+
+    fn poll_exited_panes(&mut self) -> bool {
+        let mut changed = false;
+        for (index, pane) in self.panes.iter_mut().enumerate() {
+            if pane.poll_exit() {
+                if self
+                    .follow_up
+                    .is_some_and(|prompt| prompt.pane_index == index)
+                {
+                    self.follow_up = None;
+                }
+                changed = true;
+            }
+        }
+        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
+            for pane in &mut tab.panes {
+                changed |= pane.poll_exit();
+            }
+        }
+        self.last_exit_poll = Instant::now();
         changed
     }
 
@@ -5508,25 +5539,25 @@ impl App {
         }
     }
 
-    pub fn pane_screen_lines(
+    pub fn render_pane_screen(
         &self,
+        frame: &mut Frame<'_>,
         index: usize,
-        width: u16,
-        height: u16,
+        area: Rect,
         selection: Option<PaneSelection>,
-    ) -> Vec<Line<'static>> {
+    ) {
         let Some(pane) = self.panes.get(index) else {
-            return Vec::new();
+            return;
         };
         let mut caches = self.pane_render_cache.borrow_mut();
-        ui::cached_screen_lines(
+        ui::render_cached_screen(
+            frame,
+            area,
             caches.entry(pane.id()).or_default(),
             pane.screen_revision(),
             pane.screen(),
-            width,
-            height,
             selection,
-        )
+        );
     }
 
     pub fn focused_pane(&self) -> Option<usize> {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::BTreeMap,
     env,
     ffi::OsString,
@@ -394,8 +395,8 @@ impl PtyPane {
     pub fn process_output(&mut self, bytes: &[u8]) -> String {
         self.update_cwd_from_osc7(bytes);
         self.parser.process(bytes);
-        let plain = plain_terminal_text(bytes);
-        self.append_plain_output(&plain);
+        let (plain, plain_chars) = plain_terminal_text_with_char_count(bytes);
+        self.append_plain_output(&plain, plain_chars);
         self.active = true;
         self.screen_revision = self.screen_revision.wrapping_add(1);
         self.output_activity.record_output(Instant::now());
@@ -521,15 +522,20 @@ impl PtyPane {
         if self.response_scan_tail.is_empty() && !bytes.contains(&0x1b) {
             return;
         }
-        let mut scan = Vec::with_capacity(self.response_scan_tail.len() + bytes.len());
-        scan.extend_from_slice(&self.response_scan_tail);
-        scan.extend_from_slice(bytes);
+        let scan = if self.response_scan_tail.is_empty() {
+            Cow::Borrowed(bytes)
+        } else {
+            let mut scan = Vec::with_capacity(self.response_scan_tail.len() + bytes.len());
+            scan.extend_from_slice(&self.response_scan_tail);
+            scan.extend_from_slice(bytes);
+            Cow::Owned(scan)
+        };
 
-        if contains_sequence(&scan, DEVICE_STATUS_QUERY) {
+        if contains_sequence(scan.as_ref(), DEVICE_STATUS_QUERY) {
             let _ = self.write(b"\x1b[0n");
         }
 
-        let cursor_position_requests = count_sequence(&scan, CURSOR_POSITION_QUERY);
+        let cursor_position_requests = count_sequence(scan.as_ref(), CURSOR_POSITION_QUERY);
         if cursor_position_requests > 0 {
             let (row, column) = self.parser.screen().cursor_position();
             let response = format!(
@@ -542,30 +548,37 @@ impl PtyPane {
             }
         }
 
-        if contains_sequence(&scan, PRIMARY_DEVICE_ATTRIBUTES_QUERY)
-            || contains_sequence(&scan, PRIMARY_DEVICE_ATTRIBUTES_ZERO_QUERY)
+        if contains_sequence(scan.as_ref(), PRIMARY_DEVICE_ATTRIBUTES_QUERY)
+            || contains_sequence(scan.as_ref(), PRIMARY_DEVICE_ATTRIBUTES_ZERO_QUERY)
         {
             let _ = self.write(b"\x1b[?1;2c");
         }
 
-        self.response_scan_tail = terminal_query_scan_tail(&scan);
+        self.response_scan_tail = terminal_query_scan_tail(scan.as_ref());
     }
 
     fn update_cwd_from_osc7(&mut self, bytes: &[u8]) {
         if self.osc_scan_tail.is_empty() && !bytes.contains(&0x1b) {
             return;
         }
-        let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
-        scan.extend_from_slice(&self.osc_scan_tail);
-        scan.extend_from_slice(bytes);
+        let scan = if self.osc_scan_tail.is_empty() {
+            Cow::Borrowed(bytes)
+        } else {
+            let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
+            scan.extend_from_slice(&self.osc_scan_tail);
+            scan.extend_from_slice(bytes);
+            Cow::Owned(scan)
+        };
 
-        for payload in osc_payloads(&scan) {
-            if let Some(path) = cwd_from_osc7_payload(payload) {
-                self.cwd = path;
+        if find_sequence(scan.as_ref(), b"\x1b]").is_some() {
+            for payload in osc_payloads(scan.as_ref()) {
+                if let Some(path) = cwd_from_osc7_payload(payload) {
+                    self.cwd = path;
+                }
             }
         }
 
-        self.osc_scan_tail = incomplete_osc_tail(&scan);
+        self.osc_scan_tail = incomplete_osc_tail(scan.as_ref());
     }
 
     pub fn terminate(&mut self) {
@@ -619,13 +632,13 @@ impl PtyPane {
         }
     }
 
-    fn append_plain_output(&mut self, plain: &str) {
+    fn append_plain_output(&mut self, plain: &str, plain_chars: usize) {
         if plain.is_empty() {
             return;
         }
 
         self.output_tail.push_str(plain);
-        self.output_tail_chars += plain.chars().count();
+        self.output_tail_chars += plain_chars;
         if self.output_tail_chars > OUTPUT_TAIL_TRIM_AT_CHARS {
             trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
             self.output_tail_chars = self.output_tail.chars().count();
@@ -1044,38 +1057,67 @@ fn history_replay_text(output_tail: &str, input_history: &[String]) -> String {
     replay
 }
 
-pub(crate) fn plain_terminal_text(bytes: &[u8]) -> String {
+#[cfg(test)]
+fn plain_terminal_text(bytes: &[u8]) -> String {
+    plain_terminal_text_with_char_count(bytes).0
+}
+
+fn plain_terminal_text_with_char_count(bytes: &[u8]) -> (String, usize) {
     let raw = String::from_utf8_lossy(bytes);
-    let mut plain = String::new();
-    let mut chars = raw.chars().peekable();
+    let bytes = raw.as_bytes();
+    let mut plain = String::with_capacity(bytes.len());
+    let mut plain_chars = 0;
+    let mut index = 0;
 
-    while let Some(ch) = chars.next() {
-        if ch == '\x1b' {
-            skip_escape_chars(&mut chars);
-            continue;
-        }
-
-        match ch {
-            '\r' => {
+    while index < bytes.len() {
+        match bytes[index] {
+            0x1b => index = skip_escape_sequence(bytes, index),
+            b'\r' | b'\n' => {
                 if !plain.ends_with('\n') {
                     plain.push('\n');
+                    plain_chars += 1;
                 }
+                index += 1;
             }
-            '\n' => {
-                if !plain.ends_with('\n') {
-                    plain.push('\n');
+            b'\t' => {
+                plain.push('\t');
+                plain_chars += 1;
+                index += 1;
+            }
+            0x08 => {
+                if plain.pop().is_some() {
+                    plain_chars -= 1;
                 }
+                index += 1;
             }
-            '\t' => plain.push(ch),
-            '\x08' => {
-                plain.pop();
+            byte if byte.is_ascii_control() => index += 1,
+            byte if byte.is_ascii() => {
+                let start = index;
+                index += 1;
+                while index < bytes.len()
+                    && bytes[index].is_ascii()
+                    && !bytes[index].is_ascii_control()
+                {
+                    index += 1;
+                }
+                plain.push_str(&raw[start..index]);
+                plain_chars += index - start;
             }
-            ch if ch.is_control() => {}
-            ch => plain.push(ch),
+            _ => {
+                let ch = raw[index..]
+                    .chars()
+                    .next()
+                    .expect("index remains on a UTF-8 character boundary");
+                if !ch.is_control() {
+                    plain.push(ch);
+                    plain_chars += 1;
+                }
+                index += ch.len_utf8();
+            }
         }
     }
 
-    plain
+    (plain, plain_chars)
 }
 
 fn skip_escape_sequence(bytes: &[u8], start: usize) -> usize {
@@ -1119,35 +1161,6 @@ fn skip_escape_sequence(bytes: &[u8], start: usize) -> usize {
     }
 
     index
-}
-
-fn skip_escape_chars(chars: &mut std::iter::Peekable<impl Iterator<Item = char>>) {
-    let Some(kind) = chars.next() else {
-        return;
-    };
-    match kind {
-        '[' => {
-            for ch in chars.by_ref() {
-                if ('\u{40}'..='\u{7e}').contains(&ch) {
-                    break;
-                }
-            }
-        }
-        'O' => {
-            let _ = chars.next();
-        }
-        ']' => {
-            while let Some(ch) = chars.next() {
-                if ch == '\x07' {
-                    break;
-                }
-                if ch == '\x1b' && chars.next_if_eq(&'\\').is_some() {
-                    break;
-                }
-            }
-        }
-        _ => {}
-    }
 }
 
 fn incomplete_osc_tail(buffer: &[u8]) -> Vec<u8> {
@@ -1216,6 +1229,31 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    #[ignore = "manual performance benchmark"]
+    fn benchmark_plain_terminal_text() {
+        use std::hint::black_box;
+
+        const ITERATIONS: usize = 10_000;
+        let payload = (0..128)
+            .map(|index| {
+                format!(
+                    "\x1b[38;5;{}mGridBash output {index:03}: compile passed in 1.23s — 東京\x1b[0m\r\n",
+                    32 + index % 160
+                )
+            })
+            .collect::<String>();
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            black_box(plain_terminal_text(black_box(payload.as_bytes())));
+        }
+        let elapsed = start.elapsed();
+        eprintln!(
+            "plain terminal text: {ITERATIONS} iterations in {elapsed:?} ({:?}/iteration)",
+            elapsed / ITERATIONS as u32
+        );
+    }
 
     struct SharedWriter(Arc<Mutex<Vec<u8>>>);
 
@@ -1631,6 +1669,20 @@ mod tests {
         let plain = plain_terminal_text(b"\x1b[31mred\x1b[0m\r\nok\x1b]0;title\x07");
 
         assert_eq!(plain, "red\nok");
+    }
+
+    #[test]
+    fn plain_output_character_count_matches_filtered_unicode() {
+        for input in [
+            "plain ASCII output",
+            "Tokyo 東京 — ready",
+            "erase 東京\u{8}\u{8}京",
+            "\u{1b}[32mgreen\u{1b}[0m\r\nnext",
+            "visible\u{85}control",
+        ] {
+            let (plain, count) = plain_terminal_text_with_char_count(input.as_bytes());
+            assert_eq!(count, plain.chars().count(), "input: {input:?}");
+        }
     }
 
     #[cfg(windows)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,10 @@
 use ratatui::{
     Frame,
+    buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Widget},
 };
 use vt100::Cell;
 
@@ -46,7 +47,7 @@ pub struct PaneRenderCache {
     width: u16,
     height: u16,
     selection: Option<PaneSelection>,
-    lines: Vec<Line<'static>>,
+    buffer: Buffer,
 }
 
 const QUIET_MARKER: &str = " *";
@@ -164,8 +165,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             render_sleeping_screen(frame, inner);
         } else {
             let selection = app.selection_for_pane(index);
-            let lines = app.pane_screen_lines(index, inner.width, inner.height, selection);
-            render_screen_lines(frame, inner, lines);
+            app.render_pane_screen(frame, index, inner, selection);
         }
 
         if focused && !sleeping && !modal_open && pane.screen().scrollback() == 0 {
@@ -2738,53 +2738,77 @@ fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
     }
 
     let style = Style::default().fg(Color::Black).bg(Color::Black);
-    let blank = " ".repeat(area.width as usize);
-    let lines = (0..area.height)
-        .map(|_| Line::from(Span::styled(blank.clone(), style)))
-        .collect::<Vec<_>>();
-
-    frame.render_widget(Paragraph::new(lines).style(style), area);
+    let buffer = frame.buffer_mut();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            let cell = &mut buffer[(x, y)];
+            cell.reset();
+            cell.set_style(style);
+        }
+    }
 }
 
-fn render_screen_lines(frame: &mut Frame<'_>, area: Rect, lines: Vec<Line<'static>>) {
+pub fn render_cached_screen(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    cache: &mut PaneRenderCache,
+    revision: u64,
+    screen: &vt100::Screen,
+    selection: Option<PaneSelection>,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
 
-    frame.render_widget(
-        Paragraph::new(lines).style(Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)),
-        area,
-    );
+    refresh_screen_cache(cache, revision, screen, area.width, area.height, selection);
+    blit_buffer(&cache.buffer, frame.buffer_mut(), area);
 }
 
-pub fn cached_screen_lines(
+fn refresh_screen_cache(
     cache: &mut PaneRenderCache,
     revision: u64,
     screen: &vt100::Screen,
     width: u16,
     height: u16,
     selection: Option<PaneSelection>,
-) -> Vec<Line<'static>> {
-    if width == 0 || height == 0 {
-        return Vec::new();
-    }
+) {
     if cache.revision == revision
         && cache.width == width
         && cache.height == height
         && cache.selection == selection
     {
-        return cache.lines.clone();
+        return;
     }
 
     let lines = (0..height)
         .map(|row| render_screen_row(screen, row, width, selection))
         .collect::<Vec<_>>();
+    let area = Rect::new(0, 0, width, height);
+    let mut buffer = Buffer::empty(area);
+    Widget::render(
+        Paragraph::new(lines).style(Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)),
+        area,
+        &mut buffer,
+    );
     cache.revision = revision;
     cache.width = width;
     cache.height = height;
     cache.selection = selection;
-    cache.lines.clone_from(&lines);
-    lines
+    cache.buffer = buffer;
+}
+
+fn blit_buffer(source: &Buffer, target: &mut Buffer, area: Rect) {
+    debug_assert_eq!(source.area.width, area.width);
+    debug_assert_eq!(source.area.height, area.height);
+    debug_assert_eq!(area.intersection(target.area), area);
+
+    let width = area.width as usize;
+    for row in 0..area.height {
+        let source_start = row as usize * width;
+        let target_start = target.index_of(area.x, area.y + row);
+        target.content[target_start..target_start + width]
+            .clone_from_slice(&source.content[source_start..source_start + width]);
+    }
 }
 
 fn render_screen_row<'a>(
@@ -2964,6 +2988,48 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "manual performance benchmark"]
+    fn benchmark_cached_screen_render() {
+        use std::{hint::black_box, time::Instant};
+
+        use ratatui::buffer::Buffer;
+
+        const ITERATIONS: usize = 5_000;
+        let mut parser = vt100::Parser::new(40, 120, 10_000);
+        let output = (0..40)
+            .map(|row| {
+                format!(
+                    "\x1b[38;5;{}mrow {row:02}: GridBash performance benchmark output with styled terminal cells\x1b[0m\r\n",
+                    32 + row
+                )
+            })
+            .collect::<String>();
+        parser.process(output.as_bytes());
+
+        let area = Rect::new(0, 0, 120, 40);
+        let mut buffer = Buffer::empty(area);
+        let mut cache = PaneRenderCache::default();
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            refresh_screen_cache(
+                &mut cache,
+                1,
+                parser.screen(),
+                area.width,
+                area.height,
+                None,
+            );
+            blit_buffer(black_box(&cache.buffer), &mut buffer, area);
+        }
+        let elapsed = start.elapsed();
+        eprintln!(
+            "cached screen render: {ITERATIONS} iterations in {elapsed:?} ({:?}/iteration)",
+            elapsed / ITERATIONS as u32
+        );
+        black_box(buffer);
+    }
 
     #[test]
     fn idle_pane_has_no_state_badges() {
@@ -3293,13 +3359,14 @@ mod tests {
         parser.process(b"hello");
         let mut cache = PaneRenderCache::default();
 
-        let first = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 10, 2, None);
+        let first = cache.buffer.clone();
         parser.process(b" world");
-        let cached = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
-        assert_eq!(cached, first);
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 10, 2, None);
+        assert_eq!(cache.buffer, first);
 
-        let refreshed = cached_screen_lines(&mut cache, 2, parser.screen(), 10, 2, None);
-        assert_ne!(refreshed, first);
+        refresh_screen_cache(&mut cache, 2, parser.screen(), 10, 2, None);
+        assert_ne!(cache.buffer, first);
     }
 
     #[test]
@@ -3307,18 +3374,35 @@ mod tests {
         let mut parser = vt100::Parser::new(2, 10, 100);
         parser.process(b"hello");
         let mut cache = PaneRenderCache::default();
-        let plain = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, None);
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 10, 2, None);
+        let plain = cache.buffer.clone();
         let selection = Some(PaneSelection {
             start_row: 0,
             start_column: 0,
             end_row: 0,
             end_column: 4,
         });
-        let selected = cached_screen_lines(&mut cache, 1, parser.screen(), 10, 2, selection);
-        assert_ne!(selected, plain);
-        assert_eq!(
-            cached_screen_lines(&mut cache, 1, parser.screen(), 5, 2, selection).len(),
-            2
-        );
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 10, 2, selection);
+        assert_ne!(cache.buffer, plain);
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 5, 2, selection);
+        assert_eq!(cache.buffer.area, Rect::new(0, 0, 5, 2));
+    }
+
+    #[test]
+    fn cached_screen_buffer_blits_at_the_pane_offset() {
+        let mut source = Buffer::empty(Rect::new(0, 0, 2, 2));
+        source[(0, 0)].set_symbol("A");
+        source[(1, 0)].set_symbol("B");
+        source[(0, 1)].set_symbol("C");
+        source[(1, 1)].set_symbol("D");
+        let mut target = Buffer::empty(Rect::new(0, 0, 6, 4));
+
+        blit_buffer(&source, &mut target, Rect::new(3, 1, 2, 2));
+
+        assert_eq!(target[(3, 1)].symbol(), "A");
+        assert_eq!(target[(4, 1)].symbol(), "B");
+        assert_eq!(target[(3, 2)].symbol(), "C");
+        assert_eq!(target[(4, 2)].symbol(), "D");
+        assert_eq!(target[(2, 1)].symbol(), " ");
     }
 }


### PR DESCRIPTION
## Summary
- cache final pane cell buffers so unchanged terminal panes avoid styled-line cloning and rebuilding
- skip idle whole-grid workload/routing scans and use ordered hash batching for PTY output
- speed ANSI history filtering and avoid duplicate control-sequence allocations
- add correctness coverage, opt-in microbenchmarks, and a performance devlog

## Measured impact
- unchanged 120x40 pane redraw: 273.6µs -> 75.3µs per frame (3.6x faster)
- ANSI-to-history filtering: 26.1µs -> 14.4µs (45% faster)

## Validation
- cargo fmt --all -- --check
- cargo check --tests
- release test executables: 174 passed, 3 intentionally ignored
- cargo clippy --all-targets -- -D warnings
- npm run test:launcher (11 passed)
- cargo build --release
- cargo test --release benchmark_ -- --ignored --nocapture --test-threads=1

Tracks #218