### PR TITLE
feat: add keyboard scrollback search and copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ agents and shells.
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
 | `Alt+f` | Zoom or restore the focused pane |
+| `Alt+b` | Search, select, and copy focused-pane scrollback |
 | `Alt+g` / `Alt+u` | Start or stop the grid manager goal |
 | `Alt+Shift+V` | Dictate one prompt without submitting it |
 | `Alt+o` | Open settings |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -145,6 +145,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
 | Alt+f | Zoom the focused pane to the full grid area, or restore the grid. |
+| Alt+b | Open keyboard scrollback search and copy mode for the focused pane. |
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
 | Alt+p | Open the focused-pane activity summary. |
@@ -160,6 +161,15 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+q | Quit. |
 
 Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
+
+Keyboard copy mode snapshots the focused pane's bounded terminal history while
+live PTY output continues in the background. Navigate with arrows, Home/End,
+Ctrl+Home/Ctrl+End, and PageUp/PageDown. Press `/` to edit an incremental search,
+Enter to finish the query, and `n` or `N` for the next or previous match. Space
+starts character selection, `V` starts whole-line selection, and `y` copies the
+selection through the same clipboard path as mouse selection. With no active
+selection, `y` copies the current line. Escape, `q`, or Alt+B closes the viewer
+and restores ordinary terminal input.
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
 

--- a/docs/devlogs/2026-07-15-add-keyboard-scrollback-search-and-copy-mode.md
+++ b/docs/devlogs/2026-07-15-add-keyboard-scrollback-search-and-copy-mode.md
@@ -1,0 +1,35 @@
+# Add keyboard scrollback search and copy mode
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added a keyboard-first viewer for searching, selecting, and copying the
+  focused pane's bounded terminal history.
+
+## What Changed
+
+- Added Alt+B copy mode with arrows, Home/End, and page navigation.
+- Added incremental `/` search with next/previous match navigation.
+- Added character and whole-line selection with clipboard copy through the
+  existing OSC 52 and macOS paths.
+- Kept the viewer snapshot stable while live PTY output continues behind it.
+
+## Why It Matters
+
+- Keyboard-first users can locate and reuse earlier agent output without
+  reaching for the mouse or disturbing sibling panes.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test copy_mode`
+- `cargo test history_snapshot`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Press Alt+B to search, select, and copy focused-pane scrollback from the
+  keyboard.

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ use crate::{
     composer::{Composer, GridPicker, GridPickerAction},
     config::{Config, PaletteColor, PaneWorkloadPolicy, UiConfig, UiPalette},
     control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
+    copy_mode::{CopyMode, CopyModeView},
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
@@ -94,6 +95,7 @@ pub struct App {
     selected: BTreeSet<usize>,
     pane_names: Vec<Option<String>>,
     text_selection: Option<MouseSelection>,
+    copy_mode: Option<CopyMode>,
     sleeping: BTreeSet<usize>,
     manager_goal: Option<ManagerGoal>,
     goal_editor: Option<GoalEditorState>,
@@ -1956,6 +1958,7 @@ impl App {
             selected: BTreeSet::new(),
             pane_names: Vec::new(),
             text_selection: None,
+            copy_mode: None,
             sleeping: BTreeSet::new(),
             manager_goal: None,
             goal_editor: None,
@@ -2064,6 +2067,7 @@ impl App {
         self.panes.clear();
         self.pane_names = vec![None; plan.panes.len()];
         self.text_selection = None;
+        self.copy_mode = None;
         self.sleeping.clear();
         self.manager_goal = None;
         self.goal_editor = None;
@@ -2139,6 +2143,7 @@ impl App {
         self.follow_up = None;
         self.goal_editor = None;
         self.text_selection = None;
+        self.copy_mode = None;
         self.command_line.focused = false;
         self.grid_resizer = None;
     }
@@ -2155,6 +2160,7 @@ impl App {
         self.selected.clear();
         self.pane_names = vec![None; plan.panes.len()];
         self.text_selection = None;
+        self.copy_mode = None;
         self.sleeping.clear();
         self.manager_goal = None;
         self.goal_editor = None;
@@ -3054,6 +3060,10 @@ impl App {
             self.status = "quit canceled".into();
         }
 
+        if self.copy_mode.is_some() {
+            return self.handle_copy_mode_key(terminal, key);
+        }
+
         if self.help_open {
             return Ok(self.handle_help_key(key));
         }
@@ -3191,6 +3201,205 @@ impl App {
         }
     }
 
+    fn open_copy_mode(&mut self) {
+        self.close_tab_modals();
+        self.settings.open = false;
+        self.image_overlay = None;
+        self.help_open = false;
+
+        let pane_index = self.focus;
+        let (width, height) = self.copy_mode_dimensions(pane_index);
+        let Some(pane) = self.panes.get_mut(pane_index) else {
+            self.status = "no focused pane available for copy mode".into();
+            return;
+        };
+        let lines = pane.history_lines();
+        let mode = CopyMode::new(pane_index, lines, width, height);
+        let line_count = mode.line_count();
+        self.copy_mode = Some(mode);
+        self.status = format!(
+            "copy mode: {line_count} lines | / search | Space/V select | y copy | Esc close"
+        );
+    }
+
+    fn close_copy_mode(&mut self) {
+        let pane_index = self.copy_mode.take().map(|mode| mode.pane());
+        if let Some(pane) = pane_index.and_then(|index| self.panes.get_mut(index)) {
+            pane.reset_view();
+        }
+        self.status = "copy mode closed; terminal input restored".into();
+    }
+
+    fn handle_copy_mode_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
+        let alt_b = key.modifiers.contains(KeyModifiers::ALT)
+            && matches!(key.code, KeyCode::Char('b') | KeyCode::Char('B'));
+        if matches!(key.code, KeyCode::Esc) || alt_b {
+            self.close_copy_mode();
+            return Ok(KeyOutcome::Render);
+        }
+
+        let pane_index = self.copy_mode.as_ref().map_or(self.focus, CopyMode::pane);
+        let (width, height) = self.copy_mode_dimensions(pane_index);
+        let searching = self.copy_mode.as_ref().is_some_and(CopyMode::searching);
+
+        if searching {
+            let mode = self.copy_mode.as_mut().expect("copy mode checked above");
+            match key.code {
+                KeyCode::Enter => mode.finish_search(),
+                KeyCode::Backspace => mode.backspace_search(width, height),
+                KeyCode::Char('u')
+                    if key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
+                {
+                    mode.clear_search(width, height);
+                }
+                KeyCode::Char(ch)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
+                {
+                    mode.insert_search_char(ch, width, height);
+                }
+                _ => return Ok(KeyOutcome::Continue),
+            }
+            self.status = mode.status_label();
+            return Ok(KeyOutcome::Render);
+        }
+
+        if matches!(key.code, KeyCode::Char('q'))
+            && !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            self.close_copy_mode();
+            return Ok(KeyOutcome::Render);
+        }
+
+        if matches!(key.code, KeyCode::Char('y') | KeyCode::Char('Y'))
+            && !key
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            let (pane, text) = self
+                .copy_mode
+                .as_ref()
+                .map(|mode| (mode.pane(), mode.copy_text()))
+                .expect("copy mode checked above");
+            if text.is_empty() {
+                self.status = "copy selection is empty".into();
+                return Ok(KeyOutcome::Render);
+            }
+            copy_to_clipboard(terminal, &text)?;
+            self.copy_mode = None;
+            if let Some(pane) = self.panes.get_mut(pane) {
+                pane.reset_view();
+            }
+            self.status = format!(
+                "copied {} characters from pane {}",
+                text.chars().count(),
+                pane + 1
+            );
+            return Ok(KeyOutcome::Render);
+        }
+
+        let Some(mode) = self.copy_mode.as_mut() else {
+            return Ok(KeyOutcome::Continue);
+        };
+        let handled = match key.code {
+            KeyCode::Char('/')
+                if !key
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                mode.begin_search(width, height);
+                true
+            }
+            KeyCode::Char('n') if key.modifiers.is_empty() => {
+                mode.next_match(true, width, height);
+                true
+            }
+            KeyCode::Char(ch)
+                if ch.eq_ignore_ascii_case(&'n')
+                    && (ch == 'N' || key.modifiers.contains(KeyModifiers::SHIFT))
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                mode.next_match(false, width, height);
+                true
+            }
+            KeyCode::Up => {
+                mode.move_vertical(-1, width, height);
+                true
+            }
+            KeyCode::Down => {
+                mode.move_vertical(1, width, height);
+                true
+            }
+            KeyCode::Left => {
+                mode.move_horizontal(-1, width, height);
+                true
+            }
+            KeyCode::Right => {
+                mode.move_horizontal(1, width, height);
+                true
+            }
+            KeyCode::PageUp => {
+                mode.move_page(-1, width, height);
+                true
+            }
+            KeyCode::PageDown => {
+                mode.move_page(1, width, height);
+                true
+            }
+            KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                mode.move_document_boundary(false, width, height);
+                true
+            }
+            KeyCode::End if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                mode.move_document_boundary(true, width, height);
+                true
+            }
+            KeyCode::Home => {
+                mode.move_line_boundary(false, width, height);
+                true
+            }
+            KeyCode::End => {
+                mode.move_line_boundary(true, width, height);
+                true
+            }
+            KeyCode::Char(' ') if key.modifiers.is_empty() => {
+                mode.toggle_character_selection();
+                true
+            }
+            KeyCode::Char(ch)
+                if ch.eq_ignore_ascii_case(&'v')
+                    && (ch == 'V' || key.modifiers.contains(KeyModifiers::SHIFT))
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                mode.toggle_line_selection();
+                true
+            }
+            _ => false,
+        };
+        if handled {
+            self.status = mode.status_label();
+            Ok(KeyOutcome::Render)
+        } else {
+            Ok(KeyOutcome::Continue)
+        }
+    }
+
+    fn copy_mode_dimensions(&self, pane: usize) -> (usize, usize) {
+        self.rects.get(pane).map_or((80, 20), |rect| {
+            (
+                usize::from(rect.width.saturating_sub(2)).max(1),
+                usize::from(rect.height.saturating_sub(3)).max(1),
+            )
+        })
+    }
+
     fn handle_app_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<Option<bool>> {
         match key.code {
             KeyCode::Char(ch) => self.handle_alt_char(terminal, ch, key.modifiers),
@@ -3227,6 +3436,10 @@ impl App {
         let lower = ch.to_ascii_lowercase();
         match lower {
             'q' => Ok(Some(true)),
+            'b' => {
+                self.open_copy_mode();
+                Ok(Some(false))
+            }
             's' => {
                 if self.command_line.focused {
                     self.status = "command line focused".into();
@@ -4352,6 +4565,10 @@ impl App {
                 | MouseEventKind::ScrollRight
                 | MouseEventKind::ScrollUp
         ) {
+            return Ok(false);
+        }
+
+        if self.copy_mode.is_some() {
             return Ok(false);
         }
 
@@ -5565,6 +5782,19 @@ impl App {
             height,
             selection,
         )
+    }
+
+    pub fn copy_mode_view(&self, index: usize, width: u16, height: u16) -> Option<CopyModeView> {
+        let mode = self
+            .copy_mode
+            .as_ref()
+            .filter(|mode| mode.pane() == index)?;
+        let body_height = height.saturating_sub(1);
+        Some(mode.view(usize::from(width), usize::from(body_height)))
+    }
+
+    pub fn copy_mode_open(&self) -> bool {
+        self.copy_mode.is_some()
     }
 
     pub fn focused_pane(&self) -> Option<usize> {

--- a/src/copy_mode.rs
+++ b/src/copy_mode.rs
@@ -1,0 +1,560 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TextPoint {
+    pub line: usize,
+    pub column: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopyCellKind {
+    Normal,
+    Match,
+    ActiveMatch,
+    Selection,
+    Cursor,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectionKind {
+    Characters,
+    Lines,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Selection {
+    anchor: TextPoint,
+    kind: SelectionKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MatchRange {
+    start: TextPoint,
+    end: TextPoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyModeRow {
+    pub line: usize,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CopyModeView {
+    pub pane: usize,
+    pub rows: Vec<CopyModeRow>,
+    pub total_lines: usize,
+    pub top_line: usize,
+    pub left_column: usize,
+    pub cursor: TextPoint,
+    pub query: String,
+    pub searching: bool,
+    pub active_match: Option<usize>,
+    pub match_count: usize,
+    pub selection_label: Option<&'static str>,
+    selection: Option<Selection>,
+    matches: Vec<MatchRange>,
+}
+
+impl CopyModeView {
+    pub fn cell_kind(&self, point: TextPoint) -> CopyCellKind {
+        if point == self.cursor {
+            return CopyCellKind::Cursor;
+        }
+        if self
+            .selection
+            .is_some_and(|selection| selection_contains(selection, self.cursor, point))
+        {
+            return CopyCellKind::Selection;
+        }
+        if self
+            .active_match
+            .and_then(|index| self.matches.get(index))
+            .is_some_and(|range| match_contains(*range, point))
+        {
+            return CopyCellKind::ActiveMatch;
+        }
+        if self
+            .matches
+            .iter()
+            .any(|range| match_contains(*range, point))
+        {
+            return CopyCellKind::Match;
+        }
+        CopyCellKind::Normal
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CopyMode {
+    pane: usize,
+    lines: Vec<String>,
+    cursor: TextPoint,
+    selection: Option<Selection>,
+    query: String,
+    searching: bool,
+    matches: Vec<MatchRange>,
+    active_match: Option<usize>,
+    top_line: usize,
+    left_column: usize,
+}
+
+impl CopyMode {
+    pub fn new(pane: usize, mut lines: Vec<String>, width: usize, height: usize) -> Self {
+        if lines.is_empty() {
+            lines.push(String::new());
+        }
+        let line = lines.len().saturating_sub(1);
+        let column = line_char_len(&lines[line]).saturating_sub(1);
+        let mut mode = Self {
+            pane,
+            lines,
+            cursor: TextPoint { line, column },
+            selection: None,
+            query: String::new(),
+            searching: false,
+            matches: Vec::new(),
+            active_match: None,
+            top_line: 0,
+            left_column: 0,
+        };
+        mode.ensure_visible(width, height);
+        mode
+    }
+
+    pub fn pane(&self) -> usize {
+        self.pane
+    }
+
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    pub fn searching(&self) -> bool {
+        self.searching
+    }
+
+    pub fn status_label(&self) -> String {
+        if self.searching {
+            return format!(
+                "copy search: /{} ({} matches)",
+                self.query,
+                self.matches.len()
+            );
+        }
+        if !self.query.is_empty() {
+            return format!(
+                "copy mode: match {}/{} for /{}",
+                self.active_match.map_or(0, |index| index + 1),
+                self.matches.len(),
+                self.query
+            );
+        }
+        format!(
+            "copy mode: line {}/{}",
+            self.cursor.line + 1,
+            self.lines.len()
+        )
+    }
+
+    pub fn begin_search(&mut self, width: usize, height: usize) {
+        self.searching = true;
+        self.query.clear();
+        self.matches.clear();
+        self.active_match = None;
+        self.ensure_visible(width, height);
+    }
+
+    pub fn finish_search(&mut self) {
+        self.searching = false;
+    }
+
+    pub fn insert_search_char(&mut self, ch: char, width: usize, height: usize) {
+        self.query.push(ch);
+        self.rebuild_matches(width, height);
+    }
+
+    pub fn backspace_search(&mut self, width: usize, height: usize) {
+        self.query.pop();
+        self.rebuild_matches(width, height);
+    }
+
+    pub fn clear_search(&mut self, width: usize, height: usize) {
+        self.query.clear();
+        self.rebuild_matches(width, height);
+    }
+
+    pub fn next_match(&mut self, forward: bool, width: usize, height: usize) {
+        if self.matches.is_empty() {
+            self.active_match = None;
+            return;
+        }
+        let current = self.active_match.unwrap_or(0);
+        let next = if forward {
+            (current + 1) % self.matches.len()
+        } else {
+            current
+                .checked_sub(1)
+                .unwrap_or_else(|| self.matches.len() - 1)
+        };
+        self.activate_match(next, width, height);
+    }
+
+    pub fn move_vertical(&mut self, delta: isize, width: usize, height: usize) {
+        self.cursor.line = offset_index(self.cursor.line, delta, self.lines.len());
+        self.clamp_cursor_column();
+        self.ensure_visible(width, height);
+    }
+
+    pub fn move_horizontal(&mut self, delta: isize, width: usize, height: usize) {
+        if delta < 0 {
+            if self.cursor.column > 0 {
+                self.cursor.column -= 1;
+            } else if self.cursor.line > 0 {
+                self.cursor.line -= 1;
+                self.cursor.column = self.line_max_column(self.cursor.line);
+            }
+        } else if delta > 0 {
+            let max_column = self.line_max_column(self.cursor.line);
+            if self.cursor.column < max_column {
+                self.cursor.column += 1;
+            } else if self.cursor.line + 1 < self.lines.len() {
+                self.cursor.line += 1;
+                self.cursor.column = 0;
+            }
+        }
+        self.ensure_visible(width, height);
+    }
+
+    pub fn move_page(&mut self, pages: isize, width: usize, height: usize) {
+        let rows = height.max(1).min(isize::MAX as usize) as isize;
+        self.move_vertical(pages.saturating_mul(rows), width, height);
+    }
+
+    pub fn move_line_boundary(&mut self, end: bool, width: usize, height: usize) {
+        self.cursor.column = if end {
+            self.line_max_column(self.cursor.line)
+        } else {
+            0
+        };
+        self.ensure_visible(width, height);
+    }
+
+    pub fn move_document_boundary(&mut self, end: bool, width: usize, height: usize) {
+        self.cursor.line = if end {
+            self.lines.len().saturating_sub(1)
+        } else {
+            0
+        };
+        self.cursor.column = if end {
+            self.line_max_column(self.cursor.line)
+        } else {
+            0
+        };
+        self.ensure_visible(width, height);
+    }
+
+    pub fn toggle_character_selection(&mut self) {
+        self.selection = match self.selection {
+            Some(Selection {
+                kind: SelectionKind::Characters,
+                ..
+            }) => None,
+            _ => Some(Selection {
+                anchor: self.cursor,
+                kind: SelectionKind::Characters,
+            }),
+        };
+    }
+
+    pub fn toggle_line_selection(&mut self) {
+        self.selection = match self.selection {
+            Some(Selection {
+                kind: SelectionKind::Lines,
+                ..
+            }) => None,
+            _ => Some(Selection {
+                anchor: self.cursor,
+                kind: SelectionKind::Lines,
+            }),
+        };
+    }
+
+    pub fn copy_text(&self) -> String {
+        let Some(selection) = self.selection else {
+            return self.lines[self.cursor.line].clone();
+        };
+
+        match selection.kind {
+            SelectionKind::Lines => {
+                let start = selection.anchor.line.min(self.cursor.line);
+                let end = selection.anchor.line.max(self.cursor.line);
+                self.lines[start..=end].join("\n")
+            }
+            SelectionKind::Characters => {
+                let (start, end) = normalize_points(selection.anchor, self.cursor);
+                let mut selected = Vec::new();
+                for line in start.line..=end.line {
+                    let from = if line == start.line { start.column } else { 0 };
+                    let to = if line == end.line {
+                        end.column.saturating_add(1)
+                    } else {
+                        line_char_len(&self.lines[line])
+                    };
+                    selected.push(slice_chars(&self.lines[line], from, to));
+                }
+                selected.join("\n")
+            }
+        }
+    }
+
+    pub fn view(&self, width: usize, height: usize) -> CopyModeView {
+        let width = width.max(1);
+        let height = height.max(1);
+        let max_top = self.lines.len().saturating_sub(height);
+        let top_line = self.top_line.min(max_top);
+        let rows = self
+            .lines
+            .iter()
+            .enumerate()
+            .skip(top_line)
+            .take(height)
+            .map(|(line, text)| {
+                let mut text = slice_chars(
+                    text,
+                    self.left_column,
+                    self.left_column.saturating_add(width),
+                );
+                if text.is_empty() && line == self.cursor.line {
+                    text.push(' ');
+                }
+                CopyModeRow { line, text }
+            })
+            .collect();
+
+        CopyModeView {
+            pane: self.pane,
+            rows,
+            total_lines: self.lines.len(),
+            top_line,
+            left_column: self.left_column,
+            cursor: self.cursor,
+            query: self.query.clone(),
+            searching: self.searching,
+            active_match: self.active_match,
+            match_count: self.matches.len(),
+            selection_label: self.selection.map(|selection| match selection.kind {
+                SelectionKind::Characters => "CHAR",
+                SelectionKind::Lines => "LINE",
+            }),
+            selection: self.selection,
+            matches: self.matches.clone(),
+        }
+    }
+
+    fn rebuild_matches(&mut self, width: usize, height: usize) {
+        self.matches.clear();
+        self.active_match = None;
+        if self.query.is_empty() {
+            self.ensure_visible(width, height);
+            return;
+        }
+
+        let query_chars = self.query.chars().count();
+        for (line, text) in self.lines.iter().enumerate() {
+            for (byte_start, _) in text.match_indices(&self.query) {
+                let start_column = text[..byte_start].chars().count();
+                self.matches.push(MatchRange {
+                    start: TextPoint {
+                        line,
+                        column: start_column,
+                    },
+                    end: TextPoint {
+                        line,
+                        column: start_column + query_chars,
+                    },
+                });
+            }
+        }
+
+        let next = self
+            .matches
+            .iter()
+            .position(|range| range.start >= self.cursor)
+            .unwrap_or(0);
+        self.activate_match(next, width, height);
+    }
+
+    fn activate_match(&mut self, index: usize, width: usize, height: usize) {
+        let Some(found) = self.matches.get(index).copied() else {
+            self.active_match = None;
+            return;
+        };
+        self.active_match = Some(index);
+        self.cursor = found.start;
+        self.ensure_visible(width, height);
+    }
+
+    fn line_max_column(&self, line: usize) -> usize {
+        line_char_len(&self.lines[line]).saturating_sub(1)
+    }
+
+    fn clamp_cursor_column(&mut self) {
+        self.cursor.column = self
+            .cursor
+            .column
+            .min(self.line_max_column(self.cursor.line));
+    }
+
+    fn ensure_visible(&mut self, width: usize, height: usize) {
+        let width = width.max(1);
+        let height = height.max(1);
+        if self.cursor.line < self.top_line {
+            self.top_line = self.cursor.line;
+        } else if self.cursor.line >= self.top_line.saturating_add(height) {
+            self.top_line = self.cursor.line + 1 - height;
+        }
+        self.top_line = self.top_line.min(self.lines.len().saturating_sub(height));
+
+        if self.cursor.column < self.left_column {
+            self.left_column = self.cursor.column;
+        } else if self.cursor.column >= self.left_column.saturating_add(width) {
+            self.left_column = self.cursor.column + 1 - width;
+        }
+    }
+}
+
+fn selection_contains(selection: Selection, cursor: TextPoint, point: TextPoint) -> bool {
+    match selection.kind {
+        SelectionKind::Lines => {
+            let start = selection.anchor.line.min(cursor.line);
+            let end = selection.anchor.line.max(cursor.line);
+            (start..=end).contains(&point.line)
+        }
+        SelectionKind::Characters => {
+            let (start, end) = normalize_points(selection.anchor, cursor);
+            (start..=end).contains(&point)
+        }
+    }
+}
+
+fn match_contains(range: MatchRange, point: TextPoint) -> bool {
+    point.line == range.start.line
+        && point.column >= range.start.column
+        && point.column < range.end.column
+}
+
+fn normalize_points(first: TextPoint, second: TextPoint) -> (TextPoint, TextPoint) {
+    if first <= second {
+        (first, second)
+    } else {
+        (second, first)
+    }
+}
+
+fn offset_index(index: usize, delta: isize, len: usize) -> usize {
+    if delta.is_negative() {
+        index.saturating_sub(delta.unsigned_abs())
+    } else {
+        index
+            .saturating_add(delta as usize)
+            .min(len.saturating_sub(1))
+    }
+}
+
+fn line_char_len(line: &str) -> usize {
+    line.chars().count()
+}
+
+fn slice_chars(line: &str, start: usize, end: usize) -> String {
+    line.chars()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mode(lines: &[&str]) -> CopyMode {
+        CopyMode::new(
+            0,
+            lines.iter().map(|line| (*line).to_string()).collect(),
+            20,
+            4,
+        )
+    }
+
+    #[test]
+    fn incremental_search_and_match_navigation_are_unicode_safe() {
+        let mut mode = mode(&["alpha caf\u{e9}", "beta", "another caf\u{e9}"]);
+        mode.move_document_boundary(false, 20, 4);
+        mode.begin_search(20, 4);
+        for ch in "caf\u{e9}".chars() {
+            mode.insert_search_char(ch, 20, 4);
+        }
+
+        let first = mode.view(20, 4);
+        assert_eq!(first.match_count, 2);
+        assert_eq!(first.cursor, TextPoint { line: 0, column: 6 });
+
+        mode.next_match(true, 20, 4);
+        assert_eq!(mode.view(20, 4).cursor.line, 2);
+        mode.next_match(true, 20, 4);
+        assert_eq!(mode.view(20, 4).cursor.line, 0);
+        mode.next_match(false, 20, 4);
+        assert_eq!(mode.view(20, 4).cursor.line, 2);
+    }
+
+    #[test]
+    fn character_and_line_selections_extract_expected_text() {
+        let mut mode = mode(&["alpha", "bravo", "charlie"]);
+        mode.move_document_boundary(false, 20, 4);
+        mode.move_horizontal(1, 20, 4);
+        mode.toggle_character_selection();
+        mode.move_vertical(1, 20, 4);
+        assert_eq!(mode.copy_text(), "lpha\nbr");
+
+        mode.toggle_line_selection();
+        mode.move_vertical(1, 20, 4);
+        assert_eq!(mode.copy_text(), "bravo\ncharlie");
+    }
+
+    #[test]
+    fn empty_history_and_narrow_views_remain_renderable() {
+        let mode = CopyMode::new(2, Vec::new(), 0, 0);
+        let view = mode.view(1, 1);
+
+        assert_eq!(view.pane, 2);
+        assert_eq!(view.total_lines, 1);
+        assert_eq!(view.rows.len(), 1);
+        assert_eq!(view.rows[0].text, " ");
+        assert_eq!(mode.copy_text(), "");
+    }
+
+    #[test]
+    fn selection_and_active_search_styles_have_stable_precedence() {
+        let mut mode = mode(&["find this"]);
+        mode.move_document_boundary(false, 20, 4);
+        mode.begin_search(20, 4);
+        for ch in "find".chars() {
+            mode.insert_search_char(ch, 20, 4);
+        }
+        mode.finish_search();
+        mode.toggle_character_selection();
+        mode.move_horizontal(1, 20, 4);
+        let view = mode.view(20, 4);
+
+        assert_eq!(
+            view.cell_kind(TextPoint { line: 0, column: 0 }),
+            CopyCellKind::Selection
+        );
+        assert_eq!(
+            view.cell_kind(TextPoint { line: 0, column: 1 }),
+            CopyCellKind::Cursor
+        );
+        assert_eq!(
+            view.cell_kind(TextPoint { line: 0, column: 2 }),
+            CopyCellKind::ActiveMatch
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod codex_sqlite;
 mod composer;
 mod config;
 mod control;
+mod copy_mode;
 mod image_preview;
 mod layout;
 mod manager;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -373,6 +373,10 @@ impl PtyPane {
         self.screen_revision
     }
 
+    pub fn history_lines(&mut self) -> Vec<String> {
+        screen_history_lines(self.parser.screen_mut())
+    }
+
     pub fn scroll_view(&mut self, rows: isize) -> bool {
         let changed = scroll_screen(self.parser.screen_mut(), rows);
         if changed {
@@ -642,6 +646,34 @@ fn scroll_screen(screen: &mut Screen, rows: isize) -> bool {
     };
     screen.set_scrollback(next);
     screen.scrollback() != before
+}
+
+fn screen_history_lines(screen: &mut Screen) -> Vec<String> {
+    let original_scrollback = screen.scrollback();
+    let (rows, columns) = screen.size();
+    let page_rows = usize::from(rows).max(1);
+    let mut lines = Vec::new();
+
+    screen.set_scrollback(usize::MAX);
+    let history_rows = screen.scrollback();
+    let mut history_start = 0;
+    while history_start < history_rows {
+        screen.set_scrollback(history_rows - history_start);
+        let rows_to_take = (history_rows - history_start).min(page_rows);
+        lines.extend(screen.rows(0, columns).take(rows_to_take));
+        history_start += rows_to_take;
+    }
+
+    screen.set_scrollback(0);
+    lines.extend(screen.rows(0, columns));
+    screen.set_scrollback(original_scrollback);
+
+    let first_content = lines.iter().position(|line| !line.is_empty());
+    let last_content = lines.iter().rposition(|line| !line.is_empty());
+    match (first_content, last_content) {
+        (Some(first), Some(last)) => lines[first..=last].to_vec(),
+        _ => vec![String::new()],
+    }
 }
 
 impl Drop for PtyPane {
@@ -1611,6 +1643,26 @@ mod tests {
         assert!(scroll_screen(parser.screen_mut(), -3));
         assert_eq!(parser.screen().scrollback(), 0);
         assert!(parser.screen().contents().contains("five"));
+    }
+
+    #[test]
+    fn history_snapshot_includes_bounded_scrollback_and_restores_the_view() {
+        let mut parser = Parser::new(3, 20, 4);
+        parser.process(b"one\r\ntwo\r\nthree\r\nfour\r\nfive\r\nsix");
+        parser.screen_mut().set_scrollback(2);
+
+        let lines = screen_history_lines(parser.screen_mut());
+
+        assert_eq!(lines, ["one", "two", "three", "four", "five", "six"]);
+        assert_eq!(parser.screen().scrollback(), 2);
+    }
+
+    #[test]
+    fn empty_history_snapshot_keeps_one_renderable_line() {
+        let mut parser = Parser::new(2, 10, 10);
+
+        assert_eq!(screen_history_lines(parser.screen_mut()), [""]);
+        assert_eq!(parser.screen().scrollback(), 0);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     auth::{AgentKind, AuthProfile},
     composer::GridPickerMode,
+    copy_mode::{CopyCellKind, CopyModeView, TextPoint},
     image_preview::ImagePreview,
 };
 
@@ -89,7 +90,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let help_open = app.help_open();
+    let copy_mode_open = app.copy_mode_open();
     let exited_recovery = if help_open
+        || copy_mode_open
         || app.settings_open()
         || previous_panes_view.is_some()
         || pane_settings_open
@@ -105,6 +108,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         app.exited_recovery_view()
     };
     let modal_open = help_open
+        || copy_mode_open
         || app.settings_open()
         || previous_panes_view.is_some()
         || pane_settings_open
@@ -163,7 +167,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        if sleeping {
+        if let Some(copy_mode) = app.copy_mode_view(index, inner.width, inner.height) {
+            render_copy_mode(frame, inner, &copy_mode, palette);
+        } else if sleeping {
             render_sleeping_screen(frame, inner);
         } else {
             let selection = app.selection_for_pane(index);
@@ -2497,6 +2503,7 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+f", "zoom or restore focused pane"),
+        ("Alt+b", "search and copy pane scrollback"),
         ("Alt+l", "resize the grid"),
         ("Alt+r", "rename focused pane"),
         ("Alt+Shift+t", "restart exited panes"),
@@ -2767,6 +2774,108 @@ fn render_screen_lines(frame: &mut Frame<'_>, area: Rect, lines: Vec<Line<'stati
     );
 }
 
+fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, palette: &GridPalette) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let footer_height = u16::from(area.height > 1);
+    let body = Rect {
+        height: area.height.saturating_sub(footer_height),
+        ..area
+    };
+    let footer = Rect {
+        y: area.y + body.height,
+        height: footer_height,
+        ..area
+    };
+    let lines = view
+        .rows
+        .iter()
+        .map(|row| {
+            let spans = row
+                .text
+                .chars()
+                .enumerate()
+                .map(|(offset, ch)| {
+                    let point = TextPoint {
+                        line: row.line,
+                        column: view.left_column + offset,
+                    };
+                    let style = match view.cell_kind(point) {
+                        CopyCellKind::Normal => {
+                            Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)
+                        }
+                        CopyCellKind::Match => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::DarkGray)
+                            .add_modifier(Modifier::BOLD),
+                        CopyCellKind::ActiveMatch => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                        CopyCellKind::Selection => Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::LightCyan)
+                            .add_modifier(Modifier::BOLD),
+                        CopyCellKind::Cursor => Style::default()
+                            .fg(Color::Black)
+                            .bg(palette.focus())
+                            .add_modifier(Modifier::BOLD),
+                    };
+                    Span::styled(ch.to_string(), style)
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(
+        Paragraph::new(lines).style(Style::default().fg(Color::White).bg(APP_BG)),
+        body,
+    );
+
+    if footer.height > 0 {
+        let search = if view.searching {
+            format!(
+                " /{}▌ {}/{}",
+                view.query,
+                view.active_match.map_or(0, |i| i + 1),
+                view.match_count
+            )
+        } else if view.query.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " /{} {}/{}",
+                view.query,
+                view.active_match.map_or(0, |i| i + 1),
+                view.match_count
+            )
+        };
+        let selection = view
+            .selection_label
+            .map(|kind| format!(" {kind}"))
+            .unwrap_or_default();
+        let label = format!(
+            " COPY {}:{}/{}{}{} | / search n/N next Space/V select y copy Esc close ",
+            view.pane + 1,
+            view.cursor.line + 1,
+            view.total_lines,
+            search,
+            selection
+        );
+        frame.render_widget(
+            Paragraph::new(truncate_text(&label, footer.width as usize)).style(
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(palette.focus())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            footer,
+        );
+    }
+}
+
 pub fn cached_screen_lines(
     cache: &mut PaneRenderCache,
     revision: u64,
@@ -2974,6 +3083,20 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn copy_mode_renders_at_one_cell_without_overflow() {
+        let backend = ratatui::backend::TestBackend::new(1, 1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+        let mode = crate::copy_mode::CopyMode::new(0, vec!["\u{6771}".into()], 1, 1);
+        let view = mode.view(1, 1);
+
+        terminal
+            .draw(|frame| {
+                render_copy_mode(frame, Rect::new(0, 0, 1, 1), &view, &GridPalette::default());
+            })
+            .expect("render copy mode");
+    }
 
     #[test]
     fn idle_pane_has_no_state_badges() {


### PR DESCRIPTION
## Summary

- add Alt+B keyboard copy mode for bounded focused-pane history
- add incremental search, next/previous navigation, character and line selection
- copy through the existing OSC-52/macOS clipboard path while live PTY output continues
- render a pane-local viewer with narrow-size handling and documented controls

## Validation

- direct `rustfmt` on changed Rust sources
- `git diff --check`
- compiler-bearing focused and broad checks deferred to automatic lease-owned batch validation

Closes #220