### PR TITLE
feat: capture and continuously log pane output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ agents and shells.
 | `Alt` + arrow keys | Move focus between panes |
 | `Alt+s` / `Alt+a` | Toggle the focused pane / select or clear all panes |
 | `Alt+c` | Open or close the command line |
+| `Alt+Shift+C` | Save bounded recent output from the target panes |
+| `Alt+Shift+L` | Start or stop continuous target-pane logging |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
 | `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |
@@ -121,8 +123,9 @@ gridbash --agent-api 2x3 --profile codex
 ```
 
 Configure an agent MCP server to run `gridbash --mcp`. It can show local images,
-send commands to specific panes, and update the GridBash status bar. The API is
-localhost-only, token-authenticated, and off by default.
+send commands, capture or continuously log specific panes, and update the
+GridBash status bar. The API is localhost-only, token-authenticated, and off by
+default.
 
 ## Compatibility and current limits
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -123,6 +123,9 @@ The MCP server exposes:
 | `gridbash_show_image` | Display a local PNG, JPEG, GIF, or WebP file in an overlay. |
 | `gridbash_send_command` | Send text to one or more 1-based pane numbers; submitting with Enter is optional. |
 | `gridbash_set_status` | Replace the current session's status-bar message. |
+| `gridbash_capture_output` | Save each target pane's bounded recent plain-text output. |
+| `gridbash_start_logging` | Start a separate continuous plain-text output log for each target pane. |
+| `gridbash_stop_logging` | Stop and flush each target pane's active output log. |
 
 The API binds only to localhost, authenticates with a per-session token, and is disabled by default.
 
@@ -144,6 +147,8 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+s | Toggle selection of the focused pane. |
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
+| Alt+Shift+C | Save bounded recent plain-text output from the focused or selected panes. |
+| Alt+Shift+L | Start or stop continuous output logs for the focused or selected panes. |
 | Alt+f | Zoom the focused pane to the full grid area, or restore the grid. |
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
@@ -161,6 +166,16 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+q | Quit. |
 
 Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
+
+Output capture writes the same bounded, ANSI-stripped pane tail used for session
+context. Continuous logging appends only new PTY output; submitted input,
+environment variables, and sibling panes are never added separately. With
+multiple selected panes, capture and logging create one file per selected pane;
+otherwise they target the focused pane. Active logs show a `logging` pane badge.
+Default collision-safe files live under GridBash's platform-local data `output`
+directory, and every operation reports its resolved path. Agent API capture and
+start-log calls may provide an explicit output directory. A write failure stops
+only the affected log and is reported in the status bar.
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
 

--- a/docs/devlogs/2026-07-15-capture-and-continuously-log-pane-output.md
+++ b/docs/devlogs/2026-07-15-capture-and-continuously-log-pane-output.md
@@ -1,0 +1,36 @@
+# Capture and continuously log pane output
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added bounded pane-output capture and opt-in continuous plain-text logging.
+
+## What Changed
+
+- Added Alt+Shift+C capture and Alt+Shift+L logging controls for the focused or
+  selected panes.
+- Added collision-safe per-pane output files with visible logging badges and
+  resolved-path status messages.
+- Added capture, start-log, and stop-log tools to the local agent control API.
+- Isolated log write failures so one failed destination cannot interrupt PTY
+  parsing or sibling panes.
+
+## Why It Matters
+
+- Agent debugging, build evidence, and long-running command output can be saved
+  without manual selection or mixing unrelated pane input into the record.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test output_capture`
+- `cargo test control`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Capture recent pane output or maintain continuous per-pane logs from the TUI
+  and local control API.

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,7 @@ use crate::{
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
+    output_capture::{self, OutputLogs, PaneLogKey},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile},
     pty::{PtyEvent, PtyPane, PtyWriteToken},
@@ -124,6 +125,7 @@ pub struct App {
     status: String,
     restored_histories: Vec<SavedPaneHistory>,
     session_recorder: Option<SessionRecorder>,
+    output_logs: OutputLogs,
     next_pane_id: usize,
     next_tab_number: usize,
     previous_panes_button: Option<Rect>,
@@ -1994,6 +1996,7 @@ impl App {
             status: init.status,
             restored_histories: init.restored_histories,
             session_recorder: init.session_recorder,
+            output_logs: OutputLogs::default(),
             next_pane_id: 0,
             next_tab_number: 2,
             previous_panes_button: None,
@@ -2573,20 +2576,28 @@ impl App {
             let bytes = pending_output
                 .remove(&(pane, generation))
                 .expect("pending output order and batches stay in sync");
+            let log_key = PaneLogKey::new(pane, generation);
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
                     let target = &mut self.panes[index];
                     let plain = target.process_output(&bytes);
                     self.capture_goal_output(index, &plain);
+                    changed |= self.append_output_log(log_key, index + 1, &plain);
                     self.mark_pane_touched(index);
                     changed |= !self.sleeping.contains(&index);
                 }
                 Some(PaneRoute::Inactive { tab, pane }) => {
-                    if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
+                    let plain = if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
                         let was_active = tab.panes[pane].active;
                         let plain = tab.panes[pane].process_output(&bytes);
                         capture_goal_text(&mut tab.manager_goal, &tab.sleeping, pane, &plain);
                         changed |= !was_active;
+                        Some(plain)
+                    } else {
+                        None
+                    };
+                    if let Some(plain) = plain {
+                        changed |= self.append_output_log(log_key, pane + 1, &plain);
                     }
                 }
                 None => {}
@@ -2594,6 +2605,18 @@ impl App {
         }
 
         for (pane, generation) in exited {
+            let log_key = PaneLogKey::new(pane, generation);
+            match self.output_logs.stop(log_key) {
+                Ok(Some(path)) => {
+                    self.status = format!("pane output log saved to {}", path.display());
+                    changed = true;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    self.status = format!("failed to finish pane output log: {error:#}");
+                    changed = true;
+                }
+            }
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
                     let target = &mut self.panes[index];
@@ -2629,6 +2652,18 @@ impl App {
         }
 
         changed
+    }
+
+    fn append_output_log(&mut self, key: PaneLogKey, pane_number: usize, plain_text: &str) -> bool {
+        match self.output_logs.append(key, plain_text) {
+            Ok(()) => false,
+            Err(error) => {
+                self.status = format!(
+                    "pane {pane_number} output logging stopped after a write failure: {error:#}"
+                );
+                true
+            }
+        }
     }
 
     fn poll_exited_panes(&mut self) -> bool {
@@ -2950,6 +2985,13 @@ impl App {
                 submit,
             } => self.send_control_command(&panes, &command, submit),
             ControlCommand::ShowImage { path, title } => self.show_control_image(path, title),
+            ControlCommand::CaptureOutput { panes, directory } => {
+                self.capture_control_output(&panes, directory.as_deref())
+            }
+            ControlCommand::StartLogging { panes, directory } => {
+                self.start_control_logging(&panes, directory.as_deref())
+            }
+            ControlCommand::StopLogging { panes } => self.stop_control_logging(&panes),
         }
     }
 
@@ -3032,6 +3074,187 @@ impl App {
         );
         self.image_overlay = Some(preview);
         ControlResponse::with_data(self.status.clone(), data)
+    }
+
+    fn capture_control_output(
+        &mut self,
+        pane_numbers: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.capture_output_for_indices(&targets, directory)
+    }
+
+    fn capture_output_for_indices(
+        &mut self,
+        targets: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to capture");
+        }
+        let directory = match output_capture::prepare_output_directory(directory) {
+            Ok(directory) => directory,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+
+        let mut files = Vec::new();
+        let mut paths = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let path =
+                match output_capture::capture_output(&directory, index + 1, pane.output_tail()) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        self.status = format!("pane {} capture failed: {error:#}", index + 1);
+                        return ControlResponse::error(self.status.clone());
+                    }
+                };
+            files.push(serde_json::json!({
+                "pane": index + 1,
+                "path": path.display().to_string()
+            }));
+            paths.push(path);
+        }
+
+        self.status = if let [path] = paths.as_slice() {
+            format!("captured pane output to {}", path.display())
+        } else {
+            format!(
+                "captured {} {} to {}",
+                targets.len(),
+                pane_word(targets.len()),
+                directory.display()
+            )
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({
+                "directory": directory.display().to_string(),
+                "files": files
+            }),
+        )
+    }
+
+    fn start_control_logging(
+        &mut self,
+        pane_numbers: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.start_logging_for_indices(&targets, directory)
+    }
+
+    fn start_logging_for_indices(
+        &mut self,
+        targets: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to log");
+        }
+        let directory = match output_capture::prepare_output_directory(directory) {
+            Ok(directory) => directory,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+
+        let mut logs = Vec::new();
+        let mut paths = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let key = PaneLogKey::new(pane.id(), pane.generation());
+            let path = match self.output_logs.path(key) {
+                Some(path) => path.to_path_buf(),
+                None => match self.output_logs.start(key, index + 1, &directory) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        self.status = format!("pane {} logging failed: {error:#}", index + 1);
+                        return ControlResponse::error(self.status.clone());
+                    }
+                },
+            };
+            logs.push(serde_json::json!({
+                "pane": index + 1,
+                "path": path.display().to_string()
+            }));
+            paths.push(path);
+        }
+
+        self.status = if let [path] = paths.as_slice() {
+            format!("logging pane output to {}", path.display())
+        } else {
+            format!(
+                "logging {} {} to {}",
+                targets.len(),
+                pane_word(targets.len()),
+                directory.display()
+            )
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({
+                "directory": directory.display().to_string(),
+                "logs": logs
+            }),
+        )
+    }
+
+    fn stop_control_logging(&mut self, pane_numbers: &[usize]) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.stop_logging_for_indices(&targets)
+    }
+
+    fn stop_logging_for_indices(&mut self, targets: &[usize]) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to stop logging");
+        }
+
+        let mut stopped = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let key = PaneLogKey::new(pane.id(), pane.generation());
+            match self.output_logs.stop(key) {
+                Ok(Some(path)) => stopped.push(serde_json::json!({
+                    "pane": index + 1,
+                    "path": path.display().to_string()
+                })),
+                Ok(None) => {}
+                Err(error) => {
+                    self.status = format!("pane {} log stop failed: {error:#}", index + 1);
+                    return ControlResponse::error(self.status.clone());
+                }
+            }
+        }
+
+        self.status = if stopped.is_empty() {
+            "target panes were not being logged".into()
+        } else if stopped.len() == 1 {
+            format!(
+                "stopped pane output log: {}",
+                stopped[0]["path"].as_str().unwrap_or("unknown path")
+            )
+        } else {
+            format!("stopped {} pane output log(s)", stopped.len())
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({ "stopped": stopped }),
+        )
     }
 
     fn control_pane_indices(&self, pane_numbers: &[usize]) -> Result<Vec<usize>> {
@@ -3303,6 +3526,10 @@ impl App {
                 self.open_new_tab(terminal)?;
                 Ok(Some(false))
             }
+            'l' if modifiers.contains(KeyModifiers::SHIFT) => {
+                self.toggle_target_output_logging();
+                Ok(Some(false))
+            }
             'l' => {
                 self.open_grid_resizer();
                 Ok(Some(false))
@@ -3313,6 +3540,10 @@ impl App {
             }
             'f' => {
                 self.toggle_zoom();
+                Ok(Some(false))
+            }
+            'c' if modifiers.contains(KeyModifiers::SHIFT) => {
+                self.capture_target_output();
                 Ok(Some(false))
             }
             'c' => {
@@ -5462,6 +5693,32 @@ impl App {
         input_targets_for(self.focus, &self.selected, self.panes.len())
     }
 
+    fn capture_target_output(&mut self) {
+        let targets = self.target_panes();
+        let response = self.capture_output_for_indices(&targets, None);
+        self.status = response.message;
+    }
+
+    fn toggle_target_output_logging(&mut self) {
+        let targets = self.target_panes();
+        if targets.is_empty() {
+            self.status = "no target panes available to log".into();
+            return;
+        }
+        let all_logging = targets.iter().all(|index| {
+            self.panes.get(*index).is_some_and(|pane| {
+                self.output_logs
+                    .is_active(PaneLogKey::new(pane.id(), pane.generation()))
+            })
+        });
+        let response = if all_logging {
+            self.stop_logging_for_indices(&targets)
+        } else {
+            self.start_logging_for_indices(&targets, None)
+        };
+        self.status = response.message;
+    }
+
     fn toggle_sleep_for_focused_pane(&mut self) {
         if self.panes.is_empty() {
             self.status = "no panes to sleep".into();
@@ -5702,6 +5959,13 @@ impl App {
 
     pub fn pane_sleeping(&self, index: usize) -> bool {
         self.sleeping.contains(&index)
+    }
+
+    pub fn pane_logging(&self, index: usize) -> bool {
+        self.panes.get(index).is_some_and(|pane| {
+            self.output_logs
+                .is_active(PaneLogKey::new(pane.id(), pane.generation()))
+        })
     }
 
     pub fn status(&self) -> &str {
@@ -8250,6 +8514,16 @@ mod tests {
     #[test]
     fn input_targets_selected_panes_when_multiple_panes_are_selected() {
         assert_eq!(input_targets_for(2, &selected(&[0, 3]), 4), vec![0, 3]);
+    }
+
+    #[test]
+    fn output_actions_use_the_focused_or_multi_selected_target_set() {
+        assert_eq!(input_targets_for(2, &selected(&[]), 4), vec![2]);
+        assert_eq!(input_targets_for(2, &selected(&[1]), 4), vec![2]);
+        assert_eq!(
+            input_targets_for(2, &selected(&[0, 1, 3]), 4),
+            vec![0, 1, 3]
+        );
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -47,6 +47,17 @@ pub enum ControlCommand {
         path: PathBuf,
         title: Option<String>,
     },
+    CaptureOutput {
+        panes: Vec<usize>,
+        directory: Option<PathBuf>,
+    },
+    StartLogging {
+        panes: Vec<usize>,
+        directory: Option<PathBuf>,
+    },
+    StopLogging {
+        panes: Vec<usize>,
+    },
 }
 
 #[derive(Debug)]
@@ -308,6 +319,68 @@ fn tools_list_result() -> Value {
                     },
                     "required": ["message"]
                 }
+            },
+            {
+                "name": "gridbash_capture_output",
+                "title": "Capture Pane Output",
+                "description": "Save bounded recent plain-text output from one or more GridBash panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to capture.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        },
+                        "directory": {
+                            "type": "string",
+                            "description": "Optional output directory. GridBash local data storage is used by default."
+                        }
+                    },
+                    "required": ["panes"]
+                }
+            },
+            {
+                "name": "gridbash_start_logging",
+                "title": "Start Pane Logging",
+                "description": "Continuously append new plain-text output from one or more GridBash panes to separate files.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to log.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        },
+                        "directory": {
+                            "type": "string",
+                            "description": "Optional output directory. GridBash local data storage is used by default."
+                        }
+                    },
+                    "required": ["panes"]
+                }
+            },
+            {
+                "name": "gridbash_stop_logging",
+                "title": "Stop Pane Logging",
+                "description": "Stop and flush continuous output logs for one or more GridBash panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to stop logging.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        }
+                    },
+                    "required": ["panes"]
+                }
             }
         ]
     })
@@ -370,6 +443,42 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
             Ok(ControlCommand::SetStatus {
                 message: args.message,
             })
+        }
+        "gridbash_capture_output" | "gridbash_start_logging" => {
+            #[derive(Deserialize)]
+            struct Args {
+                panes: Vec<usize>,
+                directory: Option<PathBuf>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid output args")?;
+            if args.panes.is_empty() {
+                return Err(anyhow!("at least one pane is required"));
+            }
+            let directory = args.directory.map(absolute_tool_path).transpose()?;
+            if tool_name == "gridbash_capture_output" {
+                Ok(ControlCommand::CaptureOutput {
+                    panes: args.panes,
+                    directory,
+                })
+            } else {
+                Ok(ControlCommand::StartLogging {
+                    panes: args.panes,
+                    directory,
+                })
+            }
+        }
+        "gridbash_stop_logging" => {
+            #[derive(Deserialize)]
+            struct Args {
+                panes: Vec<usize>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid logging args")?;
+            if args.panes.is_empty() {
+                return Err(anyhow!("at least one pane is required"));
+            }
+            Ok(ControlCommand::StopLogging { panes: args.panes })
         }
         _ => Err(anyhow!("unknown GridBash tool: {tool_name}")),
     }
@@ -472,7 +581,10 @@ mod tests {
             vec![
                 "gridbash_show_image",
                 "gridbash_send_command",
-                "gridbash_set_status"
+                "gridbash_set_status",
+                "gridbash_capture_output",
+                "gridbash_start_logging",
+                "gridbash_stop_logging"
             ]
         );
     }
@@ -495,6 +607,27 @@ mod tests {
                 command,
                 submit: true
             } if panes == vec![2] && command == "cargo test"
+        ));
+    }
+
+    #[test]
+    fn output_tools_parse_targets_and_optional_directories() {
+        let capture = tool_arguments_to_command(
+            "gridbash_capture_output",
+            json!({ "panes": [1, 3], "directory": "captures" }),
+        )
+        .expect("capture command");
+        assert!(matches!(
+            capture,
+            ControlCommand::CaptureOutput { panes, directory: Some(path) }
+                if panes == vec![1, 3] && path.is_absolute() && path.ends_with("captures")
+        ));
+
+        let stop = tool_arguments_to_command("gridbash_stop_logging", json!({ "panes": [2] }))
+            .expect("stop command");
+        assert!(matches!(
+            stop,
+            ControlCommand::StopLogging { panes } if panes == vec![2]
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod image_preview;
 mod layout;
 mod manager;
 mod onboarding;
+mod output_capture;
 mod process_priority;
 mod profiles;
 mod pty;

--- a/src/output_capture.rs
+++ b/src/output_capture.rs
@@ -1,0 +1,343 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions},
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use directories::ProjectDirs;
+
+use crate::layout::PaneId;
+
+const OUTPUT_FILE_ATTEMPTS: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PaneLogKey {
+    pub pane: PaneId,
+    pub generation: u64,
+}
+
+impl PaneLogKey {
+    pub fn new(pane: PaneId, generation: u64) -> Self {
+        Self { pane, generation }
+    }
+}
+
+pub fn default_output_directory() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "GridBash")
+        .map(|dirs| dirs.data_local_dir().join("output"))
+        .ok_or_else(|| anyhow!("failed to resolve GridBash output directory"))
+}
+
+pub fn prepare_output_directory(directory: Option<&Path>) -> Result<PathBuf> {
+    let directory = match directory {
+        Some(path) if path.as_os_str().is_empty() => bail!("output directory cannot be empty"),
+        Some(path) => path.to_path_buf(),
+        None => default_output_directory()?,
+    };
+
+    if directory.exists() && !directory.is_dir() {
+        bail!("output path is not a directory: {}", directory.display());
+    }
+    fs::create_dir_all(&directory)
+        .with_context(|| format!("failed to create output directory {}", directory.display()))?;
+    Ok(directory)
+}
+
+pub fn capture_output(directory: &Path, pane_number: usize, plain_text: &str) -> Result<PathBuf> {
+    let (path, mut file) = create_output_file(directory, "capture", pane_number, "txt")?;
+    file.write_all(plain_text.as_bytes())
+        .with_context(|| format!("failed to write capture {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush capture {}", path.display()))?;
+    Ok(path)
+}
+
+struct PaneLogger {
+    path: PathBuf,
+    writer: Box<dyn Write + Send>,
+}
+
+impl std::fmt::Debug for PaneLogger {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PaneLogger")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl PaneLogger {
+    fn start(directory: &Path, pane_number: usize) -> Result<Self> {
+        let (path, file) = create_output_file(directory, "log", pane_number, "log")?;
+        Ok(Self {
+            path,
+            writer: Box::new(BufWriter::new(file)),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_writer(path: PathBuf, writer: impl Write + Send + 'static) -> Self {
+        Self {
+            path,
+            writer: Box::new(writer),
+        }
+    }
+
+    fn append(&mut self, plain_text: &str) -> Result<()> {
+        if plain_text.is_empty() {
+            return Ok(());
+        }
+        self.writer
+            .write_all(plain_text.as_bytes())
+            .with_context(|| format!("failed to append log {}", self.path.display()))?;
+        self.writer
+            .flush()
+            .with_context(|| format!("failed to flush log {}", self.path.display()))
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.writer
+            .flush()
+            .with_context(|| format!("failed to flush log {}", self.path.display()))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct OutputLogs {
+    active: HashMap<PaneLogKey, PaneLogger>,
+}
+
+impl OutputLogs {
+    pub fn start(
+        &mut self,
+        key: PaneLogKey,
+        pane_number: usize,
+        directory: &Path,
+    ) -> Result<PathBuf> {
+        if let Some(logger) = self.active.get(&key) {
+            bail!(
+                "pane {pane_number} is already logging to {}",
+                logger.path.display()
+            );
+        }
+        let logger = PaneLogger::start(directory, pane_number)?;
+        let path = logger.path.clone();
+        self.active.insert(key, logger);
+        Ok(path)
+    }
+
+    pub fn stop(&mut self, key: PaneLogKey) -> Result<Option<PathBuf>> {
+        let Some(mut logger) = self.active.remove(&key) else {
+            return Ok(None);
+        };
+        let path = logger.path.clone();
+        logger.finish()?;
+        Ok(Some(path))
+    }
+
+    pub fn append(&mut self, key: PaneLogKey, plain_text: &str) -> Result<()> {
+        let result = match self.active.get_mut(&key) {
+            Some(logger) => logger.append(plain_text),
+            None => return Ok(()),
+        };
+        if result.is_err() {
+            self.active.remove(&key);
+        }
+        result
+    }
+
+    pub fn is_active(&self, key: PaneLogKey) -> bool {
+        self.active.contains_key(&key)
+    }
+
+    pub fn path(&self, key: PaneLogKey) -> Option<&Path> {
+        self.active.get(&key).map(|logger| logger.path.as_path())
+    }
+
+    #[cfg(test)]
+    fn insert_logger(&mut self, key: PaneLogKey, logger: PaneLogger) {
+        self.active.insert(key, logger);
+    }
+}
+
+fn create_output_file(
+    directory: &Path,
+    kind: &str,
+    pane_number: usize,
+    extension: &str,
+) -> Result<(PathBuf, File)> {
+    let directory = prepare_output_directory(Some(directory))?;
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_millis();
+
+    for attempt in 0..OUTPUT_FILE_ATTEMPTS {
+        let suffix = if attempt == 0 {
+            String::new()
+        } else {
+            format!("-{attempt}")
+        };
+        let path = directory.join(format!(
+            "gridbash-{kind}-{stamp}-pane-{pane_number}{suffix}.{extension}"
+        ));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to create output file {}", path.display()));
+            }
+        }
+    }
+
+    bail!(
+        "failed to allocate a unique {kind} filename in {}",
+        directory.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let unique = format!(
+                "gridbash-{label}-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("test clock")
+                    .as_nanos()
+            );
+            let path = std::env::temp_dir().join(unique);
+            fs::create_dir_all(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("writer lock").extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _bytes: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("disk unavailable"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn key(generation: u64) -> PaneLogKey {
+        PaneLogKey::new(PaneId(7), generation)
+    }
+
+    #[test]
+    fn output_directory_validation_rejects_empty_and_file_paths() {
+        let directory = TestDirectory::new("path-validation");
+        let file = directory.path().join("not-a-directory");
+        fs::write(&file, "content").expect("write fixture");
+
+        assert!(prepare_output_directory(Some(Path::new(""))).is_err());
+        assert!(prepare_output_directory(Some(&file)).is_err());
+        assert_eq!(
+            prepare_output_directory(Some(directory.path())).expect("valid directory"),
+            directory.path()
+        );
+    }
+
+    #[test]
+    fn captures_use_collision_safe_paths() {
+        let directory = TestDirectory::new("capture-paths");
+        let first = capture_output(directory.path(), 1, "first").expect("first capture");
+        let second = capture_output(directory.path(), 1, "second").expect("second capture");
+
+        assert_ne!(first, second);
+        assert_eq!(fs::read_to_string(first).expect("first text"), "first");
+        assert_eq!(fs::read_to_string(second).expect("second text"), "second");
+    }
+
+    #[test]
+    fn logger_appends_output_in_order() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let writer = SharedWriter(bytes.clone());
+        let mut logger = PaneLogger::with_writer(PathBuf::from("ordered.log"), writer);
+
+        logger.append("first\n").expect("first append");
+        logger.append("second\n").expect("second append");
+
+        assert_eq!(
+            String::from_utf8(bytes.lock().expect("bytes lock").clone()).expect("utf8"),
+            "first\nsecond\n"
+        );
+    }
+
+    #[test]
+    fn logging_can_stop_and_restart_with_a_new_file() {
+        let directory = TestDirectory::new("restart");
+        let mut logs = OutputLogs::default();
+        let first = logs.start(key(1), 1, directory.path()).expect("start");
+        assert!(logs.is_active(key(1)));
+        assert_eq!(logs.stop(key(1)).expect("stop"), Some(first.clone()));
+        assert!(!logs.is_active(key(1)));
+
+        let second = logs.start(key(1), 1, directory.path()).expect("restart");
+        assert_ne!(first, second);
+        assert!(logs.is_active(key(1)));
+    }
+
+    #[test]
+    fn write_failure_removes_only_the_failed_logger() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let mut logs = OutputLogs::default();
+        logs.insert_logger(
+            key(1),
+            PaneLogger::with_writer(PathBuf::from("failed.log"), FailingWriter),
+        );
+        logs.insert_logger(
+            key(2),
+            PaneLogger::with_writer(PathBuf::from("healthy.log"), SharedWriter(bytes.clone())),
+        );
+
+        assert!(logs.append(key(1), "lost").is_err());
+        assert!(!logs.is_active(key(1)));
+        assert!(logs.append(key(2), "kept").is_ok());
+        assert!(logs.is_active(key(2)));
+        assert_eq!(&*bytes.lock().expect("bytes lock"), b"kept");
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -135,6 +135,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let selected = app.selected().contains(&index);
         let sleeping = app.pane_sleeping(index);
         let quiet = app.activity_badges_enabled() && pane.output_quiet();
+        let logging = app.pane_logging(index);
         let chrome = pane_chrome(
             selected,
             focused,
@@ -144,6 +145,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             quiet,
             palette,
         );
+        let badge = if logging {
+            format!("{} logging", chrome.badge)
+        } else {
+            chrome.badge.to_string()
+        };
 
         let header_summary = app.pane_header_summary(index, rect.width as usize);
         let usage = app.pane_usage_label(index);
@@ -152,7 +158,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             chrome.quiet_marker,
             &header_summary,
             usage.as_deref(),
-            chrome.badge,
+            &badge,
             app.compact_titles_enabled(),
             rect.width.saturating_sub(2),
         );
@@ -2599,6 +2605,8 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+t", "switch to next tab"),
         ("Alt+Shift+r", "rename current tab"),
         ("Alt+c", "expand or close the command line"),
+        ("Alt+Shift+c", "capture target pane output"),
+        ("Alt+Shift+l", "start or stop pane logging"),
         ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+f", "zoom or restore focused pane"),


### PR DESCRIPTION
## Summary

- capture each target pane bounded ANSI-stripped output tail to a collision-safe file
- start and stop stable-ID per-pane continuous logs with visible pane badges
- isolate write failures to the affected logger while PTY parsing continues
- expose capture/start/stop through the local control API and document TUI shortcuts

## Validation

- direct `rustfmt` on changed Rust sources
- `git diff --check`
- compiler-bearing focused and broad checks deferred to automatic lease-owned batch validation

Closes #221