### PR TITLE
feat: deactivate panes and compact grid

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -163,7 +163,9 @@ Drag selection is contained to its source pane and copies through the standard O
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
 
-Pane Activity provides auth, rename, refresh, sleep/wake, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+o switches to overall settings.
+Pane Activity provides auth, rename, refresh, sleep/wake, deactivate, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `d` to deactivate, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+o switches to overall settings.
+
+Deactivating a pane ends its terminal process, compacts the remaining panes, and shrinks the grid whenever a smaller dimension can still hold them. Columns are removed before rows, so deactivating two panes from a `2x3` grid compacts it to `2x2`. The final pane cannot be deactivated.
 
 If the focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
 

--- a/docs/devlogs/2026-07-15-deactivate-panes-and-compact-the-grid.md
+++ b/docs/devlogs/2026-07-15-deactivate-panes-and-compact-the-grid.md
@@ -1,0 +1,35 @@
+# Deactivate panes and compact the grid
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added a focused-pane deactivation control that automatically compacts the
+  live grid.
+
+## What Changed
+
+- Added a Deactivate pane action and `d` shortcut to Pane Activity.
+- Removed deactivated pane processes and compacted pane-indexed state without
+  disturbing the remaining terminals.
+- Shrunk grid dimensions column-first whenever the remaining pane count fits;
+  a `2x3` grid with four panes now becomes `2x2`.
+- Kept the final pane protected so every tab retains a usable terminal.
+
+## Why It Matters
+
+- GridBash no longer leaves a hole where a pane was deactivated.
+- Dense grids reclaim screen space automatically instead of requiring a
+  separate resize pass.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- Focused pane compaction and settings UI tests
+- Full Rust test suite
+
+## Release Notes
+
+- Open Pane Activity with `Alt+p`, select Deactivate pane, and the remaining
+  panes immediately reflow into the smallest column-first layout that fits.

--- a/src/app.rs
+++ b/src/app.rs
@@ -132,6 +132,7 @@ pub struct App {
     pane_settings_rename_button: Option<Rect>,
     pane_settings_reload_button: Option<Rect>,
     pane_settings_sleep_button: Option<Rect>,
+    pane_settings_deactivate_button: Option<Rect>,
     pane_settings_goal_button: Option<Rect>,
     pane_settings_stop_goal_button: Option<Rect>,
     event_tx: mpsc::Sender<PtyEvent>,
@@ -775,17 +776,24 @@ pub enum PaneSettingsTarget {
     #[default]
     Reload,
     Sleep,
+    Deactivate,
     Goal,
     StopGoal,
 }
 
 impl PaneSettingsTarget {
     fn available(has_auth: bool, has_goal: bool) -> Vec<Self> {
-        let mut targets = Vec::with_capacity(6);
+        let mut targets = Vec::with_capacity(7);
         if has_auth {
             targets.push(Self::Auth);
         }
-        targets.extend([Self::Rename, Self::Reload, Self::Sleep, Self::Goal]);
+        targets.extend([
+            Self::Rename,
+            Self::Reload,
+            Self::Sleep,
+            Self::Deactivate,
+            Self::Goal,
+        ]);
         if has_goal {
             targets.push(Self::StopGoal);
         }
@@ -1994,6 +2002,7 @@ impl App {
             pane_settings_rename_button: None,
             pane_settings_reload_button: None,
             pane_settings_sleep_button: None,
+            pane_settings_deactivate_button: None,
             pane_settings_goal_button: None,
             pane_settings_stop_goal_button: None,
             event_tx,
@@ -2313,6 +2322,8 @@ impl App {
                     self.pane_settings_rename_button = draw_state.pane_settings_rename_button;
                     self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
                     self.pane_settings_sleep_button = draw_state.pane_settings_sleep_button;
+                    self.pane_settings_deactivate_button =
+                        draw_state.pane_settings_deactivate_button;
                     self.pane_settings_goal_button = draw_state.pane_settings_goal_button;
                     self.pane_settings_stop_goal_button = draw_state.pane_settings_stop_goal_button;
                 })?;
@@ -3691,6 +3702,12 @@ impl App {
             self.toggle_sleep_for_panes(&[pane_index]);
             return Ok(KeyOutcome::Render);
         }
+        if matches!(key.code, KeyCode::Char('d') | KeyCode::Char('D')) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Deactivate;
+            let pane_index = self.pane_settings.pane_index;
+            self.deactivate_pane(pane_index);
+            return Ok(KeyOutcome::Render);
+        }
         if matches!(key.code, KeyCode::Char('g') | KeyCode::Char('G')) {
             self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             let pane_index = self.pane_settings.pane_index;
@@ -3788,6 +3805,7 @@ impl App {
             PaneSettingsTarget::Rename => self.begin_rename_for(pane_index),
             PaneSettingsTarget::Reload => self.reload_pane_history(),
             PaneSettingsTarget::Sleep => self.toggle_sleep_for_panes(&[pane_index]),
+            PaneSettingsTarget::Deactivate => self.deactivate_pane(pane_index),
             PaneSettingsTarget::Goal => {
                 self.pane_settings.close();
                 self.open_goal_editor_for(pane_index);
@@ -4533,6 +4551,12 @@ impl App {
             self.toggle_sleep_for_panes(&[pane_index]);
             return true;
         }
+        if self.pane_settings_deactivate_button_at(mouse.column, mouse.row) {
+            self.pane_settings.selected_target = PaneSettingsTarget::Deactivate;
+            let pane_index = self.pane_settings.pane_index;
+            self.deactivate_pane(pane_index);
+            return true;
+        }
         if self.pane_settings_goal_button_at(mouse.column, mouse.row) {
             self.pane_settings.selected_target = PaneSettingsTarget::Goal;
             let pane_index = self.pane_settings.pane_index;
@@ -4583,6 +4607,11 @@ impl App {
 
     fn pane_settings_sleep_button_at(&self, x: u16, y: u16) -> bool {
         self.pane_settings_sleep_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn pane_settings_deactivate_button_at(&self, x: u16, y: u16) -> bool {
+        self.pane_settings_deactivate_button
             .is_some_and(|rect| rect_contains(rect, x, y))
     }
 
@@ -4864,6 +4893,90 @@ impl App {
         };
 
         Ok(())
+    }
+
+    fn deactivate_pane(&mut self, pane_index: usize) {
+        let before = self.panes.len();
+        if before <= 1 {
+            self.status = "the only pane cannot be deactivated".into();
+            return;
+        }
+        if pane_index >= before {
+            self.pane_settings.close();
+            self.status = format!("pane {} is no longer available", pane_index + 1);
+            return;
+        }
+
+        let current = self.layout.size();
+        let remaining = before - 1;
+        let next = current.compact_for_count(remaining);
+        let old_to_new = pane_index_map_after_removal(before, pane_index);
+        let removed_pane = self.panes.remove(pane_index);
+        let removed_id = removed_pane.id();
+
+        if pane_index < self.pane_idle.len() {
+            self.pane_idle.remove(pane_index);
+        }
+        if pane_index < self.pane_names.len() {
+            self.pane_names.remove(pane_index);
+        }
+        self.focus = focused_index_after_removal(self.focus, pane_index, remaining);
+        self.selected = remap_index_set(&self.selected, &old_to_new);
+        self.sleeping = remap_index_set(&self.sleeping, &old_to_new);
+        self.text_selection = self.text_selection.and_then(|selection| {
+            old_to_new
+                .get(&selection.pane)
+                .copied()
+                .map(|pane| MouseSelection { pane, ..selection })
+        });
+        self.follow_up = self.follow_up.and_then(|prompt| {
+            old_to_new
+                .get(&prompt.pane_index)
+                .copied()
+                .map(|pane_index| FollowUpPromptState {
+                    pane_index,
+                    ..prompt
+                })
+        });
+        self.previous_panes.cursor = old_to_new
+            .get(&self.previous_panes.cursor)
+            .copied()
+            .unwrap_or_else(|| pane_index.min(remaining - 1));
+        self.pane_settings.close();
+        self.rects.clear();
+        self.layout.set_size(next);
+
+        self.pane_render_cache.borrow_mut().remove(&removed_id);
+        self.conversation_cache.borrow_mut().remove(&removed_id);
+        self.applied_workloads.remove(&removed_id);
+
+        let next_plan = self.launch_plan.as_mut().map(|plan| {
+            if pane_index < plan.panes.len() {
+                plan.panes.remove(pane_index);
+            }
+            plan.grid = next;
+            plan.clone()
+        });
+        if let Some(plan) = next_plan.as_ref() {
+            self.start_usage_monitor(plan);
+        }
+
+        drop(removed_pane);
+        self.status = if next != current {
+            format!(
+                "deactivated pane {}; grid compacted to {}x{}",
+                pane_index + 1,
+                next.rows,
+                next.columns
+            )
+        } else {
+            format!(
+                "deactivated pane {}; {remaining} panes remain in {}x{}",
+                pane_index + 1,
+                next.rows,
+                next.columns
+            )
+        };
     }
 
     fn toggle_sleep_for_targets(&mut self) {
@@ -7488,6 +7601,24 @@ fn grid_resize_slots(current: GridSize, next: GridSize, pane_count: usize) -> Ve
     slots
 }
 
+fn pane_index_map_after_removal(pane_count: usize, removed: usize) -> BTreeMap<usize, usize> {
+    (0..pane_count)
+        .filter(|index| *index != removed)
+        .enumerate()
+        .map(|(new, old)| (old, new))
+        .collect()
+}
+
+fn focused_index_after_removal(focus: usize, removed: usize, remaining: usize) -> usize {
+    if focus < removed {
+        focus
+    } else if focus > removed {
+        focus - 1
+    } else {
+        removed.min(remaining.saturating_sub(1))
+    }
+}
+
 fn remap_index_set(
     indices: &BTreeSet<usize>,
     old_to_new: &BTreeMap<usize, usize>,
@@ -7909,6 +8040,22 @@ mod tests {
             .collect();
 
         assert_eq!(resized_focus_index(5, current, next, &old_to_new), 3);
+    }
+
+    #[test]
+    fn removing_a_pane_compacts_following_indices() {
+        assert_eq!(
+            pane_index_map_after_removal(6, 2),
+            BTreeMap::from([(0, 0), (1, 1), (3, 2), (4, 3), (5, 4)])
+        );
+    }
+
+    #[test]
+    fn removing_the_focused_pane_chooses_the_nearest_remaining_pane() {
+        assert_eq!(focused_index_after_removal(2, 2, 5), 2);
+        assert_eq!(focused_index_after_removal(5, 5, 5), 4);
+        assert_eq!(focused_index_after_removal(4, 2, 5), 3);
+        assert_eq!(focused_index_after_removal(1, 2, 5), 1);
     }
 
     #[test]
@@ -8494,6 +8641,7 @@ mod tests {
                 PaneSettingsTarget::Rename,
                 PaneSettingsTarget::Reload,
                 PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Deactivate,
                 PaneSettingsTarget::Goal,
             ]
         );
@@ -8504,6 +8652,7 @@ mod tests {
                 PaneSettingsTarget::Rename,
                 PaneSettingsTarget::Reload,
                 PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Deactivate,
                 PaneSettingsTarget::Goal,
             ]
         );
@@ -8513,6 +8662,7 @@ mod tests {
                 PaneSettingsTarget::Rename,
                 PaneSettingsTarget::Reload,
                 PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Deactivate,
                 PaneSettingsTarget::Goal,
                 PaneSettingsTarget::StopGoal,
             ]
@@ -8524,6 +8674,7 @@ mod tests {
                 PaneSettingsTarget::Rename,
                 PaneSettingsTarget::Reload,
                 PaneSettingsTarget::Sleep,
+                PaneSettingsTarget::Deactivate,
                 PaneSettingsTarget::Goal,
                 PaneSettingsTarget::StopGoal,
             ]
@@ -8543,7 +8694,7 @@ mod tests {
         assert_eq!(settings.selected_target, PaneSettingsTarget::Sleep);
         settings.selected_target = PaneSettingsTarget::StopGoal;
         settings.move_target(-1, false, false);
-        assert_eq!(settings.selected_target, PaneSettingsTarget::Sleep);
+        assert_eq!(settings.selected_target, PaneSettingsTarget::Deactivate);
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -52,6 +52,20 @@ impl GridSize {
     pub fn count(self) -> usize {
         self.rows * self.columns
     }
+
+    pub fn compact_for_count(self, count: usize) -> Self {
+        let count = count.clamp(1, self.count());
+        let mut compact = self;
+
+        while compact.columns > 1 && compact.rows * (compact.columns - 1) >= count {
+            compact.columns -= 1;
+        }
+        while compact.rows > 1 && (compact.rows - 1) * compact.columns >= count {
+            compact.rows -= 1;
+        }
+
+        compact
+    }
 }
 
 impl GridLayout {
@@ -263,6 +277,61 @@ mod tests {
     fn auto_grid_caps_at_hundred() {
         let grid = GridSize::from_count(100);
         assert_eq!(grid.count(), 100);
+    }
+
+    #[test]
+    fn compacting_grid_removes_columns_before_rows() {
+        let grid = GridSize {
+            rows: 3,
+            columns: 3,
+        };
+
+        assert_eq!(
+            grid.compact_for_count(6),
+            GridSize {
+                rows: 3,
+                columns: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn compacting_two_by_three_for_four_panes_makes_two_by_two() {
+        let grid = GridSize {
+            rows: 2,
+            columns: 3,
+        };
+
+        assert_eq!(
+            grid.compact_for_count(4),
+            GridSize {
+                rows: 2,
+                columns: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn compacting_grid_keeps_enough_cells_for_every_pane() {
+        let grid = GridSize {
+            rows: 2,
+            columns: 3,
+        };
+
+        assert_eq!(
+            grid.compact_for_count(3),
+            GridSize {
+                rows: 2,
+                columns: 2,
+            }
+        );
+        assert_eq!(
+            grid.compact_for_count(1),
+            GridSize {
+                rows: 1,
+                columns: 1,
+            }
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,6 +36,7 @@ pub struct DrawState {
     pub pane_settings_rename_button: Option<Rect>,
     pub pane_settings_reload_button: Option<Rect>,
     pub pane_settings_sleep_button: Option<Rect>,
+    pub pane_settings_deactivate_button: Option<Rect>,
     pub pane_settings_goal_button: Option<Rect>,
     pub pane_settings_stop_goal_button: Option<Rect>,
 }
@@ -118,6 +119,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let mut pane_settings_rename_button = None;
     let mut pane_settings_reload_button = None;
     let mut pane_settings_sleep_button = None;
+    let mut pane_settings_deactivate_button = None;
     let mut pane_settings_goal_button = None;
     let mut pane_settings_stop_goal_button = None;
     render_tabs(frame, tab_area, &app.tab_labels(), palette);
@@ -250,6 +252,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         pane_settings_rename_button = buttons.rename;
         pane_settings_reload_button = buttons.reload;
         pane_settings_sleep_button = buttons.sleep;
+        pane_settings_deactivate_button = buttons.deactivate;
         pane_settings_goal_button = buttons.goal;
         pane_settings_stop_goal_button = buttons.stop_goal;
     } else if let Some(dialog) = follow_up_dialog.as_ref() {
@@ -291,6 +294,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         pane_settings_rename_button,
         pane_settings_reload_button,
         pane_settings_sleep_button,
+        pane_settings_deactivate_button,
         pane_settings_goal_button,
         pane_settings_stop_goal_button,
     }
@@ -712,6 +716,11 @@ fn render_pane_settings(
         rename: pane_settings_rename_rect(inner, view.auth_kind.is_some()),
         reload: pane_settings_reload_rect(inner, view.auth_kind.is_some()),
         sleep: pane_settings_sleep_rect(inner, view.auth_kind.is_some(), view.goal.is_some()),
+        deactivate: pane_settings_deactivate_rect(
+            inner,
+            view.auth_kind.is_some(),
+            view.goal.is_some(),
+        ),
         goal: pane_settings_goal_rect(inner, view.auth_kind.is_some(), view.goal.is_some()),
         stop_goal: pane_settings_stop_goal_rect(
             inner,
@@ -726,6 +735,7 @@ struct PaneSettingsButtons {
     rename: Option<Rect>,
     reload: Option<Rect>,
     sleep: Option<Rect>,
+    deactivate: Option<Rect>,
     goal: Option<Rect>,
     stop_goal: Option<Rect>,
 }
@@ -813,6 +823,11 @@ fn pane_settings_lines(
             view.sleeping,
             palette,
             view.selected_target == PaneSettingsTarget::Sleep,
+        ));
+        lines.push(pane_settings_deactivate_line(
+            width,
+            palette,
+            view.selected_target == PaneSettingsTarget::Deactivate,
         ));
         lines.push(pane_settings_goal_line(
             width,
@@ -958,6 +973,11 @@ fn pane_settings_lines(
         palette,
         view.selected_target == PaneSettingsTarget::Sleep,
     ));
+    lines.push(pane_settings_deactivate_line(
+        width,
+        palette,
+        view.selected_target == PaneSettingsTarget::Deactivate,
+    ));
     lines.push(pane_settings_goal_line(
         width,
         view.goal.is_some(),
@@ -1048,6 +1068,14 @@ fn pane_settings_sleep_line(
         palette.quiet(),
         selected,
     )
+}
+
+fn pane_settings_deactivate_line(
+    width: u16,
+    palette: &GridPalette,
+    selected: bool,
+) -> Line<'static> {
+    pane_settings_action_line("[ Deactivate pane ]", width, palette.exited(), selected)
 }
 
 fn pane_settings_goal_line(
@@ -1176,7 +1204,7 @@ fn pane_settings_sleep_rect(area: Rect, has_auth: bool, has_goal: bool) -> Optio
     pane_settings_action_rect(area, row)
 }
 
-fn pane_settings_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
+fn pane_settings_deactivate_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
     let row = if area.width < 36 {
         if has_auth { 6 } else { 5 }
     } else if has_goal {
@@ -1187,14 +1215,25 @@ fn pane_settings_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option
     pane_settings_action_rect(area, row)
 }
 
+fn pane_settings_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
+    let row = if area.width < 36 {
+        if has_auth { 7 } else { 6 }
+    } else if has_goal {
+        12
+    } else {
+        11
+    };
+    pane_settings_action_rect(area, row)
+}
+
 fn pane_settings_stop_goal_rect(area: Rect, has_auth: bool, has_goal: bool) -> Option<Rect> {
     if !has_goal {
         return None;
     }
     let row = if area.width < 36 {
-        if has_auth { 7 } else { 6 }
+        if has_auth { 8 } else { 7 }
     } else {
-        12
+        13
     };
     pane_settings_action_rect(area, row)
 }
@@ -3123,6 +3162,7 @@ mod tests {
             .join("\n");
         assert!(wide.contains("RECENT ACTIVITY"));
         assert!(wide.contains("summary  all focused tests passed"));
+        assert!(wide.contains("Deactivate pane"));
         assert!(!wide.contains("run the focused tests"));
 
         let narrow = pane_settings_lines(&view, 30, &GridPalette::default())
@@ -3131,6 +3171,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         assert!(narrow.contains("latest: all focused tests"));
+        assert!(narrow.contains("Deactivate pane"));
     }
 
     #[test]
@@ -3164,12 +3205,16 @@ mod tests {
             Some(Rect::new(5, 19, 40, 1))
         );
         assert_eq!(
+            pane_settings_deactivate_rect(Rect::new(5, 10, 40, 14), false, false),
+            Some(Rect::new(5, 20, 40, 1))
+        );
+        assert_eq!(
             pane_settings_goal_rect(Rect::new(5, 10, 40, 14), false, true),
-            Some(Rect::new(5, 21, 40, 1))
+            Some(Rect::new(5, 22, 40, 1))
         );
         assert_eq!(
             pane_settings_stop_goal_rect(Rect::new(5, 10, 40, 14), false, true),
-            Some(Rect::new(5, 22, 40, 1))
+            Some(Rect::new(5, 23, 40, 1))
         );
         assert_eq!(
             pane_settings_stop_goal_rect(Rect::new(5, 10, 40, 14), false, false),


### PR DESCRIPTION
## Summary
- add a Deactivate pane action and direct key inside Pane Activity
- remove the selected pane process while remapping pane-indexed state and preserving remaining terminals
- compact grid dimensions column-first, including 2x3 to 2x2 when four panes remain
- protect the final pane from deactivation

## Validation
- cargo fmt --all -- --check
- cargo test pending the repository integration lease

Refs #253