### PR TITLE
feat: keep terminals running after exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The npm package installs only the native binary for your current platform.
   Amp, Cursor, Copilot, shells, or custom commands.
 - **Built-in workflow tools.** Resize grids, restore sessions, dictate prompts,
   inspect pane activity, and let a manager route targeted follow-ups.
+- **Optional background terminals.** Close the UI without stopping live panes,
+  then reconnect to the same processes from a saved session.
 
 ## Common commands
 
@@ -86,6 +88,11 @@ agents and shells.
 
 See the [full controls reference](docs/REFERENCE.md#controls) for resizing,
 renaming, sleeping, restarting, scrolling, settings, and recovery actions.
+
+To keep live terminals running after GridBash closes, open Settings with
+`Alt+o` and enable **Keep terminals running**. GridBash returns control to the
+launching shell when you quit; reconnect later with `gridbash resume --latest`
+or select the session with `gridbash resume`.
 
 ## Profiles and configuration
 
@@ -128,9 +135,9 @@ localhost-only, token-authenticated, and off by default.
   SSH or tmux when the remote session advertises a color-capable `TERM`.
 - Use `--no-mouse` when a terminal or multiplexer does not forward mouse input.
   `TERM=dumb` and Linux kernel consoles are not supported.
-- GridBash v1 is single-process: quitting it closes its child agents. Session
-  resume restores layout, pane metadata, and recent context by relaunching
-  terminals; it does not reattach live processes or replay commands.
+- Background pane hosts are local and single-client. Closing GridBash can leave
+  them running, but rebooting the machine or stopping a host loses the live PTY;
+  saved history and launch metadata remain available for a fresh resume.
 
 ## Development
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,8 @@ pane_workload = "adaptive"
 compact_titles = false
 activity_badges = true
 confirm_quit = false
+# Leave live pane processes in local background hosts when the UI closes.
+keep_terminals_running = false
 scrollback_rows = 10000
 refresh_ms = 16
 

--- a/docs/DAEMON_ARCHITECTURE.md
+++ b/docs/DAEMON_ARCHITECTURE.md
@@ -2,10 +2,14 @@
 
 ## Status and goal
 
-This is a design proposal, not the v1 runtime contract. GridBash v1 intentionally
-owns PTYs inside the foreground TUI process. The next major architecture should
-let a user detach the UI while pane processes continue, then attach one or more
-clients without changing ordinary single-machine workflows.
+GridBash now has a first local detach/reattach layer: each pane PTY is owned by
+an authenticated background host, and the foreground TUI can reconnect through
+saved session metadata. That layer is intentionally single-client and keeps
+layout/session coordination in the TUI.
+
+This document remains the proposal for consolidating those hosts into a durable
+per-user `gridbashd` that owns complete sessions and supports multiple clients
+without changing ordinary single-machine workflows.
 
 The first daemon release should preserve local PTYs and local trust boundaries.
 Remote access, web clients, plugins, and multi-host orchestration should build on

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -72,10 +72,15 @@ gridbash resume <session-id>
 
 A snapshot restores grid dimensions, pane profiles, working directories,
 worktree names, auth assignments, and a pane-local view of recent submitted
-commands and output. Resume starts new child terminals. It does not reattach old
-processes or replay commands into a shell.
+commands and output. By default, resume starts new child terminals and does not
+replay old commands into a shell.
 
-GridBash is currently single-process: closing it closes its child agents. Session resume is recovery context, not detach and reattach.
+Enable **Keep terminals running** in Settings to detach live pane hosts when the
+GridBash UI closes. `gridbash resume` then reconnects to the same PTYs; output
+produced while detached is added to the restored view. If a host is no longer
+available, GridBash starts a replacement terminal and retains the saved context.
+The background hosts are local, authenticated, and accept one GridBash client at
+a time.
 
 ## Managed git worktrees
 
@@ -264,6 +269,7 @@ pane_workload = "adaptive"     # or "unrestricted"
 compact_titles = false
 activity_badges = true
 confirm_quit = false
+keep_terminals_running = false
 scrollback_rows = 10000
 refresh_ms = 16
 
@@ -289,7 +295,7 @@ claude = "claude-1"
 codex = "codex-2"
 ```
 
-Settings persist compact titles, activity badges, quit confirmation, new-pane scrollback, refresh delay, todo prompts, auth and workload policy, and the interface palette. Supported runtime changes apply immediately.
+Settings persist compact titles, activity badges, quit confirmation, background-terminal behavior, new-pane scrollback, refresh delay, todo prompts, auth and workload policy, and the interface palette. Supported runtime changes apply immediately.
 
 ### Grid manager
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,11 +8,12 @@
 - Built-in CLI agent profiles.
 - Demo-ready dark theme.
 - Release as a single Windows x64 executable.
+- Optional local background pane hosts with saved-session reattachment.
 - Stable-release gates are tracked in [`V1_ACCEPTANCE.md`](V1_ACCEPTANCE.md).
 
 ## V2
 
-- Background daemon for detach/reattach.
+- Consolidated per-user session daemon and durable detach/reattach state.
 - Multi-client attach.
 - Agent status classifiers.
 - Plugin API.

--- a/docs/V1_ACCEPTANCE.md
+++ b/docs/V1_ACCEPTANCE.md
@@ -78,8 +78,8 @@ an ancestor of that tested commit and no relevant code changed afterward.
       agree on supported Windows versions and profiles.
 - [ ] Security reporting, support, contribution, license, and code-of-conduct
       links are present and valid.
-- [ ] Known v1 limitations explicitly include single-process lifetime and the
-      lack of daemon-backed detach/reattach.
+- [ ] Known v1 limitations explicitly include single-client background hosts and
+      the lack of a consolidated, multi-client session daemon.
 
 ## Packaging and release
 

--- a/docs/devlogs/2026-07-15-keep-terminals-running-after-exit.md
+++ b/docs/devlogs/2026-07-15-keep-terminals-running-after-exit.md
@@ -1,0 +1,38 @@
+# Keep terminals running after exit
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added an opt-in way to close GridBash while its live terminal processes keep
+  running locally.
+
+## What Changed
+
+- Moved pane PTY ownership into authenticated local background hosts.
+- Added a **Keep terminals running** workflow setting that updates active and
+  inactive-tab panes immediately.
+- Saved pane-host references with session snapshots so `gridbash resume`
+  reconnects to the same PTYs and receives output produced while detached.
+- Kept the existing stop-on-close behavior as the default and fall back to a new
+  terminal with saved context if a background host is unavailable.
+
+## Why It Matters
+
+- Long-running agents, builds, and shells no longer have to stop just because a
+  user closes the GridBash interface.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --no-fail-fast`
+- `npm test`
+- Manual detach/reattach lifecycle coverage through the pane-host integration
+  test.
+
+## Release Notes
+
+- GridBash can now keep live terminals running after the UI closes and reattach
+  to them from a saved session.

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,17 +32,17 @@ use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 use crate::{
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
-    codex_sqlite::{CodexSqlitePool, PaneCodexSqlite},
     composer::{Composer, GridPicker, GridPickerAction},
     config::{Config, PaletteColor, PaneWorkloadPolicy, UiConfig, UiPalette},
     control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
+    pane_host::{PaneHostBusy, PaneHostIncompatible, PaneHostRejected, PtyHostRef, PtyPane},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile},
-    pty::{PtyEvent, PtyPane, PtyWriteToken},
-    session::{SavedPaneHistory, SessionRecord, SessionRecorder},
+    pty::{PtyEvent, PtyWriteToken},
+    session::{SavedPaneHistory, SavedTab, SessionRecord, SessionRecorder},
     setup::{LaunchPlan, PaneLaunchSpec},
     ui,
     usage::{self, UsageEvent, UsageTarget},
@@ -87,7 +87,6 @@ pub struct App {
     layout: GridLayout,
     grid_area: Rect,
     panes: Vec<PtyPane>,
-    codex_sqlite: CodexSqlitePool,
     pane_idle: Vec<PaneIdleState>,
     focus: usize,
     selected: BTreeSet<usize>,
@@ -122,6 +121,8 @@ pub struct App {
     pane_settings: PaneSettingsState,
     status: String,
     restored_histories: Vec<SavedPaneHistory>,
+    restored_hosts: Vec<Option<PtyHostRef>>,
+    restored_tabs: Vec<SavedTab>,
     session_recorder: Option<SessionRecorder>,
     next_pane_id: usize,
     next_tab_number: usize,
@@ -159,7 +160,10 @@ struct AppInit {
     control_handle: Option<ControlHandle>,
     control_rx: Option<std_mpsc::Receiver<ControlEnvelope>>,
     settings: SettingsState,
+    tab_title: String,
     restored_histories: Vec<SavedPaneHistory>,
+    restored_hosts: Vec<Option<PtyHostRef>>,
+    restored_tabs: Vec<SavedTab>,
     session_recorder: Option<SessionRecorder>,
     status: String,
 }
@@ -640,6 +644,7 @@ enum SettingsTarget {
     CompactTitles,
     ActivityBadges,
     ConfirmQuit,
+    KeepTerminalsRunning,
     IdleFollowups,
     IdleSeconds,
     Todo(usize),
@@ -1052,6 +1057,7 @@ struct SettingsState {
     compact_titles: bool,
     activity_badges: bool,
     confirm_quit: bool,
+    keep_terminals_running: bool,
     idle_followups: bool,
     idle_seconds: u64,
     todo_prompts: Vec<String>,
@@ -1219,6 +1225,7 @@ impl Default for SettingsState {
             compact_titles: false,
             activity_badges: true,
             confirm_quit: false,
+            keep_terminals_running: false,
             idle_followups: true,
             idle_seconds: crate::config::TodoSettings::default_idle_seconds(),
             todo_prompts: Vec::new(),
@@ -1239,6 +1246,7 @@ impl SettingsState {
             compact_titles: config.ui.compact_titles,
             activity_badges: config.ui.activity_badges,
             confirm_quit: config.ui.confirm_quit,
+            keep_terminals_running: config.ui.keep_terminals_running,
             idle_followups: config.todos.enabled,
             idle_seconds: config
                 .todos
@@ -1279,6 +1287,10 @@ impl SettingsState {
                 self.confirm_quit = !self.confirm_quit;
                 SettingsChange::SaveUi
             }
+            Some(SettingsTarget::KeepTerminalsRunning) => {
+                self.keep_terminals_running = !self.keep_terminals_running;
+                SettingsChange::SaveUi
+            }
             Some(SettingsTarget::IdleFollowups) => {
                 self.idle_followups = !self.idle_followups;
                 SettingsChange::SaveTodos
@@ -1314,6 +1326,12 @@ impl SettingsState {
             Some(SettingsTarget::ConfirmQuit) => {
                 if delta != 0 {
                     self.confirm_quit = !self.confirm_quit;
+                }
+                SettingsChange::SaveUi
+            }
+            Some(SettingsTarget::KeepTerminalsRunning) => {
+                if delta != 0 {
+                    self.keep_terminals_running = !self.keep_terminals_running;
                 }
                 SettingsChange::SaveUi
             }
@@ -1450,6 +1468,7 @@ impl SettingsState {
             compact_titles: self.compact_titles,
             activity_badges: self.activity_badges,
             confirm_quit: self.confirm_quit,
+            keep_terminals_running: self.keep_terminals_running,
             scrollback_rows: self.scrollback.clamp(1_000, 50_000) as usize,
             refresh_ms: self.refresh_ms.clamp(8, 100) as u64,
             palette: UiPalette::from(self.palette),
@@ -1585,6 +1604,7 @@ impl SettingsState {
             SettingsTarget::CompactTitles,
             SettingsTarget::ActivityBadges,
             SettingsTarget::ConfirmQuit,
+            SettingsTarget::KeepTerminalsRunning,
             SettingsTarget::IdleFollowups,
             SettingsTarget::IdleSeconds,
         ];
@@ -1665,6 +1685,14 @@ impl SettingsState {
             "Confirm before quit",
             switch_value(self.confirm_quit),
             "extra guard for Alt+q",
+        ));
+        rows.push(self.row(
+            SettingsTarget::KeepTerminalsRunning,
+            SettingsGroup::Workflow,
+            SettingsValueKind::Switch,
+            "Keep terminals running",
+            switch_value(self.keep_terminals_running),
+            "detach on quit; reconnect with gridbash resume",
         ));
         rows.push(self.row(
             SettingsTarget::IdleFollowups,
@@ -1893,7 +1921,10 @@ impl App {
             control_handle,
             control_rx,
             settings,
+            tab_title: "Grid 1".into(),
             restored_histories: Vec::new(),
+            restored_hosts: Vec::new(),
+            restored_tabs: Vec::new(),
             session_recorder: None,
             status,
         })
@@ -1904,6 +1935,13 @@ impl App {
         apply_auth_defaults(&mut launch_plan, &config)?;
         let grid = launch_plan.grid;
         let restored_histories = record.session.pane_histories();
+        let restored_hosts = record.session.pane_hosts();
+        let restored_tabs = record.session.tabs.clone();
+        let tab_title = if record.session.title.is_empty() {
+            "Grid 1".into()
+        } else {
+            record.session.title.clone()
+        };
         let session_id = record.session.id.clone();
         let recorder = SessionRecorder::continue_record(record);
         let settings = SettingsState::from_config(&config);
@@ -1924,7 +1962,10 @@ impl App {
             control_handle: None,
             control_rx: None,
             settings,
+            tab_title,
             restored_histories,
+            restored_hosts,
+            restored_tabs,
             session_recorder: Some(recorder),
             status: format!("resumed session {session_id}"),
         })
@@ -1942,12 +1983,11 @@ impl App {
             worktrees: init.worktrees,
             tabs: vec![None],
             active_tab: 0,
-            tab_title: "Grid 1".into(),
+            tab_title: init.tab_title,
             launch_plan: init.launch_plan,
             layout: GridLayout::new(init.grid),
             grid_area: Rect::default(),
             panes: Vec::new(),
-            codex_sqlite: CodexSqlitePool::new()?,
             pane_idle: Vec::new(),
             focus: 0,
             selected: BTreeSet::new(),
@@ -1982,6 +2022,8 @@ impl App {
             pane_settings: PaneSettingsState::default(),
             status: init.status,
             restored_histories: init.restored_histories,
+            restored_hosts: init.restored_hosts,
+            restored_tabs: init.restored_tabs,
             session_recorder: init.session_recorder,
             next_pane_id: 0,
             next_tab_number: 2,
@@ -2013,6 +2055,19 @@ impl App {
         let mut terminal = setup_terminal(self.mouse_enabled)?;
         let result = self.run_in_terminal(&mut terminal);
         teardown_terminal(&mut terminal, self.mouse_enabled)?;
+        if result.is_ok()
+            && self.settings.keep_terminals_running
+            && (self.panes.iter().any(|pane| !pane.exited)
+                || self
+                    .tabs
+                    .iter()
+                    .filter_map(Option::as_ref)
+                    .any(|tab| tab.panes.iter().any(|pane| !pane.exited)))
+        {
+            println!(
+                "gridbash: terminals are still running; reconnect with `gridbash resume --latest`"
+            );
+        }
         result
     }
 
@@ -2043,6 +2098,8 @@ impl App {
         self.layout = GridLayout::new(plan.grid);
         self.launch_plan = Some(plan);
         self.restored_histories.clear();
+        self.restored_hosts.clear();
+        self.restored_tabs.clear();
         Ok(())
     }
 
@@ -2054,8 +2111,6 @@ impl App {
         self.tabs.clear();
         self.tabs.push(None);
         self.active_tab = 0;
-        self.tab_title = "Grid 1".into();
-        self.next_tab_number = 2;
         self.tab_rename.close();
         self.layout = GridLayout::new(plan.grid);
         self.panes.clear();
@@ -2074,6 +2129,12 @@ impl App {
             self.spawn_pane_spec(index, spec)?;
         }
         self.restored_histories.clear();
+        self.restored_hosts.clear();
+        for saved_tab in mem::take(&mut self.restored_tabs) {
+            let snapshot = self.restore_saved_tab(saved_tab)?;
+            self.tabs.push(Some(snapshot));
+        }
+        self.next_tab_number = self.tabs.len() + 1;
         self.start_usage_monitor(&plan);
 
         self.save_session_snapshot()
@@ -2083,6 +2144,37 @@ impl App {
         let title = format!("Grid {}", self.next_tab_number);
         self.next_tab_number += 1;
         title
+    }
+
+    fn restore_saved_tab(&mut self, saved: SavedTab) -> Result<GridTabSnapshot> {
+        let mut plan = saved.launch_plan()?;
+        apply_auth_defaults(&mut plan, &self.config)?;
+        let histories = saved.pane_histories();
+        let hosts = saved.pane_hosts();
+        let mut panes = Vec::with_capacity(plan.panes.len());
+        for (index, spec) in plan.panes.iter().enumerate() {
+            let history = histories.get(index).cloned().unwrap_or_default();
+            let host = hosts.get(index).cloned().flatten();
+            panes.push(self.create_pane(spec, index, &history, host)?);
+        }
+        let pane_count = panes.len();
+        let grid = plan.grid;
+        Ok(GridTabSnapshot {
+            title: saved.title,
+            launch_plan: Some(plan),
+            layout: GridLayout::new(grid),
+            panes,
+            pane_idle: (0..pane_count)
+                .map(|_| PaneIdleState::new(Instant::now()))
+                .collect(),
+            focus: 0,
+            selected: BTreeSet::new(),
+            pane_names: vec![None; pane_count],
+            text_selection: None,
+            sleeping: BTreeSet::new(),
+            manager_goal: None,
+            rects: Vec::new(),
+        })
     }
 
     fn take_current_tab_snapshot(&mut self) -> GridTabSnapshot {
@@ -2155,6 +2247,7 @@ impl App {
         self.rects.clear();
         self.follow_up = None;
         self.restored_histories.clear();
+        self.restored_hosts.clear();
         if let Some(cwd) = plan.panes.first().map(|pane| pane.cwd.clone()) {
             self.command_line.cwd = cwd;
         }
@@ -2194,23 +2287,75 @@ impl App {
     }
 
     fn spawn_pane_spec(&mut self, index: usize, spec: &PaneLaunchSpec) -> Result<()> {
-        let mut pane = self.spawn_pane_instance(spec, index)?;
-        if let Some(history) = self.restored_histories.get(index) {
-            pane.restore_history_display(&history.output_tail, &history.input_history);
-        }
+        let history = self
+            .restored_histories
+            .get(index)
+            .cloned()
+            .unwrap_or_default();
+        let host = self.restored_hosts.get(index).cloned().flatten();
+        let pane = self.create_pane(spec, index, &history, host)?;
         self.panes.push(pane);
         self.pane_idle.push(PaneIdleState::new(Instant::now()));
         Ok(())
+    }
+
+    fn create_pane(
+        &mut self,
+        spec: &PaneLaunchSpec,
+        index: usize,
+        history: &SavedPaneHistory,
+        host: Option<PtyHostRef>,
+    ) -> Result<PtyPane> {
+        if let Some(host) = host {
+            let id = PaneId(self.next_pane_id);
+            self.next_pane_id += 1;
+            match PtyPane::attach(
+                host,
+                id,
+                0,
+                &spec.cwd,
+                self.config.ui.scrollback_rows,
+                self.config.ui.keep_terminals_running,
+                &history.output_tail,
+                &history.input_history,
+                self.event_tx.clone(),
+            ) {
+                Ok(pane) => return Ok(pane),
+                Err(error) => {
+                    if error.is::<PaneHostBusy>() {
+                        return Err(error).with_context(|| {
+                            format!(
+                                "background pane {} is already open in another GridBash client",
+                                index + 1
+                            )
+                        });
+                    }
+                    if error.is::<PaneHostIncompatible>() || error.is::<PaneHostRejected>() {
+                        return Err(error).with_context(|| {
+                            format!("background pane {} cannot be reattached", index + 1)
+                        });
+                    }
+                    self.status = format!(
+                        "background pane {} unavailable; started a new terminal ({error:#})",
+                        index + 1
+                    );
+                    let mut pane = self.spawn_pane_instance(spec, index)?;
+                    pane.restore_history_display(&history.output_tail, &history.input_history);
+                    return Ok(pane);
+                }
+            }
+        }
+
+        let mut pane = self.spawn_pane_instance(spec, index)?;
+        pane.restore_history_display(&history.output_tail, &history.input_history);
+        Ok(pane)
     }
 
     fn spawn_pane_instance(&mut self, spec: &PaneLaunchSpec, pane_index: usize) -> Result<PtyPane> {
         let launch = spec.resolved_command()?;
         let id = PaneId(self.next_pane_id);
         self.next_pane_id += 1;
-        let PaneCodexSqlite {
-            env: extra_env,
-            lease: codex_sqlite_lease,
-        } = self.pane_env(pane_index, &spec.env)?;
+        let extra_env = self.pane_env(pane_index);
         PtyPane::spawn(
             &spec.profile_name,
             id,
@@ -2220,23 +2365,18 @@ impl App {
             &spec.env,
             &spec.cwd,
             &extra_env,
-            codex_sqlite_lease,
             self.config.ui.scrollback_rows,
             self.config.defaults.pane_priority,
             self.config.defaults.pane_workload,
+            self.config.ui.keep_terminals_running,
             self.event_tx.clone(),
         )
     }
 
-    fn pane_env(
-        &self,
-        pane_index: usize,
-        spec_env: &BTreeMap<String, String>,
-    ) -> Result<PaneCodexSqlite> {
-        let mut pane_sqlite = self.codex_sqlite.for_pane(spec_env)?;
-
+    fn pane_env(&self, pane_index: usize) -> Vec<(OsString, OsString)> {
+        let mut env = Vec::new();
         if let Some(control) = &self.control_handle {
-            pane_sqlite.env.extend([
+            env.extend([
                 (
                     "GRIDBASH_CONTROL_ADDR".into(),
                     control.endpoint().to_string().into(),
@@ -2251,8 +2391,7 @@ impl App {
                 ),
             ]);
         }
-
-        Ok(pane_sqlite)
+        env
     }
 
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
@@ -5047,18 +5186,42 @@ impl App {
         let previous = self.config.ui.clone();
         self.config.ui = self.settings.ui_config();
         match self.config.save(self.config_path.as_deref()) {
-            Ok(_) => true,
+            Ok(_) => {
+                self.sync_keep_running_policy();
+                true
+            }
             Err(error) => {
                 self.config.ui = previous.clone();
                 self.settings.compact_titles = previous.compact_titles;
                 self.settings.activity_badges = previous.activity_badges;
                 self.settings.confirm_quit = previous.confirm_quit;
+                self.settings.keep_terminals_running = previous.keep_terminals_running;
                 self.settings.scrollback = previous.scrollback_rows.clamp(1_000, 50_000) as i32;
                 self.settings.refresh_ms = previous.refresh_ms.clamp(8, 100) as i32;
                 self.settings.palette = GridPalette::from(previous.palette);
                 self.status = format!("failed to save UI settings: {error:#}");
                 false
             }
+        }
+    }
+
+    fn sync_keep_running_policy(&mut self) {
+        let keep_running = self.settings.keep_terminals_running;
+        let mut first_error = None;
+        for pane in &mut self.panes {
+            if let Err(error) = pane.set_keep_running(keep_running) {
+                first_error.get_or_insert(error);
+            }
+        }
+        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
+            for pane in &mut tab.panes {
+                if let Err(error) = pane.set_keep_running(keep_running) {
+                    first_error.get_or_insert(error);
+                }
+            }
+        }
+        if let Some(error) = first_error {
+            self.status = format!("saved setting; failed to update a pane host: {error:#}");
         }
     }
 
@@ -6161,7 +6324,7 @@ impl App {
 
     fn start_session_recorder(&mut self, plan: &LaunchPlan) -> Result<()> {
         if self.session_recorder.is_none() {
-            self.session_recorder = Some(SessionRecorder::start_new(plan)?);
+            self.session_recorder = Some(SessionRecorder::start_new(&self.tab_title, plan)?);
         }
         Ok(())
     }
@@ -6170,11 +6333,21 @@ impl App {
         let Some(plan) = self.launch_plan.clone() else {
             return Ok(());
         };
+        let tabs = self
+            .tabs
+            .iter()
+            .filter_map(Option::as_ref)
+            .filter_map(|tab| {
+                tab.launch_plan
+                    .as_ref()
+                    .map(|plan| SavedTab::from_live(&tab.title, plan, &tab.panes))
+            })
+            .collect();
         let Some(recorder) = self.session_recorder.as_mut() else {
             return Ok(());
         };
 
-        recorder.update(&plan, &self.panes);
+        recorder.update(&self.tab_title, &plan, &self.panes, tabs);
         recorder.save()
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,10 @@ pub struct Cli {
     #[arg(long)]
     pub mcp: bool,
 
+    /// Internal launch specification for a detached pane host.
+    #[arg(long, hide = true)]
+    pub pane_host: Option<PathBuf>,
+
     /// Print detected launch profiles and exit.
     #[arg(long)]
     pub list_profiles: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,8 @@ pub struct UiConfig {
     pub activity_badges: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub confirm_quit: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub keep_terminals_running: bool,
     #[serde(
         default = "UiConfig::default_scrollback_rows",
         skip_serializing_if = "UiConfig::is_default_scrollback_rows"
@@ -89,6 +91,7 @@ impl Default for UiConfig {
             compact_titles: false,
             activity_badges: Self::default_activity_badges(),
             confirm_quit: false,
+            keep_terminals_running: false,
             scrollback_rows: Self::default_scrollback_rows(),
             refresh_ms: Self::default_refresh_ms(),
             palette: UiPalette::default(),
@@ -113,6 +116,7 @@ impl UiConfig {
         !self.compact_titles
             && self.activity_badges == Self::default_activity_badges()
             && !self.confirm_quit
+            && !self.keep_terminals_running
             && self.scrollback_rows == Self::default_scrollback_rows()
             && self.refresh_ms == Self::default_refresh_ms()
             && self.palette.is_default()
@@ -513,6 +517,7 @@ mod tests {
             compact_titles = true
             activity_badges = false
             confirm_quit = true
+            keep_terminals_running = true
             scrollback_rows = 24000
             refresh_ms = 32
 
@@ -529,6 +534,7 @@ mod tests {
         assert!(config.ui.compact_titles);
         assert!(!config.ui.activity_badges);
         assert!(config.ui.confirm_quit);
+        assert!(config.ui.keep_terminals_running);
         assert_eq!(config.ui.scrollback_rows, 24_000);
         assert_eq!(config.ui.refresh_ms, 32);
         assert_eq!(config.ui.palette.accent, PaletteColor::Amber);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod image_preview;
 mod layout;
 mod manager;
 mod onboarding;
+mod pane_host;
 mod process_priority;
 mod profiles;
 mod pty;
@@ -35,6 +36,10 @@ use crate::{
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(spec_path) = cli.pane_host.as_deref() {
+        return pane_host::run_pane_host(spec_path);
+    }
 
     if cli.mcp {
         return control::run_mcp_server();

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -1,0 +1,1265 @@
+use std::{
+    collections::BTreeMap,
+    ffi::{OsString, OsString as PlatformString},
+    fs::{self, OpenOptions},
+    io::{BufRead, BufReader, Write},
+    net::{Shutdown, SocketAddr, TcpListener, TcpStream},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{Arc, Mutex, mpsc as std_mpsc},
+    thread,
+    time::{Duration, Instant},
+};
+use std::{error::Error as StdError, fmt};
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use vt100::Screen;
+
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+
+use crate::{
+    codex_sqlite::{CodexSqlitePool, PaneCodexSqlite},
+    config::{PaneProcessPriority, PaneWorkloadPolicy},
+    layout::PaneId,
+    process_priority::PaneWorkloadClass,
+    pty::{PtyEvent, PtyPane as LocalPtyPane, PtyView, PtyWriteToken},
+};
+
+const HOST_START_TIMEOUT: Duration = Duration::from_secs(8);
+const HOST_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const HOST_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
+const BACKGROUND_OUTPUT_LIMIT: usize = 2 * 1024 * 1024;
+const PANE_HOST_PROTOCOL_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PtyHostRef {
+    pub endpoint: String,
+    pub token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct HostLaunchSpec {
+    token: String,
+    ready_path: PathBuf,
+    profile_name: String,
+    pane_id: usize,
+    generation: u64,
+    command: PathBuf,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    cwd: PathBuf,
+    extra_env: Vec<(String, String)>,
+    scrollback_rows: usize,
+    process_priority: PaneProcessPriority,
+    workload_policy: PaneWorkloadPolicy,
+    keep_running: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct HostReadyFile {
+    endpoint: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum HostCommand {
+    Hello {
+        protocol_version: u16,
+        token: String,
+        keep_running: bool,
+    },
+    Write {
+        data: String,
+        #[serde(default)]
+        token: Option<String>,
+    },
+    Resize {
+        rows: u16,
+        cols: u16,
+    },
+    ApplyWorkload {
+        policy: PaneWorkloadPolicy,
+        class: PaneWorkloadClass,
+    },
+    SetKeepRunning {
+        keep_running: bool,
+    },
+    Disconnect {
+        keep_running: bool,
+    },
+    Terminate,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum HostEvent {
+    Ready {
+        #[serde(default)]
+        protocol_version: u16,
+        background_output: String,
+        cwd: PathBuf,
+        exited: bool,
+    },
+    Output {
+        data: String,
+    },
+    Exited,
+    WriteFailed {
+        #[serde(default)]
+        token: Option<String>,
+        error: String,
+    },
+    WriteSucceeded {
+        token: String,
+    },
+    Error {
+        error: String,
+    },
+    Incompatible {
+        host_version: u16,
+    },
+    Busy,
+}
+
+#[derive(Debug)]
+pub struct PaneHostBusy;
+
+impl fmt::Display for PaneHostBusy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("pane host already has an attached GridBash client")
+    }
+}
+
+impl StdError for PaneHostBusy {}
+
+#[derive(Debug)]
+pub struct PaneHostIncompatible {
+    host_version: u16,
+}
+
+impl fmt::Display for PaneHostIncompatible {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "pane host protocol mismatch: client {}, host {}; reopen with the previous GridBash version or stop the old host",
+            PANE_HOST_PROTOCOL_VERSION, self.host_version
+        )
+    }
+}
+
+impl StdError for PaneHostIncompatible {}
+
+#[derive(Debug)]
+pub struct PaneHostRejected {
+    reason: String,
+}
+
+impl fmt::Display for PaneHostRejected {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "pane host rejected the connection: {}",
+            self.reason
+        )
+    }
+}
+
+impl StdError for PaneHostRejected {}
+
+pub struct PtyPane {
+    id: PaneId,
+    generation: u64,
+    connection: Arc<Mutex<TcpStream>>,
+    host: PtyHostRef,
+    view: PtyView,
+    keep_running: bool,
+    pub active: bool,
+    pub exited: bool,
+}
+
+impl PtyPane {
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn(
+        profile_name: &str,
+        id: PaneId,
+        generation: u64,
+        command: &Path,
+        args: &[String],
+        env: &BTreeMap<String, String>,
+        cwd: &Path,
+        extra_env: &[(OsString, OsString)],
+        scrollback_rows: usize,
+        process_priority: PaneProcessPriority,
+        workload_policy: PaneWorkloadPolicy,
+        keep_running: bool,
+        event_tx: mpsc::Sender<PtyEvent>,
+    ) -> Result<Self> {
+        let token = random_token()?;
+        let directory = pane_hosts_dir()?;
+        create_private_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create pane host directory {}",
+                directory.display()
+            )
+        })?;
+        let spec_path = directory.join(format!("{token}.json"));
+        let ready_path = directory.join(format!("{token}.ready.json"));
+        let spec = HostLaunchSpec {
+            token: token.clone(),
+            ready_path: ready_path.clone(),
+            profile_name: profile_name.to_string(),
+            pane_id: id.0,
+            generation,
+            command: command.to_path_buf(),
+            args: args.to_vec(),
+            env: env.clone(),
+            cwd: cwd.to_path_buf(),
+            extra_env: extra_env
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
+                .collect(),
+            scrollback_rows,
+            process_priority,
+            workload_policy,
+            keep_running,
+        };
+        let raw = serde_json::to_vec(&spec).context("failed to serialize pane host launch")?;
+        write_private_file(&spec_path, &raw)
+            .with_context(|| format!("failed to write pane host spec {}", spec_path.display()))?;
+
+        let mut child = match spawn_detached_host(&spec_path) {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = fs::remove_file(&spec_path);
+                return Err(error);
+            }
+        };
+
+        let deadline = Instant::now() + HOST_START_TIMEOUT;
+        let ready = loop {
+            if let Ok(raw) = fs::read(&ready_path)
+                && let Ok(ready) = serde_json::from_slice::<HostReadyFile>(&raw)
+            {
+                break ready;
+            }
+            if let Some(status) = child
+                .try_wait()
+                .context("failed to inspect pane host startup")?
+            {
+                let _ = fs::remove_file(&spec_path);
+                let _ = fs::remove_file(&ready_path);
+                bail!("pane host exited during startup with {status}");
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = fs::remove_file(&spec_path);
+                let _ = fs::remove_file(&ready_path);
+                bail!("timed out waiting for pane host startup");
+            }
+            thread::sleep(Duration::from_millis(20));
+        };
+        let _ = fs::remove_file(&ready_path);
+        thread::spawn(move || {
+            let _ = child.wait();
+        });
+
+        let host = PtyHostRef {
+            endpoint: ready.endpoint,
+            token,
+        };
+        Self::connect(
+            host,
+            id,
+            generation,
+            cwd,
+            scrollback_rows,
+            keep_running,
+            "",
+            &[],
+            event_tx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn attach(
+        host: PtyHostRef,
+        id: PaneId,
+        generation: u64,
+        fallback_cwd: &Path,
+        scrollback_rows: usize,
+        keep_running: bool,
+        saved_output_tail: &str,
+        saved_input_history: &[String],
+        event_tx: mpsc::Sender<PtyEvent>,
+    ) -> Result<Self> {
+        Self::connect(
+            host,
+            id,
+            generation,
+            fallback_cwd,
+            scrollback_rows,
+            keep_running,
+            saved_output_tail,
+            saved_input_history,
+            event_tx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn connect(
+        host: PtyHostRef,
+        id: PaneId,
+        generation: u64,
+        fallback_cwd: &Path,
+        scrollback_rows: usize,
+        keep_running: bool,
+        saved_output_tail: &str,
+        saved_input_history: &[String],
+        event_tx: mpsc::Sender<PtyEvent>,
+    ) -> Result<Self> {
+        let endpoint = host
+            .endpoint
+            .parse::<SocketAddr>()
+            .with_context(|| format!("invalid pane host endpoint {}", host.endpoint))?;
+        let mut stream = TcpStream::connect_timeout(&endpoint, HANDSHAKE_TIMEOUT)
+            .with_context(|| format!("failed to connect to pane host {}", host.endpoint))?;
+        stream.set_nodelay(true).ok();
+        stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT)).ok();
+        send_json(
+            &mut stream,
+            &HostCommand::Hello {
+                protocol_version: PANE_HOST_PROTOCOL_VERSION,
+                token: host.token.clone(),
+                keep_running,
+            },
+        )?;
+
+        let reader_stream = stream
+            .try_clone()
+            .context("failed to clone pane host connection")?;
+        let mut reader = BufReader::new(reader_stream);
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .context("failed to read pane host handshake")?;
+        if line.is_empty() {
+            bail!("pane host closed during handshake");
+        }
+        let ready = serde_json::from_str::<HostEvent>(&line)
+            .context("failed to parse pane host handshake")?;
+        let (protocol_version, background_output, cwd, exited) = match ready {
+            HostEvent::Ready {
+                protocol_version,
+                background_output,
+                cwd,
+                exited,
+            } => (protocol_version, background_output, cwd, exited),
+            HostEvent::Error { error } => {
+                return Err(PaneHostRejected { reason: error }.into());
+            }
+            HostEvent::Busy => return Err(PaneHostBusy.into()),
+            HostEvent::Incompatible { host_version } => {
+                return Err(PaneHostIncompatible { host_version }.into());
+            }
+            _ => bail!("pane host rejected the connection"),
+        };
+        if protocol_version != PANE_HOST_PROTOCOL_VERSION {
+            return Err(PaneHostIncompatible {
+                host_version: protocol_version,
+            }
+            .into());
+        }
+
+        reader.get_mut().set_read_timeout(None).ok();
+        let mut view = PtyView::new(fallback_cwd.to_path_buf(), scrollback_rows);
+        view.restore_history_display(saved_output_tail, saved_input_history);
+        view.set_cwd(cwd);
+        let background_output = BASE64
+            .decode(background_output)
+            .context("failed to decode pane host background output")?;
+        if !background_output.is_empty() {
+            view.process_output(&background_output);
+        }
+
+        spawn_client_reader(reader, id, generation, event_tx);
+        Ok(Self {
+            id,
+            generation,
+            connection: Arc::new(Mutex::new(stream)),
+            host,
+            view,
+            keep_running,
+            active: !background_output.is_empty(),
+            exited,
+        })
+    }
+
+    pub fn id(&self) -> PaneId {
+        self.id
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn host_ref(&self) -> PtyHostRef {
+        self.host.clone()
+    }
+
+    pub fn cwd(&self) -> &Path {
+        self.view.cwd()
+    }
+
+    pub fn screen(&self) -> &Screen {
+        self.view.screen()
+    }
+
+    pub fn screen_revision(&self) -> u64 {
+        self.view.screen_revision()
+    }
+
+    pub fn scroll_view(&mut self, rows: isize) -> bool {
+        self.view.scroll_view(rows)
+    }
+
+    pub fn reset_view(&mut self) -> bool {
+        self.view.reset_view()
+    }
+
+    pub fn process_output(&mut self, bytes: &[u8]) -> String {
+        let plain = self.view.process_output(bytes);
+        self.active = true;
+        plain
+    }
+
+    pub fn output_quiet(&self) -> bool {
+        !self.exited && self.view.output_quiet()
+    }
+
+    pub fn refresh_output_activity(&mut self, now: Instant, quiet_after: Duration) -> bool {
+        if self.exited {
+            return false;
+        }
+        self.view.refresh_output_activity(now, quiet_after)
+    }
+
+    pub fn record_input(&mut self, bytes: &[u8]) {
+        self.view.record_input(bytes);
+    }
+
+    pub fn record_input_activity(&mut self, bytes: &[u8]) {
+        self.view.record_input_activity(bytes);
+    }
+
+    pub fn input_revision(&self) -> u64 {
+        self.view.input_revision()
+    }
+
+    pub fn input_history(&self) -> &[String] {
+        self.view.input_history()
+    }
+
+    pub fn output_tail(&self) -> &str {
+        self.view.output_tail()
+    }
+
+    pub fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
+        self.view
+            .restore_history_display(output_tail, input_history);
+    }
+
+    pub fn write(&self, bytes: &[u8]) -> Result<()> {
+        self.send(&HostCommand::Write {
+            data: BASE64.encode(bytes),
+            token: None,
+        })
+    }
+
+    pub fn write_tracked(&self, bytes: &[u8], token: PtyWriteToken) -> Result<()> {
+        self.send(&HostCommand::Write {
+            data: BASE64.encode(bytes),
+            token: Some(token.0.to_string()),
+        })
+    }
+
+    pub fn apply_workload(
+        &self,
+        policy: PaneWorkloadPolicy,
+        class: PaneWorkloadClass,
+    ) -> Result<()> {
+        self.send(&HostCommand::ApplyWorkload { policy, class })
+    }
+
+    pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
+        if !self.view.resize_view(rows, cols) {
+            return Ok(());
+        }
+        self.send(&HostCommand::Resize { rows, cols })
+    }
+
+    pub fn poll_exit(&mut self) -> bool {
+        false
+    }
+
+    pub fn set_keep_running(&mut self, keep_running: bool) -> Result<()> {
+        self.keep_running = keep_running;
+        self.send(&HostCommand::SetKeepRunning { keep_running })
+    }
+
+    fn send(&self, command: &HostCommand) -> Result<()> {
+        let mut stream = self
+            .connection
+            .lock()
+            .map_err(|_| anyhow!("pane host connection lock was poisoned"))?;
+        send_json(&mut stream, command)
+    }
+}
+
+impl Drop for PtyPane {
+    fn drop(&mut self) {
+        let command = if self.exited {
+            HostCommand::Terminate
+        } else {
+            HostCommand::Disconnect {
+                keep_running: self.keep_running,
+            }
+        };
+        let _ = self.send(&command);
+        if let Ok(stream) = self.connection.lock() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
+}
+
+pub fn run_pane_host(spec_path: &Path) -> Result<()> {
+    let raw = fs::read(spec_path)
+        .with_context(|| format!("failed to read pane host spec {}", spec_path.display()))?;
+    let spec = serde_json::from_slice::<HostLaunchSpec>(&raw)
+        .context("failed to parse pane host launch spec")?;
+    let _ = fs::remove_file(spec_path);
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).context("failed to bind pane host")?;
+    listener
+        .set_nonblocking(true)
+        .context("failed to make pane host listener nonblocking")?;
+    let endpoint = listener
+        .local_addr()
+        .context("failed to read pane host endpoint")?;
+    let ready = serde_json::to_vec(&HostReadyFile {
+        endpoint: endpoint.to_string(),
+    })
+    .context("failed to serialize pane host readiness")?;
+    write_private_file(&spec.ready_path, &ready).with_context(|| {
+        format!(
+            "failed to write pane host readiness {}",
+            spec.ready_path.display()
+        )
+    })?;
+
+    let PaneCodexSqlite {
+        env: codex_env,
+        lease,
+    } = CodexSqlitePool::new()?.for_pane(&spec.env)?;
+    let mut extra_env = spec
+        .extra_env
+        .iter()
+        .map(|(name, value)| (PlatformString::from(name), PlatformString::from(value)))
+        .collect::<Vec<_>>();
+    extra_env.extend(codex_env);
+    let (event_tx, mut event_rx) = mpsc::channel(256);
+    let mut pane = LocalPtyPane::spawn(
+        &spec.profile_name,
+        PaneId(spec.pane_id),
+        spec.generation,
+        &spec.command,
+        &spec.args,
+        &spec.env,
+        &spec.cwd,
+        &extra_env,
+        lease,
+        spec.scrollback_rows,
+        spec.process_priority,
+        spec.workload_policy,
+        event_tx,
+    )?;
+
+    let (command_tx, command_rx) = std_mpsc::channel::<HostInput>();
+    let mut client = None::<HostClient>;
+    let mut next_client_id = 1_u64;
+    let mut keep_running = spec.keep_running;
+    let mut background_output = Vec::new();
+    let mut last_exit_poll = Instant::now();
+
+    loop {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                if client.is_none() {
+                    if let Some(connected) = accept_client(
+                        stream,
+                        next_client_id,
+                        &spec.token,
+                        &pane,
+                        &mut background_output,
+                        command_tx.clone(),
+                    )? {
+                        keep_running = connected.keep_running;
+                        client = Some(connected.client);
+                        next_client_id = next_client_id.wrapping_add(1);
+                    }
+                } else {
+                    stream.set_nonblocking(false).ok();
+                    let _ = send_json(&mut stream, &HostEvent::Busy);
+                    let _ = stream.shutdown(Shutdown::Both);
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error).context("failed to accept pane host client"),
+        }
+
+        while let Ok(input) = command_rx.try_recv() {
+            if client.as_ref().map(|value| value.id) != Some(input.client_id) {
+                continue;
+            }
+            match input.message {
+                HostInputMessage::Command(command) => match command {
+                    HostCommand::Hello { .. } => {}
+                    HostCommand::Write { data, token } => {
+                        let decoded = BASE64.decode(data).context("invalid pane input payload")?;
+                        let tracked_token = token
+                            .map(|token| {
+                                token
+                                    .parse::<u128>()
+                                    .context("invalid tracked pane input token")
+                            })
+                            .transpose()?;
+                        let write_result = if let Some(token) = tracked_token {
+                            pane.write_tracked(&decoded, PtyWriteToken(token))
+                        } else {
+                            pane.write(&decoded)
+                        };
+                        if let Err(error) = write_result {
+                            send_to_client(
+                                &mut client,
+                                &HostEvent::WriteFailed {
+                                    token: tracked_token.map(|token| token.to_string()),
+                                    error: error.to_string(),
+                                },
+                            );
+                        }
+                    }
+                    HostCommand::Resize { rows, cols } => {
+                        if let Err(error) = pane.resize(rows, cols) {
+                            send_to_client(
+                                &mut client,
+                                &HostEvent::Error {
+                                    error: error.to_string(),
+                                },
+                            );
+                        }
+                    }
+                    HostCommand::ApplyWorkload { policy, class } => {
+                        if let Err(error) = pane.apply_workload(policy, class) {
+                            send_to_client(
+                                &mut client,
+                                &HostEvent::Error {
+                                    error: error.to_string(),
+                                },
+                            );
+                        }
+                    }
+                    HostCommand::SetKeepRunning {
+                        keep_running: value,
+                    } => keep_running = value,
+                    HostCommand::Disconnect {
+                        keep_running: value,
+                    } => {
+                        keep_running = value;
+                        disconnect_client(&mut client);
+                        if !keep_running {
+                            pane.terminate();
+                            return Ok(());
+                        }
+                    }
+                    HostCommand::Terminate => {
+                        pane.terminate();
+                        send_to_client(&mut client, &HostEvent::Exited);
+                        return Ok(());
+                    }
+                },
+                HostInputMessage::Closed => {
+                    disconnect_client(&mut client);
+                    if !keep_running {
+                        pane.terminate();
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                PtyEvent::Output { bytes, .. } => {
+                    pane.process_output(&bytes);
+                    if client.is_some() {
+                        send_to_client(
+                            &mut client,
+                            &HostEvent::Output {
+                                data: BASE64.encode(&bytes),
+                            },
+                        );
+                    }
+                    if client.is_none() {
+                        append_background_output(&mut background_output, &bytes);
+                    }
+                }
+                PtyEvent::Exited { .. } => {
+                    pane.exited = true;
+                    send_to_client(&mut client, &HostEvent::Exited);
+                }
+                PtyEvent::WriteFailed { token, error, .. } => send_to_client(
+                    &mut client,
+                    &HostEvent::WriteFailed {
+                        token: token.map(|token| token.0.to_string()),
+                        error,
+                    },
+                ),
+                PtyEvent::WriteSucceeded { token, .. } => send_to_client(
+                    &mut client,
+                    &HostEvent::WriteSucceeded {
+                        token: token.0.to_string(),
+                    },
+                ),
+            }
+        }
+
+        if last_exit_poll.elapsed() >= HOST_EXIT_POLL_INTERVAL {
+            if pane.poll_exit() {
+                send_to_client(&mut client, &HostEvent::Exited);
+            }
+            last_exit_poll = Instant::now();
+        }
+
+        if client.is_none() && !keep_running {
+            pane.terminate();
+            return Ok(());
+        }
+        thread::sleep(HOST_POLL_INTERVAL);
+    }
+}
+
+struct HostClient {
+    id: u64,
+    stream: TcpStream,
+}
+
+struct AcceptedClient {
+    client: HostClient,
+    keep_running: bool,
+}
+
+struct HostInput {
+    client_id: u64,
+    message: HostInputMessage,
+}
+
+enum HostInputMessage {
+    Command(HostCommand),
+    Closed,
+}
+
+fn accept_client(
+    mut stream: TcpStream,
+    client_id: u64,
+    expected_token: &str,
+    pane: &LocalPtyPane,
+    background_output: &mut Vec<u8>,
+    command_tx: std_mpsc::Sender<HostInput>,
+) -> Result<Option<AcceptedClient>> {
+    stream
+        .set_nonblocking(false)
+        .context("failed to make pane host client blocking")?;
+    stream.set_nodelay(true).ok();
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT)).ok();
+    let reader_stream = stream
+        .try_clone()
+        .context("failed to clone pane host client")?;
+    let mut reader = BufReader::new(reader_stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .context("failed to read pane host client handshake")?;
+    let Ok(HostCommand::Hello {
+        protocol_version,
+        token,
+        keep_running,
+    }) = serde_json::from_str::<HostCommand>(&line)
+    else {
+        let _ = send_json(
+            &mut stream,
+            &HostEvent::Error {
+                error: "expected pane host hello".into(),
+            },
+        );
+        return Ok(None);
+    };
+    if protocol_version != PANE_HOST_PROTOCOL_VERSION {
+        let _ = send_json(
+            &mut stream,
+            &HostEvent::Incompatible {
+                host_version: PANE_HOST_PROTOCOL_VERSION,
+            },
+        );
+        return Ok(None);
+    }
+    if token != expected_token {
+        let _ = send_json(
+            &mut stream,
+            &HostEvent::Error {
+                error: "pane host authentication failed".into(),
+            },
+        );
+        return Ok(None);
+    }
+
+    send_json(
+        &mut stream,
+        &HostEvent::Ready {
+            protocol_version: PANE_HOST_PROTOCOL_VERSION,
+            background_output: BASE64.encode(&*background_output),
+            cwd: pane.cwd().to_path_buf(),
+            exited: pane.exited,
+        },
+    )?;
+    background_output.clear();
+    reader.get_mut().set_read_timeout(None).ok();
+    spawn_host_reader(reader, client_id, command_tx);
+    Ok(Some(AcceptedClient {
+        client: HostClient {
+            id: client_id,
+            stream,
+        },
+        keep_running,
+    }))
+}
+
+fn spawn_host_reader(
+    mut reader: BufReader<TcpStream>,
+    client_id: u64,
+    sender: std_mpsc::Sender<HostInput>,
+) {
+    thread::spawn(move || {
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => match serde_json::from_str::<HostCommand>(&line) {
+                    Ok(command) => {
+                        if sender
+                            .send(HostInput {
+                                client_id,
+                                message: HostInputMessage::Command(command),
+                            })
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = sender.send(HostInput {
+                            client_id,
+                            message: HostInputMessage::Command(HostCommand::Disconnect {
+                                keep_running: false,
+                            }),
+                        });
+                        let _ = error;
+                        return;
+                    }
+                },
+                Err(_) => break,
+            }
+        }
+        let _ = sender.send(HostInput {
+            client_id,
+            message: HostInputMessage::Closed,
+        });
+    });
+}
+
+fn spawn_client_reader(
+    mut reader: BufReader<TcpStream>,
+    pane: PaneId,
+    generation: u64,
+    event_tx: mpsc::Sender<PtyEvent>,
+) {
+    thread::spawn(move || {
+        loop {
+            let mut line = String::new();
+            let event = match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => serde_json::from_str::<HostEvent>(&line),
+                Err(_) => break,
+            };
+            let Ok(event) = event else {
+                continue;
+            };
+            let event = match event {
+                HostEvent::Ready { .. } => continue,
+                HostEvent::Output { data } => match BASE64.decode(data) {
+                    Ok(bytes) => PtyEvent::Output {
+                        pane,
+                        generation,
+                        bytes,
+                    },
+                    Err(error) => PtyEvent::WriteFailed {
+                        pane,
+                        generation,
+                        token: None,
+                        error: format!("invalid pane host output: {error}"),
+                    },
+                },
+                HostEvent::Exited => PtyEvent::Exited { pane, generation },
+                HostEvent::WriteFailed { token, error } => PtyEvent::WriteFailed {
+                    pane,
+                    generation,
+                    token: token
+                        .and_then(|token| token.parse().ok())
+                        .map(PtyWriteToken),
+                    error,
+                },
+                HostEvent::WriteSucceeded { token } => {
+                    let Ok(token) = token.parse() else {
+                        continue;
+                    };
+                    PtyEvent::WriteSucceeded {
+                        pane,
+                        generation,
+                        token: PtyWriteToken(token),
+                    }
+                }
+                HostEvent::Error { error } => PtyEvent::WriteFailed {
+                    pane,
+                    generation,
+                    token: None,
+                    error,
+                },
+                HostEvent::Incompatible { .. } => continue,
+                HostEvent::Busy => continue,
+            };
+            if event_tx.blocking_send(event).is_err() {
+                return;
+            }
+        }
+        let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
+    });
+}
+
+fn send_to_client(client: &mut Option<HostClient>, event: &HostEvent) {
+    let failed = client
+        .as_mut()
+        .is_some_and(|client| send_json(&mut client.stream, event).is_err());
+    if failed {
+        disconnect_client(client);
+    }
+}
+
+fn disconnect_client(client: &mut Option<HostClient>) {
+    if let Some(client) = client.take() {
+        let _ = client.stream.shutdown(Shutdown::Both);
+    }
+}
+
+fn append_background_output(buffer: &mut Vec<u8>, bytes: &[u8]) {
+    buffer.extend_from_slice(bytes);
+    if buffer.len() > BACKGROUND_OUTPUT_LIMIT {
+        let excess = buffer.len() - BACKGROUND_OUTPUT_LIMIT;
+        buffer.drain(..excess);
+    }
+}
+
+fn send_json(stream: &mut TcpStream, value: &impl Serialize) -> Result<()> {
+    serde_json::to_writer(&mut *stream, value).context("failed to encode pane host message")?;
+    stream
+        .write_all(b"\n")
+        .context("failed to write pane host message")?;
+    stream.flush().context("failed to flush pane host message")
+}
+
+fn random_token() -> Result<String> {
+    let mut bytes = [0_u8; 24];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| anyhow!("failed to generate pane host token: {error}"))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn pane_hosts_dir() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "GridBash")
+        .map(|dirs| dirs.data_local_dir().join("pane-hosts"))
+        .ok_or_else(|| anyhow!("failed to resolve GridBash pane host directory"))
+}
+
+fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    builder.mode(0o700);
+    builder.create(path)?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+fn spawn_detached_host(spec_path: &Path) -> Result<std::process::Child> {
+    let executable = std::env::current_exe().context("failed to resolve GridBash executable")?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--pane-host")
+        .arg(spec_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: setsid is async-signal-safe and runs before the child execs.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    command.spawn().context("failed to start pane host")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestHostFiles {
+        directory: PathBuf,
+        spec: PathBuf,
+        ready: PathBuf,
+    }
+
+    impl TestHostFiles {
+        fn new() -> Self {
+            let token = random_token().expect("test token");
+            let directory = std::env::temp_dir().join(format!("gridbash-pane-host-test-{token}"));
+            fs::create_dir_all(&directory).expect("create test host directory");
+            Self {
+                spec: directory.join("host.json"),
+                ready: directory.join("host.ready.json"),
+                directory,
+            }
+        }
+    }
+
+    impl Drop for TestHostFiles {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.directory);
+        }
+    }
+
+    #[test]
+    fn host_protocol_round_trips_binary_output() {
+        let event = HostEvent::Output {
+            data: BASE64.encode(b"hello\0\x1b[31m"),
+        };
+        let raw = serde_json::to_string(&event).expect("serialize event");
+        let HostEvent::Output { data } =
+            serde_json::from_str::<HostEvent>(&raw).expect("parse event")
+        else {
+            panic!("wrong event kind");
+        };
+        assert_eq!(
+            BASE64.decode(data).expect("decode output"),
+            b"hello\0\x1b[31m"
+        );
+    }
+
+    #[test]
+    fn background_output_keeps_a_bounded_tail() {
+        let mut output = vec![b'a'; BACKGROUND_OUTPUT_LIMIT];
+        append_background_output(&mut output, b"latest");
+        assert_eq!(output.len(), BACKGROUND_OUTPUT_LIMIT);
+        assert!(output.ends_with(b"latest"));
+    }
+
+    #[test]
+    fn pane_host_survives_disconnect_and_accepts_reattach() {
+        let files = TestHostFiles::new();
+        let host_token = random_token().expect("host token");
+        #[cfg(windows)]
+        let (profile_name, command, args, line_ending) = (
+            "cmd",
+            PathBuf::from("cmd.exe"),
+            vec!["/d".to_string(), "/q".to_string()],
+            "\r",
+        );
+        #[cfg(unix)]
+        let (profile_name, command, args, line_ending) =
+            ("sh", PathBuf::from("/bin/sh"), vec!["-i".to_string()], "\n");
+        let spec = HostLaunchSpec {
+            token: host_token.clone(),
+            ready_path: files.ready.clone(),
+            profile_name: profile_name.into(),
+            pane_id: 7,
+            generation: 0,
+            command,
+            args,
+            env: BTreeMap::new(),
+            cwd: std::env::current_dir().expect("current directory"),
+            extra_env: Vec::new(),
+            scrollback_rows: 1_000,
+            process_priority: PaneProcessPriority::Normal,
+            workload_policy: PaneWorkloadPolicy::Unrestricted,
+            keep_running: true,
+        };
+        fs::write(
+            &files.spec,
+            serde_json::to_vec(&spec).expect("serialize host spec"),
+        )
+        .expect("write host spec");
+        let spec_path = files.spec.clone();
+        let host_thread = thread::spawn(move || run_pane_host(&spec_path));
+
+        let ready = wait_for_ready(&files.ready);
+        let host = PtyHostRef {
+            endpoint: ready.endpoint,
+            token: host_token,
+        };
+        let (first_tx, mut first_rx) = mpsc::channel(32);
+        let first = PtyPane::attach(
+            host.clone(),
+            PaneId(7),
+            0,
+            &spec.cwd,
+            1_000,
+            true,
+            "",
+            &[],
+            first_tx,
+        )
+        .expect("attach first client");
+        first
+            .write(format!("echo before-detach{line_ending}").as_bytes())
+            .expect("write before detach");
+        assert_output_contains(&mut first_rx, "before-detach");
+
+        let (busy_tx, _) = mpsc::channel(1);
+        let busy = match PtyPane::attach(
+            host.clone(),
+            PaneId(7),
+            0,
+            &spec.cwd,
+            1_000,
+            true,
+            "",
+            &[],
+            busy_tx,
+        ) {
+            Ok(_) => panic!("second simultaneous client should be rejected"),
+            Err(error) => error,
+        };
+        assert!(busy.is::<PaneHostBusy>());
+        drop(first);
+
+        thread::sleep(Duration::from_millis(100));
+        let (second_tx, mut second_rx) = mpsc::channel(32);
+        let mut second = PtyPane::attach(
+            host,
+            PaneId(7),
+            0,
+            &spec.cwd,
+            1_000,
+            true,
+            "",
+            &[],
+            second_tx,
+        )
+        .expect("reattach second client");
+        second
+            .write(format!("echo after-reattach{line_ending}").as_bytes())
+            .expect("write after reattach");
+        assert_output_contains(&mut second_rx, "after-reattach");
+        second
+            .set_keep_running(false)
+            .expect("disable host persistence");
+        drop(second);
+
+        host_thread
+            .join()
+            .expect("join pane host")
+            .expect("pane host exits cleanly");
+    }
+
+    fn wait_for_ready(path: &Path) -> HostReadyFile {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(raw) = fs::read(path)
+                && let Ok(ready) = serde_json::from_slice(&raw)
+            {
+                return ready;
+            }
+            assert!(Instant::now() < deadline, "pane host did not become ready");
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn assert_output_contains(receiver: &mut mpsc::Receiver<PtyEvent>, expected: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut output = String::new();
+        while Instant::now() < deadline {
+            match receiver.try_recv() {
+                Ok(PtyEvent::Output { bytes, .. }) => {
+                    output.push_str(&String::from_utf8_lossy(&bytes));
+                    if output.contains(expected) {
+                        return;
+                    }
+                }
+                Ok(PtyEvent::WriteFailed { error, .. }) => panic!("pane write failed: {error}"),
+                Ok(_) | Err(mpsc::error::TryRecvError::Empty) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        panic!("expected output {expected:?}, got {output:?}");
+    }
+}

--- a/src/process_priority.rs
+++ b/src/process_priority.rs
@@ -1,8 +1,11 @@
 use std::io;
 
+use serde::{Deserialize, Serialize};
+
 use crate::config::{PaneProcessPriority, PaneWorkloadPolicy};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum PaneWorkloadClass {
     Focused,
     Selected,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -225,13 +225,22 @@ impl OutputActivity {
 }
 
 pub struct PtyPane {
+    #[allow(dead_code)]
     id: PaneId,
+    #[allow(dead_code)]
     generation: u64,
     master: Box<dyn MasterPty + Send>,
     child: SpawnGuard,
     writer: PtyWriterQueue,
     workload: PaneWorkloadController,
     workload_error: Option<String>,
+    view: PtyView,
+    pub active: bool,
+    pub exited: bool,
+    child_reaped: bool,
+}
+
+pub(crate) struct PtyView {
     parser: Parser,
     screen_revision: u64,
     cwd: PathBuf,
@@ -245,11 +254,163 @@ pub struct PtyPane {
     input_revision: u64,
     output_tail: String,
     output_tail_chars: usize,
-    pub active: bool,
-    pub exited: bool,
-    child_reaped: bool,
 }
 
+impl PtyView {
+    pub(crate) fn new(cwd: PathBuf, scrollback_rows: usize) -> Self {
+        Self {
+            parser: Parser::new(24, 80, scrollback_rows.clamp(1_000, 50_000)),
+            screen_revision: 0,
+            cwd,
+            rows: 24,
+            cols: 80,
+            response_scan_tail: Vec::new(),
+            output_activity: OutputActivity::default(),
+            osc_scan_tail: Vec::new(),
+            input_history: Vec::new(),
+            pending_input: String::new(),
+            input_revision: 0,
+            output_tail: String::new(),
+            output_tail_chars: 0,
+        }
+    }
+
+    pub(crate) fn cwd(&self) -> &Path {
+        &self.cwd
+    }
+
+    pub(crate) fn set_cwd(&mut self, cwd: PathBuf) {
+        self.cwd = cwd;
+    }
+
+    pub(crate) fn screen(&self) -> &Screen {
+        self.parser.screen()
+    }
+
+    pub(crate) fn screen_revision(&self) -> u64 {
+        self.screen_revision
+    }
+
+    pub(crate) fn scroll_view(&mut self, rows: isize) -> bool {
+        let changed = scroll_screen(self.parser.screen_mut(), rows);
+        if changed {
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
+        changed
+    }
+
+    pub(crate) fn reset_view(&mut self) -> bool {
+        let screen = self.parser.screen_mut();
+        let changed = screen.scrollback() > 0;
+        screen.set_scrollback(0);
+        if changed {
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
+        changed
+    }
+
+    pub(crate) fn process_output(&mut self, bytes: &[u8]) -> String {
+        self.update_cwd_from_osc7(bytes);
+        self.parser.process(bytes);
+        let plain = plain_terminal_text(bytes);
+        self.append_plain_output(&plain);
+        self.screen_revision = self.screen_revision.wrapping_add(1);
+        self.output_activity.record_output(Instant::now());
+        plain
+    }
+
+    pub(crate) fn output_quiet(&self) -> bool {
+        self.output_activity.is_quiet()
+    }
+
+    pub(crate) fn refresh_output_activity(&mut self, now: Instant, quiet_after: Duration) -> bool {
+        self.output_activity.refresh(now, quiet_after)
+    }
+
+    pub(crate) fn record_input(&mut self, bytes: &[u8]) {
+        self.record_input_activity(bytes);
+        record_input_bytes(bytes, &mut self.pending_input, &mut self.input_history);
+    }
+
+    pub(crate) fn record_input_activity(&mut self, bytes: &[u8]) {
+        advance_input_revision(&mut self.input_revision, bytes);
+    }
+
+    pub(crate) fn input_revision(&self) -> u64 {
+        self.input_revision
+    }
+
+    pub(crate) fn input_history(&self) -> &[String] {
+        &self.input_history
+    }
+
+    pub(crate) fn output_tail(&self) -> &str {
+        &self.output_tail
+    }
+
+    pub(crate) fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
+        self.output_tail = output_tail.to_string();
+        trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
+        self.output_tail_chars = self.output_tail.chars().count();
+        self.input_history = input_history
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .rev()
+            .take(MAX_INPUT_HISTORY)
+            .cloned()
+            .collect::<Vec<_>>();
+        self.input_history.reverse();
+
+        let replay = history_replay_text(&self.output_tail, &self.input_history);
+        if !replay.is_empty() {
+            self.parser.process(replay.as_bytes());
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
+    }
+
+    pub(crate) fn resize_view(&mut self, rows: u16, cols: u16) -> bool {
+        if self.rows == rows && self.cols == cols {
+            return false;
+        }
+        self.parser.screen_mut().set_size(rows, cols);
+        self.rows = rows;
+        self.cols = cols;
+        self.screen_revision = self.screen_revision.wrapping_add(1);
+        true
+    }
+
+    fn update_cwd_from_osc7(&mut self, bytes: &[u8]) {
+        if self.osc_scan_tail.is_empty() && !bytes.contains(&0x1b) {
+            return;
+        }
+        let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
+        scan.extend_from_slice(&self.osc_scan_tail);
+        scan.extend_from_slice(bytes);
+
+        for payload in osc_payloads(&scan) {
+            if let Some(path) = cwd_from_osc7_payload(payload) {
+                self.cwd = path;
+            }
+        }
+
+        self.osc_scan_tail = incomplete_osc_tail(&scan);
+    }
+
+    fn append_plain_output(&mut self, plain: &str) {
+        if plain.is_empty() {
+            return;
+        }
+
+        self.output_tail.push_str(plain);
+        self.output_tail_chars += plain.chars().count();
+        if self.output_tail_chars > OUTPUT_TAIL_TRIM_AT_CHARS {
+            trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
+            self.output_tail_chars = self.output_tail.chars().count();
+        }
+    }
+}
+
+#[allow(dead_code)]
 impl PtyPane {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
@@ -332,19 +493,7 @@ impl PtyPane {
             writer,
             workload,
             workload_error,
-            parser: Parser::new(24, 80, scrollback_rows.clamp(1_000, 50_000)),
-            screen_revision: 0,
-            cwd: cwd.to_path_buf(),
-            rows: 24,
-            cols: 80,
-            response_scan_tail: Vec::new(),
-            output_activity: OutputActivity::default(),
-            osc_scan_tail: Vec::new(),
-            input_history: Vec::new(),
-            pending_input: String::new(),
-            input_revision: 0,
-            output_tail: String::new(),
-            output_tail_chars: 0,
+            view: PtyView::new(cwd.to_path_buf(), scrollback_rows),
             active: false,
             exited: false,
             child_reaped: false,
@@ -362,49 +511,34 @@ impl PtyPane {
     }
 
     pub fn cwd(&self) -> &Path {
-        &self.cwd
+        self.view.cwd()
     }
 
     pub fn screen(&self) -> &Screen {
-        self.parser.screen()
+        self.view.screen()
     }
 
     pub fn screen_revision(&self) -> u64 {
-        self.screen_revision
+        self.view.screen_revision()
     }
 
     pub fn scroll_view(&mut self, rows: isize) -> bool {
-        let changed = scroll_screen(self.parser.screen_mut(), rows);
-        if changed {
-            self.screen_revision = self.screen_revision.wrapping_add(1);
-        }
-        changed
+        self.view.scroll_view(rows)
     }
 
     pub fn reset_view(&mut self) -> bool {
-        let screen = self.parser.screen_mut();
-        let changed = screen.scrollback() > 0;
-        screen.set_scrollback(0);
-        if changed {
-            self.screen_revision = self.screen_revision.wrapping_add(1);
-        }
-        changed
+        self.view.reset_view()
     }
 
     pub fn process_output(&mut self, bytes: &[u8]) -> String {
-        self.update_cwd_from_osc7(bytes);
-        self.parser.process(bytes);
-        let plain = plain_terminal_text(bytes);
-        self.append_plain_output(&plain);
+        let plain = self.view.process_output(bytes);
         self.active = true;
-        self.screen_revision = self.screen_revision.wrapping_add(1);
-        self.output_activity.record_output(Instant::now());
         self.answer_terminal_queries(bytes);
         plain
     }
 
     pub fn output_quiet(&self) -> bool {
-        !self.exited && self.output_activity.is_quiet()
+        !self.exited && self.view.output_quiet()
     }
 
     pub fn refresh_output_activity(&mut self, now: Instant, quiet_after: Duration) -> bool {
@@ -412,48 +546,32 @@ impl PtyPane {
             return false;
         }
 
-        self.output_activity.refresh(now, quiet_after)
+        self.view.refresh_output_activity(now, quiet_after)
     }
 
     pub fn record_input(&mut self, bytes: &[u8]) {
-        self.record_input_activity(bytes);
-        record_input_bytes(bytes, &mut self.pending_input, &mut self.input_history);
+        self.view.record_input(bytes);
     }
 
     pub fn record_input_activity(&mut self, bytes: &[u8]) {
-        advance_input_revision(&mut self.input_revision, bytes);
+        self.view.record_input_activity(bytes);
     }
 
     pub fn input_revision(&self) -> u64 {
-        self.input_revision
+        self.view.input_revision()
     }
 
     pub fn input_history(&self) -> &[String] {
-        &self.input_history
+        self.view.input_history()
     }
 
     pub fn output_tail(&self) -> &str {
-        &self.output_tail
+        self.view.output_tail()
     }
 
     pub fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
-        self.output_tail = output_tail.to_string();
-        trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
-        self.output_tail_chars = self.output_tail.chars().count();
-        self.input_history = input_history
-            .iter()
-            .filter(|line| !line.trim().is_empty())
-            .rev()
-            .take(MAX_INPUT_HISTORY)
-            .cloned()
-            .collect::<Vec<_>>();
-        self.input_history.reverse();
-
-        let replay = history_replay_text(&self.output_tail, &self.input_history);
-        if !replay.is_empty() {
-            self.parser.process(replay.as_bytes());
-            self.screen_revision = self.screen_revision.wrapping_add(1);
-        }
+        self.view
+            .restore_history_display(output_tail, input_history);
     }
 
     pub fn write(&self, bytes: &[u8]) -> Result<()> {
@@ -486,11 +604,10 @@ impl PtyPane {
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
-        if self.rows == rows && self.cols == cols {
+        if !self.view.resize_view(rows, cols) {
             return Ok(());
         }
 
-        self.parser.screen_mut().set_size(rows, cols);
         self.master
             .resize(PtySize {
                 rows,
@@ -499,9 +616,6 @@ impl PtyPane {
                 pixel_height: 0,
             })
             .context("failed to resize PTY")?;
-        self.rows = rows;
-        self.cols = cols;
-        self.screen_revision = self.screen_revision.wrapping_add(1);
         Ok(())
     }
 
@@ -518,11 +632,11 @@ impl PtyPane {
     }
 
     fn answer_terminal_queries(&mut self, bytes: &[u8]) {
-        if self.response_scan_tail.is_empty() && !bytes.contains(&0x1b) {
+        if self.view.response_scan_tail.is_empty() && !bytes.contains(&0x1b) {
             return;
         }
-        let mut scan = Vec::with_capacity(self.response_scan_tail.len() + bytes.len());
-        scan.extend_from_slice(&self.response_scan_tail);
+        let mut scan = Vec::with_capacity(self.view.response_scan_tail.len() + bytes.len());
+        scan.extend_from_slice(&self.view.response_scan_tail);
         scan.extend_from_slice(bytes);
 
         if contains_sequence(&scan, DEVICE_STATUS_QUERY) {
@@ -531,7 +645,7 @@ impl PtyPane {
 
         let cursor_position_requests = count_sequence(&scan, CURSOR_POSITION_QUERY);
         if cursor_position_requests > 0 {
-            let (row, column) = self.parser.screen().cursor_position();
+            let (row, column) = self.view.parser.screen().cursor_position();
             let response = format!(
                 "\x1b[{};{}R",
                 row.saturating_add(1),
@@ -548,24 +662,7 @@ impl PtyPane {
             let _ = self.write(b"\x1b[?1;2c");
         }
 
-        self.response_scan_tail = terminal_query_scan_tail(&scan);
-    }
-
-    fn update_cwd_from_osc7(&mut self, bytes: &[u8]) {
-        if self.osc_scan_tail.is_empty() && !bytes.contains(&0x1b) {
-            return;
-        }
-        let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
-        scan.extend_from_slice(&self.osc_scan_tail);
-        scan.extend_from_slice(bytes);
-
-        for payload in osc_payloads(&scan) {
-            if let Some(path) = cwd_from_osc7_payload(payload) {
-                self.cwd = path;
-            }
-        }
-
-        self.osc_scan_tail = incomplete_osc_tail(&scan);
+        self.view.response_scan_tail = terminal_query_scan_tail(&scan);
     }
 
     pub fn terminate(&mut self) {
@@ -616,19 +713,6 @@ impl PtyPane {
                 return false;
             }
             thread::sleep(CHILD_REAP_POLL_INTERVAL.min(deadline - now));
-        }
-    }
-
-    fn append_plain_output(&mut self, plain: &str) {
-        if plain.is_empty() {
-            return;
-        }
-
-        self.output_tail.push_str(plain);
-        self.output_tail_chars += plain.chars().count();
-        if self.output_tail_chars > OUTPUT_TAIL_TRIM_AT_CHARS {
-            trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
-            self.output_tail_chars = self.output_tail.chars().count();
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
+    fs::{self, OpenOptions},
     io::{self, Write},
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
@@ -10,12 +10,15 @@ use anyhow::{Context, Result, anyhow, bail};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+
 use crate::{
     auth::AgentKind,
     cli::ResumeArgs,
     layout::GridSize,
+    pane_host::{PtyHostRef, PtyPane},
     profiles::Profile,
-    pty::PtyPane,
     setup::{LaunchPlan, PaneLaunchSpec},
 };
 
@@ -34,9 +37,13 @@ pub struct SavedSession {
     pub id: String,
     pub started_at: u64,
     pub updated_at: u64,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub title: String,
     pub grid: SavedGrid,
     #[serde(default)]
     pub panes: Vec<SavedPane>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tabs: Vec<SavedTab>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -60,6 +67,16 @@ pub struct SavedPane {
     pub auth_kind: Option<AgentKind>,
     #[serde(default)]
     pub history: SavedPaneHistory,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<PtyHostRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedTab {
+    pub title: String,
+    pub grid: SavedGrid,
+    #[serde(default)]
+    pub panes: Vec<SavedPane>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -83,106 +100,167 @@ impl SessionRecord {
 
 impl SavedSession {
     pub fn launch_plan(&self) -> Result<LaunchPlan> {
-        let grid = GridSize::new(self.grid.rows, self.grid.columns).ok_or_else(|| {
-            anyhow!(
-                "saved session {} has invalid grid {}x{}",
-                self.id,
-                self.grid.rows,
-                self.grid.columns
-            )
-        })?;
-
-        let panes = self
-            .panes
-            .iter()
-            .map(|pane| PaneLaunchSpec {
-                profile_name: pane.profile_name.clone(),
-                command: pane.command.clone(),
-                env: BTreeMap::new(),
-                cwd: pane.cwd.clone(),
-                folder_name: pane.folder_name.clone(),
-                worktree_name: pane.worktree_name.clone(),
-                auth_name: pane.auth_name.clone(),
-                auth_kind: pane.auth_kind,
-                auth_dir: None,
-            })
-            .collect::<Vec<_>>();
-
-        if panes.is_empty() {
-            bail!("saved session {} has no panes", self.id);
-        }
-
-        Ok(LaunchPlan { panes, grid })
+        launch_plan_from_saved(&self.id, self.grid, &self.panes)
     }
 
     pub fn pane_histories(&self) -> Vec<SavedPaneHistory> {
         self.panes.iter().map(|pane| pane.history.clone()).collect()
     }
 
-    fn new(id: String, plan: &LaunchPlan) -> Self {
+    pub fn pane_hosts(&self) -> Vec<Option<PtyHostRef>> {
+        self.panes.iter().map(|pane| pane.host.clone()).collect()
+    }
+
+    fn new(id: String, title: &str, plan: &LaunchPlan) -> Self {
         let now = now_seconds();
         Self {
             version: SESSION_VERSION,
             id,
             started_at: now,
             updated_at: now,
+            title: title.to_string(),
             grid: plan.grid.into(),
             panes: plan
                 .panes
                 .iter()
                 .enumerate()
-                .map(|(index, spec)| SavedPane::from_spec(index, spec, SavedPaneHistory::default()))
+                .map(|(index, spec)| {
+                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None)
+                })
                 .collect(),
+            tabs: Vec::new(),
         }
     }
 
-    fn update_from_live(&mut self, plan: &LaunchPlan, panes: &[PtyPane]) {
+    fn update_from_live(
+        &mut self,
+        title: &str,
+        plan: &LaunchPlan,
+        panes: &[PtyPane],
+        tabs: Vec<SavedTab>,
+    ) {
         self.version = SESSION_VERSION;
         self.updated_at = now_seconds();
+        self.title = title.to_string();
         self.grid = plan.grid.into();
-        self.panes = plan
-            .panes
-            .iter()
-            .enumerate()
-            .map(|(index, spec)| {
-                let history = panes
-                    .get(index)
-                    .map(SavedPaneHistory::from_pane)
-                    .unwrap_or_default();
-                SavedPane::from_spec(index, spec, history)
-            })
-            .collect();
+        self.panes = saved_panes_from_live(plan, panes);
+        self.tabs = tabs;
     }
 
     fn summary(&self) -> String {
+        let panes = self
+            .panes
+            .iter()
+            .chain(self.tabs.iter().flat_map(|tab| tab.panes.iter()))
+            .collect::<Vec<_>>();
         let folders = compact_labels(
-            self.panes
+            panes
                 .iter()
                 .map(|pane| pane.folder_name.as_str())
                 .filter(|name| !name.is_empty()),
         );
         let profiles = compact_labels(
-            self.panes
+            panes
                 .iter()
                 .map(|pane| pane.profile_name.as_str())
                 .filter(|name| !name.is_empty()),
         );
+        let pane_count = panes.len();
+        let tab_suffix = (!self.tabs.is_empty()).then(|| {
+            let tab_count = self.tabs.len() + 1;
+            format!(" / {tab_count} tabs")
+        });
 
         format!(
-            "{} | {}x{} | {} pane{} | {} | {}",
+            "{} | {}x{} | {} pane{}{} | {} | {}",
             age_label(self.updated_at),
             self.grid.rows,
             self.grid.columns,
-            self.panes.len(),
-            if self.panes.len() == 1 { "" } else { "s" },
+            pane_count,
+            if pane_count == 1 { "" } else { "s" },
+            tab_suffix.unwrap_or_default(),
             folders.unwrap_or_else(|| "unknown folders".into()),
             profiles.unwrap_or_else(|| "unknown profiles".into())
         )
     }
 }
 
+impl SavedTab {
+    pub fn from_live(title: &str, plan: &LaunchPlan, panes: &[PtyPane]) -> Self {
+        Self {
+            title: title.to_string(),
+            grid: plan.grid.into(),
+            panes: saved_panes_from_live(plan, panes),
+        }
+    }
+
+    pub fn launch_plan(&self) -> Result<LaunchPlan> {
+        launch_plan_from_saved(&self.title, self.grid, &self.panes)
+    }
+
+    pub fn pane_histories(&self) -> Vec<SavedPaneHistory> {
+        self.panes.iter().map(|pane| pane.history.clone()).collect()
+    }
+
+    pub fn pane_hosts(&self) -> Vec<Option<PtyHostRef>> {
+        self.panes.iter().map(|pane| pane.host.clone()).collect()
+    }
+}
+
+fn launch_plan_from_saved(
+    id: &str,
+    saved_grid: SavedGrid,
+    panes: &[SavedPane],
+) -> Result<LaunchPlan> {
+    let grid = GridSize::new(saved_grid.rows, saved_grid.columns).ok_or_else(|| {
+        anyhow!(
+            "saved session {id} has invalid grid {}x{}",
+            saved_grid.rows,
+            saved_grid.columns
+        )
+    })?;
+    let panes = panes
+        .iter()
+        .map(|pane| PaneLaunchSpec {
+            profile_name: pane.profile_name.clone(),
+            command: pane.command.clone(),
+            env: BTreeMap::new(),
+            cwd: pane.cwd.clone(),
+            folder_name: pane.folder_name.clone(),
+            worktree_name: pane.worktree_name.clone(),
+            auth_name: pane.auth_name.clone(),
+            auth_kind: pane.auth_kind,
+            auth_dir: None,
+        })
+        .collect::<Vec<_>>();
+    if panes.is_empty() {
+        bail!("saved session {id} has no panes");
+    }
+    Ok(LaunchPlan { panes, grid })
+}
+
+fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane> {
+    plan.panes
+        .iter()
+        .enumerate()
+        .map(|(index, spec)| {
+            let history = panes
+                .get(index)
+                .map(SavedPaneHistory::from_pane)
+                .unwrap_or_default();
+            let host = panes.get(index).map(PtyPane::host_ref);
+            SavedPane::from_spec(index, spec, history, host)
+        })
+        .collect()
+}
+
 impl SavedPane {
-    fn from_spec(index: usize, spec: &PaneLaunchSpec, history: SavedPaneHistory) -> Self {
+    fn from_spec(
+        index: usize,
+        spec: &PaneLaunchSpec,
+        history: SavedPaneHistory,
+        host: Option<PtyHostRef>,
+    ) -> Self {
         Self {
             index,
             profile_name: spec.profile_name.clone(),
@@ -193,6 +271,7 @@ impl SavedPane {
             auth_name: spec.auth_name.clone(),
             auth_kind: spec.auth_kind,
             history,
+            host,
         }
     }
 }
@@ -216,12 +295,12 @@ impl From<GridSize> for SavedGrid {
 }
 
 impl SessionRecorder {
-    pub fn start_new(plan: &LaunchPlan) -> Result<Self> {
+    pub fn start_new(title: &str, plan: &LaunchPlan) -> Result<Self> {
         let id = new_session_id();
         let path = session_file_path(&id)?;
         let recorder = Self {
             path,
-            session: SavedSession::new(id, plan),
+            session: SavedSession::new(id, title, plan),
         };
         recorder.save()?;
         prune_old_sessions()?;
@@ -235,19 +314,25 @@ impl SessionRecorder {
         }
     }
 
-    pub fn update(&mut self, plan: &LaunchPlan, panes: &[PtyPane]) {
-        self.session.update_from_live(plan, panes);
+    pub fn update(
+        &mut self,
+        title: &str,
+        plan: &LaunchPlan,
+        panes: &[PtyPane],
+        tabs: Vec<SavedTab>,
+    ) {
+        self.session.update_from_live(title, plan, panes, tabs);
     }
 
     pub fn save(&self) -> Result<()> {
         if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
+            create_private_dir_all(parent).with_context(|| {
                 format!("failed to create session directory {}", parent.display())
             })?;
         }
 
         let raw = toml::to_string_pretty(&self.session).context("failed to serialize session")?;
-        fs::write(&self.path, raw)
+        write_private_file(&self.path, raw.as_bytes())
             .with_context(|| format!("failed to write session {}", self.path.display()))
     }
 }
@@ -392,6 +477,30 @@ fn sessions_dir() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("failed to resolve GridBash session directory"))
 }
 
+fn create_private_dir_all(path: &std::path::Path) -> io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    builder.mode(0o700);
+    builder.create(path)?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.flush()?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
 fn session_file_path(id: &str) -> Result<PathBuf> {
     Ok(sessions_dir()?.join(format!("{id}.toml")))
 }
@@ -474,7 +583,7 @@ mod tests {
         plan.panes[0].auth_name = Some("codex-2".into());
         plan.panes[0].auth_kind = Some(AgentKind::Codex);
 
-        let session = SavedSession::new("test".into(), &plan);
+        let session = SavedSession::new("test".into(), "Grid 1", &plan);
         let restored = session.launch_plan().expect("launch plan");
 
         assert_eq!(restored.grid, grid);
@@ -492,6 +601,7 @@ mod tests {
             id: "test".into(),
             started_at: now_seconds(),
             updated_at: now_seconds(),
+            title: "Grid 1".into(),
             grid: SavedGrid {
                 rows: 2,
                 columns: 2,
@@ -501,6 +611,7 @@ mod tests {
                 pane("two", "codex"),
                 pane("one", "claude"),
             ],
+            tabs: Vec::new(),
         };
 
         let summary = session.summary();
@@ -509,6 +620,50 @@ mod tests {
         assert!(summary.contains("3 panes"));
         assert!(summary.contains("one, two"));
         assert!(summary.contains("claude, codex"));
+    }
+
+    #[test]
+    fn saved_session_round_trips_background_tabs() {
+        let mut background_pane = pane("background", "cmd");
+        background_pane.host = Some(PtyHostRef {
+            endpoint: "127.0.0.1:32123".into(),
+            token: "secret".into(),
+        });
+        let mut session = SavedSession {
+            version: SESSION_VERSION,
+            id: "test".into(),
+            started_at: now_seconds(),
+            updated_at: now_seconds(),
+            title: "Grid 1".into(),
+            grid: SavedGrid {
+                rows: 1,
+                columns: 1,
+            },
+            panes: vec![pane("active", "cmd")],
+            tabs: vec![SavedTab {
+                title: "Long build".into(),
+                grid: SavedGrid {
+                    rows: 1,
+                    columns: 1,
+                },
+                panes: vec![background_pane],
+            }],
+        };
+
+        let raw = toml::to_string(&session).expect("serialize session");
+        session = toml::from_str(&raw).expect("parse session");
+
+        assert_eq!(session.tabs.len(), 1);
+        assert_eq!(session.tabs[0].title, "Long build");
+        assert!(session.tabs[0].panes[0].host.is_some());
+        assert_eq!(
+            session.tabs[0]
+                .launch_plan()
+                .expect("tab launch plan")
+                .panes
+                .len(),
+            1
+        );
     }
 
     fn pane(folder_name: &str, profile_name: &str) -> SavedPane {
@@ -527,6 +682,7 @@ mod tests {
             auth_name: None,
             auth_kind: None,
             history: SavedPaneHistory::default(),
+            host: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- add an opt-in **Keep terminals running** workflow setting
- move pane PTY ownership into authenticated detached local hosts
- persist host references for `gridbash resume`, including inactive tabs
- safely reject busy, incompatible, or unauthorized reattachments so GridBash never starts duplicate work

## Validation

- `cargo clippy --all-targets -- -D warnings` (passed before the final protocol-hardening patch)
- `cargo test --no-fail-fast` (171 passed, 1 ignored, before the final protocol-hardening patch)
- focused pane-host detach/reattach lifecycle test
- launcher, version, issue-labeler, review-agent, and star-history Node test scripts
- `git diff --cached --check`

Current-commit Rust validation is intentionally deferred to the automatic integration lease and combined-tree batch.

Closes #216