### PR TITLE
docs: build outreach and contributor funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Workflow ideas and community discussion
+    url: https://github.com/jasonsuhari/gridbash/discussions
+    about: Share workflows, ask open-ended questions, and develop ideas before they become scoped issues.
+  - name: Contributor-ready work
+    url: https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22
+    about: Browse accepted tasks where outside contributions are actively wanted.
   - name: Security vulnerability
     url: https://github.com/jasonsuhari/gridbash/security/policy
     about: Please report vulnerabilities privately through the security policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,23 @@ GridBash is a cross-platform Rust TUI. Changes affecting terminal behavior, proc
 
 Small fixes, documentation improvements, and focused tests can go straight to a pull request.
 
+## Find Work And Get Help
+
+The live issue lists are the source of truth:
+
+- [`good first issue`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+  is reserved for tasks with a narrow outcome, named file area, and no hidden
+  design decision.
+- [`help wanted`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+  identifies accepted work where outside experience would be useful.
+
+Comment on an issue before investing significant time so the maintainer can
+confirm that it is still available and help with orientation. Contributor
+questions are welcome in the issue or in
+[the new-contributor discussion](https://github.com/jasonsuhari/gridbash/discussions/257).
+Expect an initial maintainer response within one business day. If that does not
+happen, a polite follow-up is welcome.
+
 ## Development Setup
 
 Prerequisites:
@@ -98,6 +115,10 @@ Good first issues usually involve:
 - Tests around parsing, layout, profile resolution, or configuration.
 - Clear terminal profile detection improvements.
 - Small UI state or copy fixes that do not change core PTY behavior.
+
+Non-code contributions are also useful: reproduce platform-specific behavior,
+test a pull request on a terminal the maintainer does not have, improve an
+example, record a workflow, or turn a confusing setup step into clearer docs.
 
 Please coordinate first before working on:
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ grid without juggling terminal windows.
 [Releases](https://github.com/jasonsuhari/gridbash/releases) |
 [Full reference](docs/REFERENCE.md)
 
-[![GridBash running six CLI coding agents in one terminal grid](https://raw.githubusercontent.com/jasonsuhari/gridbash/main/docs/assets/gridbash-launch-teaser-poster.png)](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-launch-teaser.mp4)
+[![GridBash running six CLI coding agents in one terminal grid](https://raw.githubusercontent.com/jasonsuhari/gridbash/main/docs/assets/gridbash-openvid-demo-poster.png)](https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-openvid-demo.mp4)
 
 ## Quick start
 
-Requires Node.js 18+. Published binaries support Windows x64, glibc-based Linux
-x64/arm64, and macOS 13+ on Apple Silicon or Intel.
+Requires Node.js 18+. GridBash releases Windows x64, glibc-based Linux
+x64/arm64, and macOS 13+ binaries for Apple Silicon and Intel.
 
 ```sh
 npm install -g gridbash
@@ -35,6 +35,9 @@ gridbash 2x3 --profile codex
 ```
 
 The npm package installs only the native binary for your current platform.
+The npm badge shows the version currently available from the registry. If it
+temporarily trails the [latest GitHub release](https://github.com/jasonsuhari/gridbash/releases/latest),
+use that release's matching native artifact until npm publication catches up.
 
 ## Why GridBash
 
@@ -141,11 +144,28 @@ packed copy instead of linking the command to a worktree.
 
 Release maintainers should follow [docs/RELEASING.md](docs/RELEASING.md).
 
+## Community
+
+- Share your current setup in the
+  [multi-agent workflow discussion](https://github.com/jasonsuhari/gridbash/discussions/256).
+- Start with a
+  [`good first issue`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+  or an issue marked
+  [`help wanted`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22).
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and DCO
+  guidance.
+- Introduce yourself in the
+  [new-contributor discussion](https://github.com/jasonsuhari/gridbash/discussions/257)
+  if you want help choosing a task.
+- See the [user and contributor growth playbook](docs/OUTREACH.md) if you want
+  to help demonstrate GridBash, welcome testers, or recruit contributors.
+
 ## Project links
 
 - [User reference](docs/REFERENCE.md)
 - [Roadmap](docs/ROADMAP.md)
 - [Devlogs](docs/devlogs/)
+- [Outreach playbook](docs/OUTREACH.md)
 - [Support](SUPPORT.md)
 - [Contributing](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)

--- a/docs/COMMUNITY_SETUP.md
+++ b/docs/COMMUNITY_SETUP.md
@@ -1,179 +1,103 @@
-# Community Setup Notes
+# Community Operations
 
-This document records the contribution infrastructure added to GridBash, plus the live GitHub settings and follow-up maintainer actions.
+This document records how GridBash keeps contribution infrastructure healthy.
+Live repository settings and issue lists are the source of truth; avoid copying
+issue numbers or release status into this file because they become stale.
 
-## Research Basis
+## Public Community Surfaces
 
-The setup follows GitHub's community health model: a public repository is easier to evaluate when it has visible README, license, contributing, code of conduct, support, security, and issue template files in supported locations.
+- `README.md` explains the product, supported platforms, quick start, and ways
+  to participate.
+- `CONTRIBUTING.md` covers development setup, validation, issue selection, pull
+  requests, and DCO sign-offs.
+- `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `SUPPORT.md` route conduct, private
+  vulnerability reports, and usage questions.
+- GitHub Discussions holds workflow examples, open-ended questions, and early
+  design conversations.
+- GitHub Issues holds reproducible bugs and accepted, scoped work.
+- [`OUTREACH.md`](OUTREACH.md) defines the user and contributor growth loop.
 
-GitHub surfaces `CONTRIBUTING.md` when people open issues or pull requests, and also shows it in repository navigation. Issue and pull request templates reduce maintainer back-and-forth by asking for the details reviewers need before the conversation starts.
+The repository description should lead with the current product:
 
-For contribution rights, this repo starts with DCO sign-offs because they are lightweight and familiar in open source. A separate CLA is kept as an optional template because CLAs can be useful for organizations, but they add more contributor friction and should be reviewed before enforcement.
+```text
+Cross-platform terminal workspace for running CLI coding agents side by side.
+```
 
-## What Is Now In The Repository
+Useful topics include `rust`, `tui`, `terminal`, `multiplexer`,
+`developer-tools`, `ai-agents`, `coding-agents`, `codex`, `claude`, `gemini`,
+`ratatui`, `pty`, `worktrees`, `windows`, `linux`, and `macos`.
 
-- `CONTRIBUTING.md` for contributor onboarding, setup, validation, issue guidance, pull request expectations, and DCO instructions.
-- `CODE_OF_CONDUCT.md` for community expectations and enforcement.
-- `SECURITY.md` for private vulnerability reporting.
-- `SUPPORT.md` for usage help routing.
-- `GOVERNANCE.md` for maintainer-led project governance.
-- `DCO.md` plus `.github/workflows/dco.yml` to require commit sign-offs on pull requests.
-- `CLA.md` as a CLA template if separate CLA enforcement is later needed.
-- `.github/ISSUE_TEMPLATE/` issue forms for bugs, features, and questions.
-- `.github/pull_request_template.md` for consistent review context.
-- `.github/CODEOWNERS` to route reviews to the maintainer when branch protection is enabled.
-- `docs/assets/gridbash-social-preview.png` as the repository social preview source asset.
+## Conversation Routing
 
-## GitHub Repository Settings
+- **Discussion:** workflow questions, show and tell, polls, and ideas that still
+  need discovery.
+- **Issue:** a concrete bug, accepted feature, documentation change, test, or
+  maintenance task.
+- **Pull request:** an implementation with a reviewable outcome.
+- **Private report:** a security vulnerability as described in `SECURITY.md`.
 
-Configured values:
-
-- Issues: enabled.
-- Projects: enabled.
-- Discussions: enabled.
-- Wiki: enabled.
-- Delete branch on merge: enabled.
-- Secret scanning: enabled.
-- Secret scanning push protection: enabled.
-- Description: `Windows-native terminal grids for running many CLI agents at once.`
-- Homepage: blank until npm metadata is corrected or a dedicated landing page exists.
-- Topics: `windows`, `rust`, `tui`, `terminal`, `multiplexer`, `cli`, `developer-tools`, `ai-agents`, `coding-agents`, `codex`, `claude`, `conpty`, `powershell`, `git-bash`, `ratatui`, `orchestration`, `npm-package`, `open-source`.
-
-Settings that still require browser or elevated-token access:
-
-- Upload `docs/assets/gridbash-social-preview.png` in Settings > General > Social preview.
-- Create the modern GitHub Project after refreshing the GitHub CLI token with `gh auth refresh --hostname github.com -s project,read:project`.
-- Enable private vulnerability reporting in Settings > Code security and analysis after `SECURITY.md` is on the default branch.
-- Protect `main` after the community files land:
-  - Require the `CI / windows` check.
-  - Require the `DCO / Signed-off-by` check.
-  - Require pull request review before merging.
-  - Require conversation resolution before merging.
-  - Block force pushes.
+When a Discussion reaches a concrete outcome, create an issue that captures the
+decision and links back to the conversation.
 
 ## Labels
 
-Default labels are preserved:
+Keep type, status, area, platform, and priority labels small enough to remain
+useful. Two labels are especially important for outside contributors:
 
-- `bug`
-- `documentation`
-- `duplicate`
-- `enhancement`
-- `good first issue`
-- `help wanted`
-- `invalid`
-- `question`
-- `wontfix`
+- `help wanted` means the task is accepted and outside contributions are
+  actively welcome.
+- `good first issue` is a stricter subset with a narrow outcome, named file
+  area, focused validation, and no hidden architecture decision.
 
-Additional labels:
+Do not label a broad roadmap idea as a good first issue merely to attract help.
+Keep three to five contributor-ready issues active and remove the labels when a
+task becomes stale, blocked, assigned, or underspecified.
 
-- `priority:p0`, `priority:p1`, `priority:p2`, `priority:p3`
-- `status:needs-triage`, `status:accepted`, `status:blocked`, `status:needs-repro`
-- `area:pty`, `area:tui`, `area:profiles`, `area:composer`, `area:config`, `area:packaging`, `area:docs`, `area:architecture`
-- `platform:windows`
-- `type:test`, `type:design`, `type:maintenance`
+## Contributor-Ready Issue Checklist
 
-New issues are classified by `.github/workflows/issue-labeler.yml`. The
-automation adds only missing type, triage-status, area, and Windows-platform
-labels; priorities and resolution labels remain maintainer decisions.
+Every promoted issue should include:
 
-## Milestones
+- the user or maintainer problem;
+- one concrete outcome;
+- the likely files or modules involved;
+- acceptance checks;
+- the narrowest useful validation command;
+- expected size or complexity;
+- a clear invitation to comment for orientation.
 
-- `v0.2 Nostromo`: public launch polish.
-- `v0.3 Nebuchadnezzar`: agent orchestration workflows.
-- `v0.4 Holodeck`: TUI/runtime experience.
-- `v1.0 Zion`: stable Windows release.
-- `v2.0 Morpheus`: daemon and reattach architecture.
+The maintainer should acknowledge contributor questions and claims within one
+business day, confirm scope before substantial work begins, and distinguish
+required review changes from optional follow-up ideas.
 
-Milestones intentionally have no due dates.
+## Contribution Rights
 
-## Starter Issues
+GridBash uses DCO sign-offs for routine contributions. `CLA.md` is an inactive
+template, not an additional current requirement. Do not require both a DCO and
+a separate CLA without a clear legal reason.
 
-- `#1 docs: add screenshot and quick-start flow to README`
-- `#2 chore: publish current npm package metadata under this repo`
-- `#3 docs: add release checklist for Windows binary and npm tarball`
-- `#4 test: verify first-run onboarding on clean Windows profile`
-- `#5 feat: improve profile detection diagnostics`
-- `#6 feat: polish startup picker controls`
-- `#7 test: add startup picker preview coverage`
-- `#8 feat: persist settings screen controls`
-- `#9 feat: add in-app help and legend overlay`
-- `#10 docs: define v1.0 acceptance checklist`
-- `#11 design: outline daemon detach and reattach architecture`
+## Repository Settings Audit
 
-## Project Setup
+Review these settings after major GitHub or release-workflow changes:
 
-Create a modern GitHub Project named `GridBash Roadmap` after the token has Project scopes:
+- Issues and Discussions are enabled.
+- The repository homepage and social preview are current.
+- Delete-branch-on-merge is enabled.
+- Secret scanning and push protection are enabled where available.
+- `main` blocks force pushes and requires the current CI and DCO checks.
+- Required check names match the current cross-platform CI matrix.
+- Private vulnerability reporting is enabled.
 
-```powershell
-gh auth refresh --hostname github.com -s project,read:project
-gh project create --owner jasonsuhari --title "GridBash Roadmap"
-```
+Do not preserve old required-check names such as a Windows-only CI job after the
+workflow becomes cross-platform.
 
-Add fields:
+## Monthly Maintenance
 
-- `Priority`: `P0`, `P1`, `P2`, `P3`
-- `Release`: `v0.2 Nostromo`, `v0.3 Nebuchadnezzar`, `v0.4 Holodeck`, `v1.0 Zion`, `v2.0 Morpheus`
-- `Area`: `Docs`, `Packaging`, `TUI`, `PTY`, `Profiles`, `Composer`, `Config`, `Architecture`
-- `Size`: `S`, `M`, `L`
+Once per month:
 
-Recommended views:
-
-- `Roadmap`
-- `Board by Status`
-- `Table by Release`
-- `Good First Issues`
-
-Add issues `#1` through `#11` to the project.
-
-## Community Surfaces
-
-- Discussions are enabled.
-- The seed discussion is `Welcome to the GridBash roadmap`.
-- Wiki is enabled. If `gridbash.wiki.git` does not exist yet, create the first page in the GitHub UI, then push a Home page that links to README, Contributing, Roadmap, Issues, Discussions, and the Project.
-
-## Branch Protection
-
-After this branch is merged, protect `main`:
-
-```text
-Require pull request before merging
-Require approvals: 1
-Require conversation resolution before merging
-Require status checks: CI / windows, DCO / Signed-off-by
-Block force pushes
-```
-
-## Social Preview
-
-Upload `docs/assets/gridbash-social-preview.png` in repository Settings > General > Social preview.
-
-The source asset is 1280x640 PNG and intentionally avoids third-party logos or copyrighted characters.
-
-## Private Vulnerability Reporting
-
-After `SECURITY.md` reaches the default branch, enable private vulnerability reporting in Settings > Code security and analysis.
-
-## CLA Activation
-
-GridBash currently uses DCO sign-offs because they are lighter for contributors than a separate CLA.
-
-If a separate CLA becomes necessary:
-
-1. Have qualified counsel review `CLA.md`.
-2. Publish the final CLA text somewhere stable, such as a GitHub Gist used only for the CLA.
-3. Link the repository or organization to a CLA tool such as CLA Assistant.
-4. Add the CLA status check to branch protection.
-5. Update `CONTRIBUTING.md` and `.github/pull_request_template.md` to state that CLA signing is mandatory.
-
-Do not require both DCO and a CLA unless there is a clear legal reason. That adds friction for new contributors.
-
-## Good First Issue Practice
-
-A good first issue should have:
-
-- A single clear outcome.
-- Reproduction steps or an exact file area.
-- A suggested validation command.
-- No hidden product decision.
-- No expected knowledge of GridBash internals beyond the files named in the issue.
+1. Review `good first issue` and `help wanted` for stale or blocked work.
+2. Check unanswered Discussions and contributor questions.
+3. Confirm README, website, roadmap, and launch copy agree on platforms and
+   installation status.
+4. Recognize merged outside contributions in release notes.
+5. Review the campaign log in [`OUTREACH.md`](OUTREACH.md) and continue only the
+   channels producing activated users, useful feedback, or contributors.

--- a/docs/LAUNCH_KIT.md
+++ b/docs/LAUNCH_KIT.md
@@ -1,223 +1,138 @@
 # GridBash Launch Kit
 
-This is the reusable publication kit for GridBash. Copy should be adapted to
-the conversation and community instead of posted everywhere verbatim.
+Use this kit only after the publication gate in [`OUTREACH.md`](OUTREACH.md)
+passes. Adapt the copy to the community; do not post the same announcement
+everywhere verbatim.
 
 ## Positioning
 
 ### One-line pitch
 
-GridBash is a Windows-native Rust terminal grid for running Codex, Claude,
-Gemini, and other CLI coding agents side by side.
+GridBash is a cross-platform terminal workspace for running CLI coding agents
+side by side.
 
 ### Short pitch
 
-GridBash puts real PTY-backed agent sessions into one selectable terminal grid.
-Run agents in parallel, send a prompt to one pane or selected panes, and give
-each pane its own git worktree when the jobs need isolation.
+GridBash puts real PTY-backed Codex, Claude, Gemini, Aider, OpenCode, Goose,
+Amp, Cursor, Copilot, shell, and custom-command sessions into one selectable
+grid. Route a prompt to one pane or a selected set, and give parallel jobs
+isolated repo-local git worktrees.
 
 ### Proof points
 
-- One-command install: `npm install -g gridbash`
-- Real Windows ConPTY sessions rather than simulated output
-- Up to 100 panes in one process
-- Input routing to one, selected, or all panes
-- Optional repo-local git worktree per pane
-- Built-in profiles for Codex, Claude, Gemini, Aider, OpenCode, Goose, Amp,
-  Cursor, and Copilot
-- Open source under the MIT License
+- Windows x64, Linux x64/arm64, and macOS arm64/x64 release artifacts.
+- Real PTYs rather than simulated agent output.
+- Up to 100 panes across tabbed grids.
+- Focused, selected-pane, and grid-wide input routing.
+- Optional repo-local git worktree per pane.
+- MIT licensed and implemented in Rust.
 
-### Honest constraint
+### Honest constraints
 
-The published v0.1.6 package is Windows x64. V1 is intentionally single-process;
-closing GridBash closes its child agents.
+- GridBash is single-process today; closing it closes its child agents.
+- Session resume relaunches panes with saved context. It does not reattach live
+  processes or replay commands.
+- macOS artifacts may show Gatekeeper warnings until signing and notarization
+  are configured.
 
-## Links and assets
+## Publication Gate
+
+Immediately before publishing:
+
+```sh
+npm view gridbash version
+```
+
+Compare that value with the latest stable GitHub release and verify the exact
+install command on the advertised platform. If npm trails GitHub because of a
+registry incident, pause broad promotion and use the matching GitHub artifact
+only for direct, clearly labeled testing outreach.
+
+## Links And Assets
 
 - Repository: https://github.com/jasonsuhari/gridbash
 - Website: https://jasonsuhari.github.io/gridbash/
 - npm: https://www.npmjs.com/package/gridbash
-- Launch teaser: https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-launch-teaser.mp4
-- Teaser poster: `docs/assets/gridbash-launch-teaser-poster.png`
-- Product walkthrough: https://github.com/jasonsuhari/gridbash/blob/main/docs/assets/gridbash-openvid-demo.mp4
+- Releases: https://github.com/jasonsuhari/gridbash/releases/latest
+- Current product walkthrough: `docs/assets/gridbash-openvid-demo.mp4`
+- Walkthrough poster: `docs/assets/gridbash-openvid-demo-poster.png`
 - Social preview: `docs/assets/gridbash-social-preview.png`
+
+The older launch teaser ends with a Windows-only card and should not be used for
+current cross-platform outreach.
+
+## Primary Workflow Demo
+
+Show one implementation/review/test loop:
+
+1. Launch three Codex panes with worktree isolation.
+2. Give one pane an implementation task.
+3. Give a second pane a review task.
+4. Give a third pane the focused test or documentation task.
+5. Show selected-pane follow-up routing.
+6. End on the resulting workflow, not a feature list.
+
+Recommended command after the publication gate passes:
+
+```sh
+npm install -g gridbash
+gridbash 1x3 --profile codex --worktrees
+```
 
 ## Show HN
 
 ### Title
 
 ```text
-Show HN: GridBash – run multiple CLI coding agents in one Windows terminal grid
+Show HN: GridBash – run CLI coding agents in one selectable terminal workspace
 ```
 
 ### First comment
 
 ```text
-I kept ending up with six terminal windows while comparing Codex, Claude, and
-Gemini or running agents against separate tasks. I built GridBash, a Rust TUI
-that puts real PTY sessions into one terminal grid and lets me send input to
-one, several, or every pane.
+I kept ending up with a pile of terminal windows while one coding agent
+implemented, another reviewed, and a third ran tests. I built GridBash, a Rust
+TUI that keeps real PTY sessions in one grid and lets me decide exactly which
+panes receive each prompt.
 
-The workflow I care about most is parallel agent work without accidental
-cross-pane input. A pane can also start in its own repo-local git worktree, so
-implementation, review, tests, and docs can run in isolation while remaining
-visible together.
+The workflow I care about most is parallel work without accidental cross-pane
+input. GridBash can also start every pane in a separate repo-local git
+worktree, so implementation, review, tests, and docs stay isolated while they
+remain visible together.
 
-It is open source and Windows x64 for now:
-
-    npm install -g gridbash
-    gridbash 2x3 --profile codex --worktrees
-
-I would especially appreciate feedback on the input-routing model and what you
-would expect from detach/reattach support.
-```
-
-Submit the repository URL, remain available to answer questions, and do not ask
-people to upvote or seed comments.
-
-## Reddit
-
-Read the current rules of each subreddit before posting. Use only the version
-that matches the community and stay in the thread to answer questions.
-
-### r/rust
-
-**Title**
-
-```text
-I built a Rust TUI for running multiple coding-agent PTYs in one Windows terminal
-```
-
-**Body**
-
-```text
-I wanted one terminal surface for several CLI coding agents without hiding the
-process behind a web dashboard. GridBash uses Ratatui plus Windows ConPTY-backed
-sessions, routes input to one or selected panes, and can start every pane in a
-separate git worktree.
-
-The tricky parts were keeping redraws cheap with many live panes, containing
-mouse selection inside a pane, and making normal terminal input coexist with
-modeless routing shortcuts.
-
-The project is MIT licensed and installable with `npm install -g gridbash` on
-Windows x64. Source and a 13-second demo:
-https://github.com/jasonsuhari/gridbash
-
-I would love feedback on the terminal architecture and where the Rust side
-could be simplified.
-```
-
-### r/commandline
-
-**Title**
-
-```text
-GridBash: one selectable terminal grid for Codex, Claude, Gemini, and other CLI agents
-```
-
-**Body**
-
-```text
-I built GridBash because parallel coding-agent work kept turning into a pile of
-terminal windows. It runs real PTY sessions in one grid, lets you select exactly
-which panes receive a command, and can isolate panes in repo-local git worktrees.
-
-Quickstart on Windows x64:
+It runs on Windows, Linux, and macOS and is MIT licensed:
 
     npm install -g gridbash
-    gridbash 2x3 --profile codex --worktrees
+    gridbash 1x3 --profile codex --worktrees
 
-Demo and source: https://github.com/jasonsuhari/gridbash
+Source and demo: https://github.com/jasonsuhari/gridbash
 
-I am most interested in feedback from people already using tmux, Windows
-Terminal, or several CLI agents at once. What would make this fit your workflow?
+I would especially value feedback on the selected-pane routing model and what
+you would need before trusting it with a daily multi-agent workflow.
 ```
 
-### Agent-specific communities
+Submit the repository URL, remain available for the first several hours, and
+never ask people to upvote or seed comments.
 
-**Title template**
+## Social Posts
+
+Upload the walkthrough video natively. Each post should demonstrate one
+workflow and ask one question.
+
+### X Or Bluesky
 
 ```text
-I built a terminal grid for running multiple <AGENT> sessions in parallel worktrees
-```
+Running an implementation agent, a reviewer, and a test agent used to mean
+three terminal windows.
 
-**Body template**
+GridBash keeps their real CLI sessions in one terminal workspace, routes a
+prompt only to the panes I select, and can put every job in its own git
+worktree.
 
-```text
-I often run one <AGENT> session for implementation, another for review, and a
-third for tests or docs. GridBash keeps those real CLI sessions visible in one
-terminal grid and lets me route prompts only to the selected panes.
-
-The built-in <AGENT> profile launches a grid directly, and `--worktrees` gives
-each pane an isolated checkout:
-
-    gridbash 2x3 --profile <PROFILE> --worktrees
-
-It is MIT licensed and currently ships for Windows x64:
+Open source for Windows, Linux, and macOS:
 https://github.com/jasonsuhari/gridbash
 
-If you use multiple <AGENT> sessions, I would value feedback on the selection
-and worktree workflow.
-```
-
-## Product Hunt
-
-### Name
-
-```text
-GridBash
-```
-
-### Tagline
-
-```text
-Run every CLI coding agent in one terminal grid
-```
-
-### Description
-
-```text
-A Windows-native Rust TUI for running Codex, Claude, Gemini, Aider, and other
-CLI agents side by side. Route prompts to selected panes and isolate parallel
-jobs with repo-local git worktrees.
-```
-
-### First comment
-
-```text
-I built GridBash after parallel coding-agent work turned my desktop into a pile
-of terminals. I wanted the sessions to stay real and visible, but I also wanted
-one reliable way to decide which agents receive each prompt.
-
-GridBash runs PTY-backed sessions in a selectable grid. You can focus one pane,
-select several, broadcast when appropriate, and start each pane in its own git
-worktree. It is open source, MIT licensed, and available for Windows x64 through
-npm.
-
-I am here all day and would love blunt feedback, especially from developers who
-already run several CLI agents at once.
-```
-
-Suggested topics: Developer Tools, Open Source, Artificial Intelligence.
-
-## Social posts
-
-Attach `gridbash-launch-teaser.mp4` directly instead of relying on a link
-preview. Put the repository link in the post or first reply according to the
-platform's current link treatment.
-
-### X / Bluesky
-
-```text
-Running six coding agents used to mean six terminal windows.
-
-So I built GridBash: a Windows-native Rust TUI for running Codex, Claude,
-Gemini, Aider, and other CLI agents in one selectable terminal grid.
-
-Each pane can even get its own git worktree.
-
-Open source: https://github.com/jasonsuhari/gridbash
+Where does your multi-agent terminal workflow break down?
 ```
 
 ### LinkedIn
@@ -225,113 +140,191 @@ Open source: https://github.com/jasonsuhari/gridbash
 ```text
 I built the terminal workflow I wanted for parallel coding agents.
 
-GridBash runs Codex, Claude, Gemini, Aider, and other CLI tools in one real
-PTY-backed grid. I can route a prompt to one pane or selected panes, keep every
-session visible, and isolate parallel jobs in repo-local git worktrees.
+GridBash keeps Codex, Claude, Gemini, Aider, and other real CLI sessions in one
+selectable workspace. I can route a prompt to one pane or a chosen set, keep
+every session visible, and isolate parallel jobs in repo-local git worktrees.
 
-It is a Rust TUI, MIT licensed, and currently available for Windows x64:
+It is a cross-platform Rust TUI and is open source under the MIT License:
 https://github.com/jasonsuhari/gridbash
 
-The most useful feedback now is from developers already juggling multiple agent
-sessions: where does your workflow break down?
+I am looking for developers who already run several agent sessions. Which
+setup, visibility, or safety problem should I test next?
 ```
 
-### Short Discord post
+## Agent-Specific Communities
+
+Use the terminology and exact profile for that community.
 
 ```text
-I made GridBash, an open-source Windows terminal grid for running multiple CLI
-coding agents side by side. It supports selected-pane input and optional git
-worktree isolation. Demo + source: https://github.com/jasonsuhari/gridbash
+I often run one <AGENT> session for implementation, another for review, and a
+third for tests or docs. GridBash keeps those real sessions visible in one
+terminal workspace and routes follow-ups only to the selected panes.
+
+Each pane can also start in an isolated git worktree:
+
+    gridbash 1x3 --profile <PROFILE> --worktrees
+
+It is MIT licensed and runs on Windows, Linux, and macOS:
+https://github.com/jasonsuhari/gridbash
+
+If you already run multiple <AGENT> sessions, I would value feedback on the
+selection and worktree workflow.
 ```
 
-## Technical article outline
+Read current community rules first. Prefer a native demo and useful workflow
+explanation over a bare repository link.
 
-The complete publication draft lives at
+## Rust And Terminal Communities
+
+Do not lead with a generic AI-tool announcement. Teach the implementation:
+
+```text
+I built a cross-platform Rust TUI that hosts many real PTYs in one process. The
+hard parts were containing mouse selection within a pane, keeping modeless
+input routing predictable, and redrawing many live terminals without turning
+the UI into a dashboard abstraction.
+
+The implementation uses Ratatui and portable-pty, with repo-local git
+worktrees as the isolation boundary for parallel coding-agent jobs.
+
+Architecture, demo, and source:
+https://github.com/jasonsuhari/gridbash
+
+I would value technical feedback on <ONE SPECIFIC AREA>.
+```
+
+The longer article lives at
 [`docs/articles/building-a-windows-pty-grid-in-rust.md`](articles/building-a-windows-pty-grid-in-rust.md).
+Update its title in a future editorial pass if the article is expanded from its
+Windows/ConPTY origin story into the complete cross-platform architecture.
 
-**Title:** Building a Windows PTY grid for coding agents in Rust
+## Contributor Recruitment
 
-1. Why multiple coding agents create a terminal coordination problem
-2. Why GridBash preserves real PTYs instead of wrapping agents behind an API
-3. ConPTY lifecycle and terminal emulation constraints
-4. Routing ordinary input without introducing modal friction
-5. Pane-local mouse selection and redraw performance
-6. Git worktrees as the isolation boundary for parallel agents
-7. What V1 deliberately does not solve: daemon detach/reattach
-8. Architecture diagram, performance numbers, install command, and repository
+Keep three to five issues genuinely ready before recruiting.
 
-The article should teach the terminal lessons first and mention GridBash as the
-working implementation rather than reading like an advertisement.
+### This Week In Rust Project Update
 
-## Response bank
+```text
+GridBash is a cross-platform Rust TUI for running CLI coding agents in a
+selectable PTY grid, with optional git-worktree isolation. The current focus is
+first-run reliability, terminal compatibility, and managed multi-agent
+workflows. Source and contributor guide:
+https://github.com/jasonsuhari/gridbash
+```
 
-### “Why not tmux?”
+### Call For Participation
+
+```text
+GridBash – <ISSUE TITLE>: <ONE-SENTENCE OUTCOME>. The issue names the relevant
+files, acceptance checks, and focused validation command. Maintainer
+orientation is available: <ISSUE URL>
+```
+
+### Direct Contributor Invitation
+
+```text
+You mentioned an interest in <RUST/TUI/TERMINAL AREA>. GridBash has a scoped
+issue in that area with the likely files and validation written down:
+<ISSUE URL>
+
+No pressure to take it, but I am happy to provide orientation if the task is a
+fit.
+```
+
+## Product Hunt
+
+Use Product Hunt only after the project has several activated users, reliable
+installation, and at least one concrete user story.
+
+Name:
+
+```text
+GridBash
+```
+
+Tagline:
+
+```text
+Run CLI coding agents in one terminal workspace
+```
+
+Description:
+
+```text
+A cross-platform Rust TUI for running Codex, Claude, Gemini, Aider, and other
+CLI agents side by side. Route prompts to selected panes and isolate parallel
+jobs with repo-local git worktrees.
+```
+
+Suggested topics: Developer Tools, Open Source, Artificial Intelligence.
+
+## Response Bank
+
+### Why not tmux?
 
 ```text
 tmux is excellent. GridBash is narrower: it is built around selecting agent
-panes, routing the same input safely, launching common agent profiles, and
-creating repo-local worktrees. If tmux already fits your workflow, keep it.
+panes, routing the same input intentionally, launching common agent profiles,
+and creating repo-local worktrees. If tmux already fits your workflow, keep it.
 ```
 
-### “Why Windows only?”
+### Is this an agent framework?
 
 ```text
-The published package started with Windows because ConPTY workflows were the
-gap I personally had. Cross-platform packaging is active work, but I do not
-want to claim a platform until a release artifact is actually available.
+It is terminal-level orchestration, not a replacement agent protocol. GridBash
+launches and routes input among independent CLI agents while preserving their
+native interfaces.
 ```
 
-### “Is this really multi-agent orchestration?”
+### Does closing it kill the agents?
 
 ```text
-It is terminal-level orchestration, not an agent framework. GridBash launches
-and routes input among independent CLI agents; it does not hide their native
-interfaces or invent a shared agent protocol.
+Yes. GridBash is intentionally single-process today, so closing it closes its
+children. Daemon-backed detach and reattach is the next major architecture
+boundary.
 ```
 
-### “Does closing it kill the agents?”
+### Which platforms are supported?
 
 ```text
-Yes in V1. GridBash is intentionally single-process today, so closing it closes
-its children. Daemon-backed detach/reattach is the major next frontier.
+GridBash builds native artifacts for Windows x64, Linux x64/arm64, and macOS
+arm64/x64. Check the latest GitHub release and npm version badge before
+installing; the registry can temporarily trail a GitHub release.
 ```
 
-## Publication sequence
+## Publication Sequence
 
-Do not dump every post on the same day. A practical sequence:
+Do not publish every item on the same day:
 
-1. Publish Show HN and stay available for the first several hours.
-2. Post the technical Rust version the next day if it complies with current
-   subreddit rules.
-3. Post the workflow version to command-line and agent-specific communities on
-   separate days.
-4. Publish the short video to social accounts with native upload.
-5. Publish the technical article and submit it as a normal HN story, not a
-   second Show HN.
-6. Schedule Product Hunt for a day when the maker can answer comments throughout
-   the Pacific-time launch window.
+1. Clear the publication gate and invite a small set of direct testers.
+2. Publish one native workflow video on the strongest existing social channel.
+3. Run Show HN and remain available to answer questions.
+4. Publish the technical Rust or terminal article.
+5. Submit one contributor task to This Week in Rust.
+6. Share a user-driven fix or outside contribution.
+7. Consider Product Hunt only after installation and retention evidence are
+   strong.
 
 ## Tracking
 
-Use source-specific links when analytics are needed:
+Use source-specific links when useful:
 
 ```text
-https://jasonsuhari.github.io/gridbash/?utm_source=hackernews&utm_medium=community&utm_campaign=launch
-https://jasonsuhari.github.io/gridbash/?utm_source=reddit&utm_medium=community&utm_campaign=launch
-https://jasonsuhari.github.io/gridbash/?utm_source=producthunt&utm_medium=launch&utm_campaign=launch
-https://jasonsuhari.github.io/gridbash/?utm_source=linkedin&utm_medium=social&utm_campaign=launch
+https://jasonsuhari.github.io/gridbash/?utm_source=hackernews&utm_medium=community&utm_campaign=workflow-launch
+https://jasonsuhari.github.io/gridbash/?utm_source=linkedin&utm_medium=social&utm_campaign=workflow-launch
+https://jasonsuhari.github.io/gridbash/?utm_source=thisweekinrust&utm_medium=community&utm_campaign=contributors
 ```
 
-GitHub stars are a lagging signal. Track qualified questions, successful
-installs, npm downloads, issue quality, returning contributors, and which
-message caused people to try the product.
+Record trials, activations, returning users, useful conversations, issues
+claimed, and merged outside pull requests in the campaign log described in
+[`OUTREACH.md`](OUTREACH.md).
 
-## Before every post
+## Before Every Post
 
-- Confirm the install command against the current published release.
-- Confirm the advertised platforms against actual downloadable artifacts.
+- Clear the publication gate.
 - Read the community's current self-promotion rules.
-- Upload the video natively when possible.
-- Use a title that states what was built, not “Please support my project.”
+- Show one workflow rather than a feature montage.
+- Upload video natively where possible.
+- State current limitations plainly.
 - Ask for product or architecture feedback, never coordinated votes.
 - Be ready to answer questions and ship small fixes while attention is active.

--- a/docs/OUTREACH.md
+++ b/docs/OUTREACH.md
@@ -1,0 +1,221 @@
+# GridBash User and Contributor Growth Playbook
+
+This is the operating playbook for growing GridBash without turning the project
+into a stream of generic launch posts. The goal is to help the right developers
+try a real workflow, learn from them quickly, and make useful contributions
+approachable.
+
+## Thirty-Day Outcomes
+
+The first growth milestone is a small, active community:
+
+- 20 people who launch a real GridBash agent grid.
+- 8 direct conversations about first-use friction.
+- 5 people who report using GridBash more than once.
+- 3 outside contributors who claim an issue.
+- 2 merged pull requests from outside contributors.
+- A first maintainer response to contributor questions within one business day.
+
+Stars, page views, downloads, and clones are useful reach signals, but they are
+not activation or retention. npm downloads and repository clones can also
+include automation.
+
+An **activated user** has launched at least a two-pane agent grid and used
+focused or selected-pane input. A **returning user** reports using GridBash in a
+second work session. Until the project has a justified, privacy-preserving
+analytics design, measure both through conversations, Discussions, and a small
+campaign log instead of adding product telemetry.
+
+## Positioning
+
+Lead with the workflow rather than the implementation:
+
+> GridBash is a managed terminal workspace for developers running multiple CLI
+> coding agents. Keep every session visible, route prompts intentionally, and
+> isolate parallel work in git worktrees.
+
+For contributors:
+
+> Help build a cross-platform Rust PTY and TUI at the intersection of terminals,
+> developer tooling, and multi-agent workflows.
+
+The playful `tokenmaxx` line can follow the concrete description. Technical and
+professional audiences should understand the product before encountering the
+in-joke.
+
+## Audiences
+
+### Agent power users
+
+Developers already running two or more Codex, Claude, Gemini, Aider, OpenCode,
+Goose, Amp, Cursor, or Copilot CLI sessions. Show implementation/review/test
+loops, comparisons, and worktree isolation.
+
+### Terminal and Rust builders
+
+People interested in PTYs, terminal emulation, Ratatui, process lifecycle,
+cross-platform packaging, and developer tools. Lead with technical lessons and
+specific contribution tasks rather than AI marketing.
+
+### Adjacent maintainers and educators
+
+Maintainers of agent CLIs, terminal tools, developer newsletters, meetups, and
+technical channels. Offer a useful integration example, technical write-up, or
+demo. Do not ask for an unearned endorsement.
+
+## Publication Gate
+
+Do not direct broad traffic into a broken installation path. Before each public
+campaign:
+
+1. Confirm the `main` CI badge is green.
+2. Compare `npm view gridbash version` with the latest stable GitHub release.
+3. Confirm every advertised platform has an artifact in that release.
+4. Smoke-test the exact install and first-run commands used in the post.
+5. Open every destination link in a signed-out browser session.
+
+If npm temporarily trails the GitHub release, say so plainly, link testers to
+the matching GitHub artifacts, and postpone broad launch posts. Do not create
+new tags or repeated releases just to work around a registry incident.
+
+## The Growth Loop
+
+```text
+useful proof -> targeted trial -> first-use conversation -> small fix
+     ^                                                   |
+     +--------- user story or contributor task <--------+
+```
+
+Every post or message should have one audience, one demonstrated workflow, and
+one request. Good requests include:
+
+- “Try this two-pane workflow and tell me where setup becomes unclear.”
+- “What information would you need before trusting worktree isolation?”
+- “This test task is scoped and mentored; comment if you want to take it.”
+
+“Please support the project” and “please star this” do not produce useful
+learning.
+
+## Channel Plan
+
+| Channel | Primary job | Best material | Call to action |
+| --- | --- | --- | --- |
+| X and LinkedIn | Recruit first users | Native 10–20 second workflow video | Try one exact command |
+| Show HN | Reach technical early adopters | Personal build story plus runnable project | Critique routing and isolation |
+| This Week in Rust | Find Rust users and contributors | Tooling update and one mentored task | Claim the linked issue |
+| Agent communities | Reach existing multi-agent users | Agent-specific recipe | Share current workflow friction |
+| Rust and terminal communities | Build technical credibility | PTY, rendering, or worktree article | Review the design or code |
+| Product Hunt | Broader awareness after proof | Polished demo and user evidence | Try the stable release |
+
+Read each community's current rules before posting. Adapt the explanation to the
+community instead of copying the same announcement everywhere.
+
+## Weekly Cadence
+
+- **Monday — proof:** publish one short, outcome-first workflow clip.
+- **Tuesday — conversations:** invite up to five relevant people to a focused
+  trial and follow up with active testers.
+- **Wednesday — depth:** publish one technical lesson, devlog, or architecture
+  note that stands on its own.
+- **Thursday — contribution:** highlight one contributor-ready task and offer
+  orientation.
+- **Friday — learning:** record source, conversations, activations, recurring
+  friction, issues claimed, and changes shipped.
+
+One strong artifact can be adapted for several channels over a week. Do not
+publish every variation on the same day.
+
+## Ethical Outbound
+
+Start with people who have publicly discussed multi-agent CLI workflows or have
+already engaged with GridBash. Send at most ten well-researched invitations per
+week. Do not scrape addresses, bulk-message stargazers, automate replies, or ask
+for coordinated votes.
+
+User trial invitation:
+
+```text
+I saw your post about running multiple <AGENT> sessions. I am building
+GridBash, a terminal workspace that keeps those sessions visible and can put
+each one in its own git worktree.
+
+Would you be willing to try one 10-minute workflow? I am looking for setup and
+input-routing friction, not a promotional post. The exact command is:
+
+    gridbash 2x2 --profile <PROFILE> --worktrees
+
+If it is not relevant to your workflow, no reply needed.
+```
+
+Maintainer or educator invitation:
+
+```text
+I maintain GridBash, an MIT-licensed Rust terminal workspace for parallel CLI
+agents. I wrote a practical explanation of <TECHNICAL TOPIC> while building it.
+It may fit your audience because <SPECIFIC REASON>.
+
+Here is the article/demo: <LINK>. No expectation to share it; technical
+corrections would be genuinely useful.
+```
+
+## Contributor Funnel
+
+Keep three to five issues actively ready for outside contributors. Each should
+have `help wanted`; reserve `good first issue` for tasks that truly require no
+hidden architecture or product decision.
+
+Every promoted task needs:
+
+- one clear outcome and a short explanation of why it matters;
+- the likely files or modules involved;
+- acceptance checks and an exact focused validation command;
+- size or expected scope;
+- a note that the maintainer will help with orientation;
+- no unresolved design decision disguised as implementation work.
+
+Contributor response practice:
+
+1. Acknowledge a claim or question within one business day.
+2. Confirm scope before the contributor invests significant work.
+3. Keep review feedback specific and separate required changes from ideas.
+4. Credit contributors in release notes and the next relevant announcement.
+5. Invite a second contribution only after the first experience is complete.
+
+Use GitHub Discussions for open-ended workflow and design questions. Convert a
+discussion into an issue only after the outcome is concrete enough to build.
+
+Suggested recurring prompts:
+
+- “What does your multi-agent terminal workflow look like today?”
+- “Which GridBash setup step was hardest on your OS and terminal?”
+- “New contributors: which part of PTY, TUI, packaging, or docs interests you?”
+
+The current seed conversations are the
+[multi-agent workflow discussion](https://github.com/jasonsuhari/gridbash/discussions/256)
+and the
+[new-contributor introduction](https://github.com/jasonsuhari/gridbash/discussions/257).
+
+## First Campaign
+
+1. Clear the publication gate and make the current platform story consistent.
+2. Demonstrate an implementation/review/test loop in three isolated worktrees.
+3. Invite ten relevant developers to try that exact workflow.
+4. Publish the same proof natively on X and LinkedIn on separate days.
+5. Run Show HN only after the install path is healthy and remain available to
+   answer questions.
+6. Submit one technical project update and one mentored issue to This Week in
+   Rust.
+7. Ship the most common first-use fix and publish what changed because of user
+   feedback.
+
+## Campaign Log
+
+Record one row per meaningful activity. Keep personal contact details out of the
+repository.
+
+| Date | Source | Artifact or conversation | Trials | Activations | Returning users | Issues claimed | Learning or action |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| YYYY-MM-DD | example | workflow demo | 0 | 0 | 0 | 0 | Replace with result |
+
+Review the log weekly. Continue a channel when it produces activated users,
+useful conversations, or contributors—not merely impressions.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -91,6 +91,37 @@ If the whole workflow needs to be dispatched again for an exact version whose
 tag already exists, the prepare job skips version preparation and publishes the
 existing tag.
 
+### Registry Publication Incident
+
+When GitHub artifacts exist but npm publication is delayed or blocked by the
+registry:
+
+1. Treat npm as unavailable for the affected version or platform. Do not claim
+   that `npm install -g gridbash` delivers the GitHub release until it does.
+2. Keep the existing release tag immutable. Do not create replacement tags or
+   bump versions solely to retry an external registry incident.
+3. Put a temporary, factual notice in the website or launch material and pause
+   broad promotion. Direct testers may use matching GitHub release artifacts.
+4. Record the failing workflow URL and the external support case privately;
+   never put credentials or private support correspondence in the repository.
+5. After npm confirms resolution, rerun the existing exact-version workflow or
+   failed publish job. The publish step is intentionally idempotent and skips
+   package versions that are already live.
+6. Verify the root launcher and every native package before clearing the notice:
+
+   ```sh
+   npm view gridbash version
+   npm view gridbash-win32-x64 version
+   npm view gridbash-linux-x64 version
+   npm view gridbash-linux-arm64 version
+   npm view gridbash-darwin-arm64 version
+   npm view gridbash-darwin-x64 version
+   ```
+
+The GitHub release succeeding does not make a failed npm publish workflow green.
+Keep the failure visible until the registry-side work is complete; do not weaken
+release checks to improve the status signal.
+
 ### Nightlies
 
 The same `Release` workflow runs daily from `main` and supports a manual
@@ -106,7 +137,7 @@ Install the rolling channel with:
 npm install --global gridbash@nightly
 ```
 
-Cross-platform preview releases use npm's `next` channel instead:
+Prerelease builds use npm's `next` channel instead:
 
 ```sh
 npm install --global gridbash@next

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,26 +1,64 @@
 # Roadmap
 
-## V1
+GridBash is developed in public, but the roadmap describes direction rather
+than a promise of dates. Shipped behavior is documented in the
+[reference](REFERENCE.md), and accepted work is tracked in
+[GitHub Issues](https://github.com/jasonsuhari/gridbash/issues).
 
-- Windows-native single process.
-- Real PTY panes.
-- Mouse selection and selected multi-pane input.
-- Built-in CLI agent profiles.
-- Demo-ready dark theme.
-- Release as a single Windows x64 executable.
-- Stable-release gates are tracked in [`V1_ACCEPTANCE.md`](V1_ACCEPTANCE.md).
+## Shipped Foundation
 
-## V2
+- Real PTY-backed panes on Windows, Linux, and macOS.
+- Focused, selected-pane, and grid-wide input routing.
+- Agent and shell launch profiles.
+- Repo-local git worktree isolation.
+- Tabbed grids, resizing, zoom, session snapshots, and activity summaries.
+- Voice input and an opt-in local agent control API.
+- Cross-platform native artifacts for Windows x64, Linux x64/arm64, and macOS
+  arm64/x64.
 
-- Background daemon for detach/reattach.
-- Multi-client attach.
-- Agent status classifiers.
-- Plugin API.
-- The proposed process, protocol, persistence, and migration boundaries are in
+## Current: Managed Agent Workspace
+
+- Make commands and capabilities easier to discover.
+- Improve per-pane activity, auth, and workload controls.
+- Strengthen manager-driven implementation, review, test, and documentation
+  loops.
+- Improve first-run reliability and diagnostics across supported terminals.
+- Turn early user feedback into small, testable workflow improvements.
+- Grow a contributor path around scoped docs, tests, profiles, packaging, and
+  TUI behavior.
+
+## Stable V1
+
+- Meet the release gates in [`V1_ACCEPTANCE.md`](V1_ACCEPTANCE.md) on every
+  advertised platform.
+- Keep CLI, config, session, and worktree behavior compatible and documented.
+- Make release publication and installation dependable.
+- Document current single-process ownership clearly: closing GridBash closes
+  its child agents.
+
+## Daemon And Reattach
+
+- Background process ownership for detach and reattach.
+- Safe multi-client attachment.
+- Durable session and terminal state boundaries.
+- Authenticated local protocol and migration from the V1 process model.
+- The proposed boundaries are in
   [`DAEMON_ARCHITECTURE.md`](DAEMON_ARCHITECTURE.md).
 
-## V3
+## Later Exploration
 
-- Cross-platform PTY support.
-- Remote/SSH workspaces.
-- Web dashboard or recording mode for public demos.
+- Remote and SSH workspaces.
+- A stable plugin or extension boundary.
+- Recording and shareable workflow artifacts.
+- Optional browser-based monitoring where it improves, rather than replaces,
+  the native terminal workflow.
+
+## Participate
+
+Use [Discussions](https://github.com/jasonsuhari/gridbash/discussions) for
+open-ended workflow and roadmap questions. Use
+[`help wanted`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+and
+[`good first issue`](https://github.com/jasonsuhari/gridbash/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+to find accepted work. Larger behavior changes should be discussed before
+implementation.

--- a/docs/V1_ACCEPTANCE.md
+++ b/docs/V1_ACCEPTANCE.md
@@ -1,8 +1,8 @@
 # GridBash v1.0 Acceptance Checklist
 
-This checklist defines the minimum evidence required to call the Windows build
-of GridBash stable. A release candidate may ship before every box is checked,
-but the stable `v1.0.0` tag must not.
+This checklist defines the minimum evidence required to call the supported
+Windows, Linux, and macOS builds of GridBash stable. A release candidate may
+ship before every box is checked, but the stable `v1.0.0` tag must not.
 
 Record evidence beside each item in the release PR or linked test report. A
 passing check from an older commit does not qualify unless the release commit is
@@ -10,14 +10,16 @@ an ancestor of that tested commit and no relevant code changed afterward.
 
 ## Installation and launch
 
-- [ ] `npm install -g gridbash` succeeds for a clean Windows x64 user without a
-      Rust toolchain.
+- [ ] `npm install -g gridbash` succeeds without a Rust toolchain on clean
+      Windows x64, Linux x64/arm64, and macOS arm64/x64 machines.
 - [ ] `gridbash --version` reports the npm package version and launches the
       packaged native executable rather than a repository worktree.
-- [ ] First launch with no GridBash config discovers available Windows shells,
+- [ ] First launch with no GridBash config discovers available native shells,
       saves the chosen default, and uses it on the next launch.
 - [ ] PowerShell, PowerShell 7, cmd, and Git Bash invocation inheritance each
       select the expected pane shell unless an explicit profile overrides it.
+- [ ] zsh, bash, fish, sh, and PowerShell resolve consistently on supported
+      macOS and Linux machines when installed.
 - [ ] Paths containing spaces and non-ASCII characters work for installation,
       config, current directories, and managed worktrees.
 
@@ -25,8 +27,8 @@ an ancestor of that tested commit and no relevant code changed afterward.
 
 - [ ] A pane can launch, accept keyboard and pasted input, resize, produce ANSI
       output, report its cwd, and exit without corrupting sibling panes.
-- [ ] Closing GridBash terminates every owned child process tree without taskkill
-      success spam or orphaned descendants.
+- [ ] Closing GridBash terminates every owned child process tree without
+      platform command noise or orphaned descendants.
 - [ ] Restarting an exited pane preserves its profile, cwd, label, auth choice,
       and managed-worktree metadata.
 - [ ] A 10x10 grid can start and shut down cleanly; busy output does not make
@@ -38,7 +40,7 @@ an ancestor of that tested commit and no relevant code changed afterward.
 
 - [ ] `gridbash --list-profiles` clearly identifies available, missing, and
       selected profiles without exposing credentials or unnecessary user paths.
-- [ ] Built-in Windows profiles resolve expected executables, and a custom
+- [ ] Built-in platform profiles resolve expected executables, and a custom
       profile reports an actionable error when its executable is missing.
 - [ ] Config defaults remain backward compatible; unknown legacy tables do not
       prevent startup.
@@ -75,7 +77,7 @@ an ancestor of that tested commit and no relevant code changed afterward.
 - [ ] README install, quickstart, controls, config, profile, session, and local
       development instructions match the release candidate.
 - [ ] `--help`, example config, release documentation, and npm package contents
-      agree on supported Windows versions and profiles.
+      agree on supported operating systems, architectures, and profiles.
 - [ ] Security reporting, support, contribution, license, and code-of-conduct
       links are present and valid.
 - [ ] Known v1 limitations explicitly include single-process lifetime and the
@@ -85,14 +87,18 @@ an ancestor of that tested commit and no relevant code changed afterward.
 
 - [ ] `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`,
       `cargo test`, launcher tests, and a release build pass on the release commit.
-- [ ] CI builds and packs Windows x64 from a clean runner, and the produced npm
-      tarballs contain only the expected launcher, metadata, docs, and executable.
+- [ ] CI builds and packs Windows x64, Linux x64/arm64, and macOS arm64/x64 from
+      clean runners, and the produced npm tarballs contain only the expected
+      launcher, metadata, docs, and executables.
 - [ ] Native packages publish before the root launcher; exact versions match
       across Cargo, npm root, optional native package, tag, and GitHub release.
 - [ ] npm trusted publishing/provenance and the token fallback are tested or
       explicitly waived with a documented reason.
-- [ ] A clean-machine smoke test installs from the intended npm dist-tag, launches
-      a real pane, exercises input/resize/quit, and removes the package cleanly.
+- [ ] Clean-machine smoke tests on every advertised OS install from the intended
+      npm dist-tag, launch a real pane, exercise input/resize/quit, and remove
+      the package cleanly.
+- [ ] Stable macOS artifacts are signed and notarized, or the release notes and
+      install flow present an explicit, reviewed exception.
 
 ## Stability decision
 

--- a/docs/articles/building-a-windows-pty-grid-in-rust.md
+++ b/docs/articles/building-a-windows-pty-grid-in-rust.md
@@ -160,9 +160,12 @@ background-process trick.
 
 ## Try it
 
-The currently published package supports Windows x64:
+GridBash releases native builds for Windows x64, Linux x64/arm64, and macOS
+arm64/x64. Check the npm badge against the latest GitHub release before using
+the install command; if registry publication is temporarily behind, use the
+matching release artifact instead:
 
-```powershell
+```sh
 npm install -g gridbash
 gridbash 2x3 --profile codex --worktrees
 ```

--- a/docs/devlogs/2026-07-15-grow-the-gridbash-user-and-contributor-community.md
+++ b/docs/devlogs/2026-07-15-grow-the-gridbash-user-and-contributor-community.md
@@ -1,0 +1,51 @@
+# Grow the GridBash user and contributor community
+
+Date: 2026-07-15
+Release target: unreleased
+Tracking issue: [#240](https://github.com/jasonsuhari/gridbash/issues/240)
+
+## Summary
+
+- Replaced stale Windows-only launch and roadmap copy with the current
+  cross-platform product story.
+- Added an operating playbook for turning outreach into activated users,
+  useful feedback, and outside contributions.
+- Made contributor-ready issues, Discussions, and maintainer response
+  expectations easier to find from the README and issue chooser.
+
+## What Changed
+
+- Added `docs/OUTREACH.md` with audiences, a publication gate, a 30-day target,
+  channel strategy, ethical outbound templates, a contributor funnel, and a
+  lightweight campaign log.
+- Rebuilt the launch kit around current Windows, Linux, and macOS support and
+  stopped recommending the legacy Windows-only teaser for new campaigns.
+- Updated the website, README, Rust article, roadmap, community operations, and
+  v1 acceptance checklist so platform and installation claims agree.
+- Documented how to handle an npm registry incident without creating replacement
+  tags, weakening checks, or advertising a version the registry does not serve.
+- Added direct links to Discussions, `help wanted`, and `good first issue`, plus
+  a one-business-day initial response target for contributor questions.
+- Opened focused workflow and contributor-introduction Discussions and curated
+  five `help wanted` tasks, including two documentation-first starter issues.
+
+## Why It Matters
+
+- GridBash can now send prospective users to an honest installation path while
+  npm publication is being resolved externally.
+- Outreach has a measurable loop—trial, conversation, small fix, user story or
+  contributor task—instead of optimizing only for impressions or stars.
+- New contributors can tell where help is wanted, what makes a task genuinely
+  approachable, and how quickly they should expect orientation.
+
+## Validation
+
+- `cargo fmt --check` (passed before documentation edits; no Rust files changed)
+- Markdown and public-copy searches for stale platform claims
+- HTML link and structure checks
+- Full Rust validation deferred to the automatic integration batch under the
+  repository's shared validation lease
+
+## Release Notes
+
+- Community and documentation update; no runtime behavior changed.

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     <link rel="canonical" href="https://jasonsuhari.github.io/gridbash/">
     <link rel="me" href="https://github.com/jasonsuhari">
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%231a1c16'/%3E%3Crect x='6' y='6' width='8' height='8' rx='2' fill='%239bd66f'/%3E%3Crect x='18' y='6' width='8' height='8' rx='2' fill='%23577542'/%3E%3Crect x='6' y='18' width='8' height='8' rx='2' fill='%23577542'/%3E%3Crect x='18' y='18' width='8' height='8' rx='2' fill='%239bd66f'/%3E%3C/svg%3E">
-    <link rel="preload" as="image" href="assets/gridbash-launch-teaser-poster.png">
+    <link rel="preload" as="image" href="assets/gridbash-openvid-demo-poster.png">
 
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="GridBash">
@@ -88,7 +88,7 @@
             "name": "How do I install GridBash?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Install the stable Windows x64 package with npm install -g gridbash, or download the v0.2 cross-platform preview from GitHub Releases."
+              "text": "Install the currently published package with npm install -g gridbash, or download the matching Windows, Linux, or macOS artifact from the latest GitHub release."
             }
           }
         ]
@@ -1328,8 +1328,8 @@
         <nav class="nav-links" aria-label="Primary navigation">
           <a href="#why">Why GridBash</a>
           <a href="#features">Features</a>
-          <a href="https://www.npmjs.com/package/gridbash">npm stable</a>
-          <a class="nav-cta" href="https://github.com/jasonsuhari/gridbash"><span class="nav-cta__long">Star on GitHub</span><span class="nav-cta__short">GitHub</span></a>
+          <a href="https://www.npmjs.com/package/gridbash">npm package</a>
+          <a class="nav-cta" href="https://github.com/jasonsuhari/gridbash"><span class="nav-cta__long">View on GitHub</span><span class="nav-cta__short">GitHub</span></a>
         </nav>
       </div>
     </header>
@@ -1341,10 +1341,10 @@
           <h1 id="hero-title">Every agent.<br><span class="hero-accent">One terminal.</span></h1>
           <p class="hero-lead">Run your entire CLI agent stack side by side. Prompt one pane, selected panes, or all of them at once.</p>
           <div class="hero-actions">
-            <a class="button button--primary" href="https://www.npmjs.com/package/gridbash">Install stable (Windows) <span class="button__arrow" aria-hidden="true">→</span></a>
-            <a class="button" href="https://github.com/jasonsuhari/gridbash">Star on GitHub</a>
+            <a class="button button--primary" href="https://github.com/jasonsuhari/gridbash/releases/latest">View latest release <span class="button__arrow" aria-hidden="true">→</span></a>
+            <a class="button" href="https://github.com/jasonsuhari/gridbash">View on GitHub</a>
           </div>
-          <button class="install-command" type="button" data-copy="npm install -g gridbash" aria-label="Copy npm command for the Windows stable package">
+          <button class="install-command" type="button" data-copy="npm install -g gridbash" aria-label="Copy the GridBash npm install command">
             <code>npm install -g gridbash</code>
             <span class="install-command__status">Copy</span>
           </button>
@@ -1356,8 +1356,8 @@
               <span>gridbash 2x3 --profile codex</span>
               <span class="terminal-bar__keys">ALT + M</span>
             </div>
-            <video autoplay muted loop playsinline poster="assets/gridbash-launch-teaser-poster.png" aria-label="GridBash running six CLI coding agents in one terminal grid">
-              <source src="assets/gridbash-launch-teaser.mp4" type="video/mp4">
+            <video autoplay muted loop playsinline poster="assets/gridbash-openvid-demo-poster.png" aria-label="GridBash running six CLI coding agents in one terminal grid">
+              <source src="assets/gridbash-openvid-demo.mp4" type="video/mp4">
             </video>
           </div>
           <div class="visual-note">
@@ -1466,8 +1466,8 @@
               <span class="step__index">01</span>
               <div>
                 <h3>Choose your channel</h3>
-                <p>Windows stable is on npm. The cross-platform preview is on <a href="https://github.com/jasonsuhari/gridbash/releases/tag/v0.2.0-macos.1">GitHub Releases</a>.</p>
-                <code>stable 0.1.6 | preview 0.2.0-macos.1</code>
+                <p>The npm registry can temporarily trail a GitHub release. Check the current package version, or use the matching Windows, Linux, or macOS artifact from <a href="https://github.com/jasonsuhari/gridbash/releases/latest">GitHub Releases</a>.</p>
+                <code>npm version badge | latest release artifacts</code>
               </div>
             </article>
             <article class="step reveal">
@@ -1510,10 +1510,10 @@
         <div class="page final-cta__inner reveal">
           <p class="section-kicker">Your agent command center</p>
           <h2 id="final-title">Stop tab juggling.</h2>
-          <p>Install the Windows stable build, or grab the cross-platform preview from GitHub Releases.</p>
+          <p>Install the current npm package, or download the matching native artifact from the latest GitHub release if registry publication is still catching up.</p>
           <div class="final-actions">
-            <button class="button button--primary install-copy" type="button" data-copy="npm install -g gridbash">Copy npm install (Windows)</button>
-            <a class="button" href="https://github.com/jasonsuhari/gridbash">Star on GitHub <span class="button__arrow" aria-hidden="true">→</span></a>
+            <button class="button button--primary install-copy" type="button" data-copy="npm install -g gridbash">Copy npm install</button>
+            <a class="button" href="https://github.com/jasonsuhari/gridbash/blob/main/CONTRIBUTING.md">Contribute on GitHub <span class="button__arrow" aria-hidden="true">→</span></a>
           </div>
         </div>
       </section>
@@ -1522,7 +1522,9 @@
     <footer class="footer">
       <div class="page footer__inner">
         <span>GridBash by Jason Suhari. MIT licensed.</span>
-        <a href="https://www.npmjs.com/package/gridbash">npm stable v0.1.6</a>
+        <a href="https://www.npmjs.com/package/gridbash">npm package</a>
+        <a href="https://github.com/jasonsuhari/gridbash/discussions">Discussions</a>
+        <a href="https://github.com/jasonsuhari/gridbash/blob/main/CONTRIBUTING.md">Contribute</a>
         <a href="https://github.com/jasonsuhari/gridbash">GitHub</a>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

- add a 30-day user and contributor growth playbook with an ethical outbound loop, publication gate, channel plan, contributor funnel, and measurable outcomes
- align README, website, launch kit, roadmap, v1 acceptance, release incident guidance, and technical copy with the current cross-platform product
- make Discussions, `help wanted`, `good first issue`, and contributor orientation easier to find
- retire the Windows-only teaser from current promoted surfaces while preserving historical release and production notes

## GitHub community work

- tracking issue: #240
- cross-platform public-copy issue addressed: #168
- new starter issues: #254 and #255
- curated help-wanted issues: #170, #171, and #175
- workflow discussion: #256
- contributor introduction: #257

## Validation

- `git diff --cached --check`
- local Markdown-link resolution check for changed docs
- website local-asset resolution check
- website JSON-LD parse check
- active-copy search for unresolved placeholders, mojibake, and stale Windows-only/npm-version claims
- `cargo fmt --check` passed before the documentation edits; no Rust files changed
- full Rust validation is intentionally deferred to the automatic integration batch under the shared lease

## External blocker

npm publication of v0.2.0 is being resolved with npm. This change documents an honest incident path and does not create replacement tags, weaken checks, or claim that the registry already serves the GitHub release.