### PR TITLE
feat: add scriptable control CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The npm package installs only the native binary for your current platform.
 | `gridbash 2x3 --profile codex --worktrees` | Isolate every pane in a git worktree |
 | `gridbash resume` | Choose a saved session to reopen |
 | `gridbash resume --latest` | Reopen the latest saved session |
+| `gridbash ctl list --json` | Discover opted-in running grids |
+| `gridbash ctl panes --session ID` | Inspect numbered and stable pane identities |
 | `gridbash --list-profiles` | Show detected profiles and resolved commands |
 | `gridbash --help` | Show every CLI option |
 
@@ -126,6 +128,19 @@ Configure an agent MCP server to run `gridbash --mcp`. It can show local images,
 send commands, capture or continuously log specific panes, and update the
 GridBash status bar. The API is localhost-only, token-authenticated, and off by
 default.
+
+The same typed API is available to scripts through `gridbash ctl`. Discovery
+metadata contains runtime IDs and localhost endpoints, never bearer tokens.
+`ctl list` and `ctl panes` are read-only; send, capture, status, and focus
+operations require `--token` or `GRIDBASH_CONTROL_TOKEN`. Child panes receive
+the session ID and token automatically:
+
+```sh
+gridbash ctl list --json
+gridbash ctl panes --session <id-or-prefix> --json
+gridbash ctl send --session <id> --pane 2 "cargo test"
+gridbash ctl focus --session <id> pane-4-gen-2
+```
 
 ## Compatibility and current limits
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ agents and shells.
 | `Alt` + arrow keys | Move focus between panes |
 | `Alt+s` / `Alt+a` | Toggle the focused pane / select or clear all panes |
 | `Alt+c` | Open or close the command line |
+| `Alt+Shift+C` | Save bounded recent output from the target panes |
+| `Alt+Shift+L` | Start or stop continuous target-pane logging |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
 | `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |
@@ -121,8 +123,9 @@ gridbash --agent-api 2x3 --profile codex
 ```
 
 Configure an agent MCP server to run `gridbash --mcp`. It can show local images,
-send commands to specific panes, and update the GridBash status bar. The API is
-localhost-only, token-authenticated, and off by default.
+send commands, capture or continuously log specific panes, and update the
+GridBash status bar. The API is localhost-only, token-authenticated, and off by
+default.
 
 ## Compatibility and current limits
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -129,6 +129,34 @@ The MCP server exposes:
 
 The API binds only to localhost, authenticates with a per-session token, and is disabled by default.
 
+### Scriptable control CLI
+
+Enabled GridBash processes publish owner-local discovery records containing a
+runtime session ID, localhost endpoint, PID, and start time. Bearer tokens are
+never written to discovery. Stale records are pruned when `ctl` cannot complete
+the server's tokenless liveness ping.
+
+```powershell
+gridbash ctl list
+gridbash ctl list --json
+gridbash ctl panes --session <id-or-unique-prefix>
+gridbash ctl panes --session <id> --json
+gridbash ctl send --session <id> --pane 2 "cargo test"
+gridbash ctl send --session <id> --pane pane-4-gen-2 --no-submit "review this"
+gridbash ctl capture --session <id> --pane 2 --directory C:\captures
+gridbash ctl status --session <id> "integration running"
+gridbash ctl focus --session <id> pane-4-gen-2
+```
+
+`ctl list` and `ctl panes` do not require a token. Mutating commands require
+`--token TOKEN` or `GRIDBASH_CONTROL_TOKEN`; when invoked inside a GridBash pane,
+`GRIDBASH_CONTROL_SESSION` also selects that grid automatically. If more than
+one session is running and no environment selection exists, `--session` must be
+an exact ID or unambiguous prefix. Pane numbers refer to the inspected current
+tab. Stable IDs have the form `pane-<id>-gen-<generation>` and are rejected if a
+pane has restarted since inspection. Add `--json` to any command for structured
+output.
+
 ## Controls
 
 GridBash is modeless: ordinary terminal input continues to the active target, while application commands use Alt shortcuts.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -123,6 +123,9 @@ The MCP server exposes:
 | `gridbash_show_image` | Display a local PNG, JPEG, GIF, or WebP file in an overlay. |
 | `gridbash_send_command` | Send text to one or more 1-based pane numbers; submitting with Enter is optional. |
 | `gridbash_set_status` | Replace the current session's status-bar message. |
+| `gridbash_capture_output` | Save each target pane's bounded recent plain-text output. |
+| `gridbash_start_logging` | Start a separate continuous plain-text output log for each target pane. |
+| `gridbash_stop_logging` | Stop and flush each target pane's active output log. |
 
 The API binds only to localhost, authenticates with a per-session token, and is disabled by default.
 
@@ -144,6 +147,8 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+s | Toggle selection of the focused pane. |
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
+| Alt+Shift+C | Save bounded recent plain-text output from the focused or selected panes. |
+| Alt+Shift+L | Start or stop continuous output logs for the focused or selected panes. |
 | Alt+f | Zoom the focused pane to the full grid area, or restore the grid. |
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
@@ -161,6 +166,16 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+q | Quit. |
 
 Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
+
+Output capture writes the same bounded, ANSI-stripped pane tail used for session
+context. Continuous logging appends only new PTY output; submitted input,
+environment variables, and sibling panes are never added separately. With
+multiple selected panes, capture and logging create one file per selected pane;
+otherwise they target the focused pane. Active logs show a `logging` pane badge.
+Default collision-safe files live under GridBash's platform-local data `output`
+directory, and every operation reports its resolved path. Agent API capture and
+start-log calls may provide an explicit output directory. A write failure stops
+only the affected log and is reported in the status bar.
 
 When multiple panes are selected, typing is broadcast to them. With zero or one selected pane, input goes only to the focused pane. The Alt+c command line captures its output and runs Enter-submitted commands in the cwd shown in its prompt.
 

--- a/docs/devlogs/2026-07-15-add-a-scriptable-cli-for-running-grid-sessions.md
+++ b/docs/devlogs/2026-07-15-add-a-scriptable-cli-for-running-grid-sessions.md
@@ -1,0 +1,35 @@
+# Add a scriptable CLI for running grid sessions
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added `gridbash ctl` for discovering, inspecting, and safely controlling
+  opted-in running grids from scripts.
+
+## What Changed
+
+- Published owner-local runtime discovery metadata without bearer credentials.
+- Added human and JSON `ctl list` and `ctl panes` output.
+- Added token-authenticated send, capture, status, and focus commands.
+- Added stable pane identities with generation checks that reject stale targets.
+- Reused the same serialized control commands for MCP tools and the CLI.
+
+## Why It Matters
+
+- External scripts can discover the right grid, inspect exact pane state, and
+  perform bounded actions without guessing ports or racing pane restarts.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test control`
+- `cargo test control_discovery`
+- `cargo test cli`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Use `gridbash ctl` for machine-readable running-session and pane control.

--- a/docs/devlogs/2026-07-15-capture-and-continuously-log-pane-output.md
+++ b/docs/devlogs/2026-07-15-capture-and-continuously-log-pane-output.md
@@ -1,0 +1,36 @@
+# Capture and continuously log pane output
+
+Date: 2026-07-15
+Release target: unreleased
+
+## Summary
+
+- Added bounded pane-output capture and opt-in continuous plain-text logging.
+
+## What Changed
+
+- Added Alt+Shift+C capture and Alt+Shift+L logging controls for the focused or
+  selected panes.
+- Added collision-safe per-pane output files with visible logging badges and
+  resolved-path status messages.
+- Added capture, start-log, and stop-log tools to the local agent control API.
+- Isolated log write failures so one failed destination cannot interrupt PTY
+  parsing or sibling panes.
+
+## Why It Matters
+
+- Agent debugging, build evidence, and long-running command output can be saved
+  without manual selection or mixing unrelated pane input into the record.
+
+## Validation
+
+- `cargo fmt -- --check`
+- `cargo test output_capture`
+- `cargo test control`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+
+## Release Notes
+
+- Capture recent pane output or maintain continuous per-pane logs from the TUI
+  and local control API.

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,7 +35,10 @@ use crate::{
     codex_sqlite::{CodexSqlitePool, PaneCodexSqlite},
     composer::{Composer, GridPicker, GridPickerAction},
     config::{Config, PaletteColor, PaneWorkloadPolicy, UiConfig, UiPalette},
-    control::{self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse},
+    control::{
+        self, ControlCommand, ControlEnvelope, ControlHandle, ControlResponse, PaneIdentity,
+        PaneTarget,
+    },
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
@@ -2263,6 +2266,10 @@ impl App {
                     control.token().to_string().into(),
                 ),
                 (
+                    "GRIDBASH_CONTROL_SESSION".into(),
+                    control.id().to_string().into(),
+                ),
+                (
                     "GRIDBASH_PANE_INDEX".into(),
                     (pane_index + 1).to_string().into(),
                 ),
@@ -2978,6 +2985,8 @@ impl App {
 
     fn handle_control_command(&mut self, command: ControlCommand) -> ControlResponse {
         match command {
+            ControlCommand::Ping => ControlResponse::ok("GridBash control session is live"),
+            ControlCommand::Describe => self.describe_control_session(),
             ControlCommand::SetStatus { message } => self.set_control_status(message),
             ControlCommand::SendCommand {
                 panes,
@@ -2992,7 +3001,70 @@ impl App {
                 self.start_control_logging(&panes, directory.as_deref())
             }
             ControlCommand::StopLogging { panes } => self.stop_control_logging(&panes),
+            ControlCommand::Focus { pane } => self.focus_control_pane(&pane),
         }
+    }
+
+    fn describe_control_session(&self) -> ControlResponse {
+        let Some(control) = self.control_handle.as_ref() else {
+            return ControlResponse::error("GridBash control API is not enabled");
+        };
+        let panes = self
+            .panes
+            .iter()
+            .enumerate()
+            .map(|(index, pane)| {
+                serde_json::json!({
+                    "number": index + 1,
+                    "id": PaneTarget::stable_label(pane.id(), pane.generation()),
+                    "pane_id": pane.id().0,
+                    "generation": pane.generation(),
+                    "label": self.pane_label(index),
+                    "cwd": pane.cwd().display().to_string(),
+                    "focused": self.focus == index && !self.command_line.focused,
+                    "selected": self.selected.contains(&index),
+                    "sleeping": self.sleeping.contains(&index),
+                    "logging": self.pane_logging(index),
+                    "exited": pane.exited
+                })
+            })
+            .collect::<Vec<_>>();
+        let grid = self.layout.size();
+        ControlResponse::with_data(
+            format!("{} running pane(s)", panes.len()),
+            serde_json::json!({
+                "id": control.id(),
+                "endpoint": control.endpoint(),
+                "pid": std::process::id(),
+                "active_tab": self.active_tab + 1,
+                "tab_title": self.tab_title,
+                "grid": { "rows": grid.rows, "columns": grid.columns },
+                "status": self.status,
+                "panes": panes
+            }),
+        )
+    }
+
+    fn focus_control_pane(&mut self, pane: &PaneTarget) -> ControlResponse {
+        let targets = match self.control_pane_indices(std::slice::from_ref(pane)) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        let index = targets[0];
+        self.command_line.focused = false;
+        self.focus = index;
+        self.mark_pane_touched(index);
+        self.status = format!("focused pane {}", index + 1);
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({
+                "number": index + 1,
+                "id": PaneTarget::stable_label(
+                    self.panes[index].id(),
+                    self.panes[index].generation()
+                )
+            }),
+        )
     }
 
     fn set_control_status(&mut self, message: String) -> ControlResponse {
@@ -3007,7 +3079,7 @@ impl App {
 
     fn send_control_command(
         &mut self,
-        pane_numbers: &[usize],
+        pane_numbers: &[PaneTarget],
         command: &str,
         submit: bool,
     ) -> ControlResponse {
@@ -3078,7 +3150,7 @@ impl App {
 
     fn capture_control_output(
         &mut self,
-        pane_numbers: &[usize],
+        pane_numbers: &[PaneTarget],
         directory: Option<&Path>,
     ) -> ControlResponse {
         let targets = match self.control_pane_indices(pane_numbers) {
@@ -3143,7 +3215,7 @@ impl App {
 
     fn start_control_logging(
         &mut self,
-        pane_numbers: &[usize],
+        pane_numbers: &[PaneTarget],
         directory: Option<&Path>,
     ) -> ControlResponse {
         let targets = match self.control_pane_indices(pane_numbers) {
@@ -3209,7 +3281,7 @@ impl App {
         )
     }
 
-    fn stop_control_logging(&mut self, pane_numbers: &[usize]) -> ControlResponse {
+    fn stop_control_logging(&mut self, pane_numbers: &[PaneTarget]) -> ControlResponse {
         let targets = match self.control_pane_indices(pane_numbers) {
             Ok(targets) => targets,
             Err(error) => return ControlResponse::error(format!("{error:#}")),
@@ -3257,27 +3329,28 @@ impl App {
         )
     }
 
-    fn control_pane_indices(&self, pane_numbers: &[usize]) -> Result<Vec<usize>> {
-        if pane_numbers.is_empty() {
-            return Err(anyhow!("at least one target pane is required"));
-        }
-
-        let mut targets = BTreeSet::new();
-        for pane_number in pane_numbers {
-            if *pane_number == 0 || *pane_number > self.panes.len() {
-                return Err(anyhow!("pane {pane_number} is not available"));
-            }
-            let index = pane_number - 1;
-            if self.sleeping.contains(&index) {
+    fn control_pane_indices(&self, pane_targets: &[PaneTarget]) -> Result<Vec<usize>> {
+        let identities = self
+            .panes
+            .iter()
+            .enumerate()
+            .map(|(index, pane)| PaneIdentity {
+                index,
+                pane: pane.id(),
+                generation: pane.generation(),
+            })
+            .collect::<Vec<_>>();
+        let targets = control::resolve_pane_targets(pane_targets, &identities)?;
+        for index in &targets {
+            let pane_number = *index + 1;
+            if self.sleeping.contains(index) {
                 return Err(anyhow!("pane {pane_number} is asleep"));
             }
-            if self.panes.get(index).is_some_and(|pane| pane.exited) {
+            if self.panes.get(*index).is_some_and(|pane| pane.exited) {
                 return Err(anyhow!("pane {pane_number} has exited"));
             }
-            targets.insert(index);
         }
-
-        Ok(targets.into_iter().collect())
+        Ok(targets)
     }
 
     fn decay_activity(&mut self) -> bool {

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,6 +39,7 @@ use crate::{
     image_preview::{self, ImagePreview},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ManagerCommand, ManagerDecision},
+    output_capture::{self, OutputLogs, PaneLogKey},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile},
     pty::{PtyEvent, PtyPane, PtyWriteToken},
@@ -124,6 +125,7 @@ pub struct App {
     status: String,
     restored_histories: Vec<SavedPaneHistory>,
     session_recorder: Option<SessionRecorder>,
+    output_logs: OutputLogs,
     next_pane_id: usize,
     next_tab_number: usize,
     previous_panes_button: Option<Rect>,
@@ -1994,6 +1996,7 @@ impl App {
             status: init.status,
             restored_histories: init.restored_histories,
             session_recorder: init.session_recorder,
+            output_logs: OutputLogs::default(),
             next_pane_id: 0,
             next_tab_number: 2,
             previous_panes_button: None,
@@ -2573,20 +2576,28 @@ impl App {
             let bytes = pending_output
                 .remove(&(pane, generation))
                 .expect("pending output order and batches stay in sync");
+            let log_key = PaneLogKey::new(pane, generation);
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
                     let target = &mut self.panes[index];
                     let plain = target.process_output(&bytes);
                     self.capture_goal_output(index, &plain);
+                    changed |= self.append_output_log(log_key, index + 1, &plain);
                     self.mark_pane_touched(index);
                     changed |= !self.sleeping.contains(&index);
                 }
                 Some(PaneRoute::Inactive { tab, pane }) => {
-                    if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
+                    let plain = if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
                         let was_active = tab.panes[pane].active;
                         let plain = tab.panes[pane].process_output(&bytes);
                         capture_goal_text(&mut tab.manager_goal, &tab.sleeping, pane, &plain);
                         changed |= !was_active;
+                        Some(plain)
+                    } else {
+                        None
+                    };
+                    if let Some(plain) = plain {
+                        changed |= self.append_output_log(log_key, pane + 1, &plain);
                     }
                 }
                 None => {}
@@ -2594,6 +2605,18 @@ impl App {
         }
 
         for (pane, generation) in exited {
+            let log_key = PaneLogKey::new(pane, generation);
+            match self.output_logs.stop(log_key) {
+                Ok(Some(path)) => {
+                    self.status = format!("pane output log saved to {}", path.display());
+                    changed = true;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    self.status = format!("failed to finish pane output log: {error:#}");
+                    changed = true;
+                }
+            }
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
                     let target = &mut self.panes[index];
@@ -2629,6 +2652,18 @@ impl App {
         }
 
         changed
+    }
+
+    fn append_output_log(&mut self, key: PaneLogKey, pane_number: usize, plain_text: &str) -> bool {
+        match self.output_logs.append(key, plain_text) {
+            Ok(()) => false,
+            Err(error) => {
+                self.status = format!(
+                    "pane {pane_number} output logging stopped after a write failure: {error:#}"
+                );
+                true
+            }
+        }
     }
 
     fn poll_exited_panes(&mut self) -> bool {
@@ -2950,6 +2985,13 @@ impl App {
                 submit,
             } => self.send_control_command(&panes, &command, submit),
             ControlCommand::ShowImage { path, title } => self.show_control_image(path, title),
+            ControlCommand::CaptureOutput { panes, directory } => {
+                self.capture_control_output(&panes, directory.as_deref())
+            }
+            ControlCommand::StartLogging { panes, directory } => {
+                self.start_control_logging(&panes, directory.as_deref())
+            }
+            ControlCommand::StopLogging { panes } => self.stop_control_logging(&panes),
         }
     }
 
@@ -3032,6 +3074,187 @@ impl App {
         );
         self.image_overlay = Some(preview);
         ControlResponse::with_data(self.status.clone(), data)
+    }
+
+    fn capture_control_output(
+        &mut self,
+        pane_numbers: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.capture_output_for_indices(&targets, directory)
+    }
+
+    fn capture_output_for_indices(
+        &mut self,
+        targets: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to capture");
+        }
+        let directory = match output_capture::prepare_output_directory(directory) {
+            Ok(directory) => directory,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+
+        let mut files = Vec::new();
+        let mut paths = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let path =
+                match output_capture::capture_output(&directory, index + 1, pane.output_tail()) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        self.status = format!("pane {} capture failed: {error:#}", index + 1);
+                        return ControlResponse::error(self.status.clone());
+                    }
+                };
+            files.push(serde_json::json!({
+                "pane": index + 1,
+                "path": path.display().to_string()
+            }));
+            paths.push(path);
+        }
+
+        self.status = if let [path] = paths.as_slice() {
+            format!("captured pane output to {}", path.display())
+        } else {
+            format!(
+                "captured {} {} to {}",
+                targets.len(),
+                pane_word(targets.len()),
+                directory.display()
+            )
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({
+                "directory": directory.display().to_string(),
+                "files": files
+            }),
+        )
+    }
+
+    fn start_control_logging(
+        &mut self,
+        pane_numbers: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.start_logging_for_indices(&targets, directory)
+    }
+
+    fn start_logging_for_indices(
+        &mut self,
+        targets: &[usize],
+        directory: Option<&Path>,
+    ) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to log");
+        }
+        let directory = match output_capture::prepare_output_directory(directory) {
+            Ok(directory) => directory,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+
+        let mut logs = Vec::new();
+        let mut paths = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let key = PaneLogKey::new(pane.id(), pane.generation());
+            let path = match self.output_logs.path(key) {
+                Some(path) => path.to_path_buf(),
+                None => match self.output_logs.start(key, index + 1, &directory) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        self.status = format!("pane {} logging failed: {error:#}", index + 1);
+                        return ControlResponse::error(self.status.clone());
+                    }
+                },
+            };
+            logs.push(serde_json::json!({
+                "pane": index + 1,
+                "path": path.display().to_string()
+            }));
+            paths.push(path);
+        }
+
+        self.status = if let [path] = paths.as_slice() {
+            format!("logging pane output to {}", path.display())
+        } else {
+            format!(
+                "logging {} {} to {}",
+                targets.len(),
+                pane_word(targets.len()),
+                directory.display()
+            )
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({
+                "directory": directory.display().to_string(),
+                "logs": logs
+            }),
+        )
+    }
+
+    fn stop_control_logging(&mut self, pane_numbers: &[usize]) -> ControlResponse {
+        let targets = match self.control_pane_indices(pane_numbers) {
+            Ok(targets) => targets,
+            Err(error) => return ControlResponse::error(format!("{error:#}")),
+        };
+        self.stop_logging_for_indices(&targets)
+    }
+
+    fn stop_logging_for_indices(&mut self, targets: &[usize]) -> ControlResponse {
+        if targets.is_empty() {
+            return ControlResponse::error("no target panes available to stop logging");
+        }
+
+        let mut stopped = Vec::new();
+        for index in targets {
+            let Some(pane) = self.panes.get(*index) else {
+                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
+            };
+            let key = PaneLogKey::new(pane.id(), pane.generation());
+            match self.output_logs.stop(key) {
+                Ok(Some(path)) => stopped.push(serde_json::json!({
+                    "pane": index + 1,
+                    "path": path.display().to_string()
+                })),
+                Ok(None) => {}
+                Err(error) => {
+                    self.status = format!("pane {} log stop failed: {error:#}", index + 1);
+                    return ControlResponse::error(self.status.clone());
+                }
+            }
+        }
+
+        self.status = if stopped.is_empty() {
+            "target panes were not being logged".into()
+        } else if stopped.len() == 1 {
+            format!(
+                "stopped pane output log: {}",
+                stopped[0]["path"].as_str().unwrap_or("unknown path")
+            )
+        } else {
+            format!("stopped {} pane output log(s)", stopped.len())
+        };
+        ControlResponse::with_data(
+            self.status.clone(),
+            serde_json::json!({ "stopped": stopped }),
+        )
     }
 
     fn control_pane_indices(&self, pane_numbers: &[usize]) -> Result<Vec<usize>> {
@@ -3303,6 +3526,10 @@ impl App {
                 self.open_new_tab(terminal)?;
                 Ok(Some(false))
             }
+            'l' if modifiers.contains(KeyModifiers::SHIFT) => {
+                self.toggle_target_output_logging();
+                Ok(Some(false))
+            }
             'l' => {
                 self.open_grid_resizer();
                 Ok(Some(false))
@@ -3313,6 +3540,10 @@ impl App {
             }
             'f' => {
                 self.toggle_zoom();
+                Ok(Some(false))
+            }
+            'c' if modifiers.contains(KeyModifiers::SHIFT) => {
+                self.capture_target_output();
                 Ok(Some(false))
             }
             'c' => {
@@ -5462,6 +5693,32 @@ impl App {
         input_targets_for(self.focus, &self.selected, self.panes.len())
     }
 
+    fn capture_target_output(&mut self) {
+        let targets = self.target_panes();
+        let response = self.capture_output_for_indices(&targets, None);
+        self.status = response.message;
+    }
+
+    fn toggle_target_output_logging(&mut self) {
+        let targets = self.target_panes();
+        if targets.is_empty() {
+            self.status = "no target panes available to log".into();
+            return;
+        }
+        let all_logging = targets.iter().all(|index| {
+            self.panes.get(*index).is_some_and(|pane| {
+                self.output_logs
+                    .is_active(PaneLogKey::new(pane.id(), pane.generation()))
+            })
+        });
+        let response = if all_logging {
+            self.stop_logging_for_indices(&targets)
+        } else {
+            self.start_logging_for_indices(&targets, None)
+        };
+        self.status = response.message;
+    }
+
     fn toggle_sleep_for_focused_pane(&mut self) {
         if self.panes.is_empty() {
             self.status = "no panes to sleep".into();
@@ -5702,6 +5959,13 @@ impl App {
 
     pub fn pane_sleeping(&self, index: usize) -> bool {
         self.sleeping.contains(&index)
+    }
+
+    pub fn pane_logging(&self, index: usize) -> bool {
+        self.panes.get(index).is_some_and(|pane| {
+            self.output_logs
+                .is_active(PaneLogKey::new(pane.id(), pane.generation()))
+        })
     }
 
     pub fn status(&self) -> &str {
@@ -8250,6 +8514,16 @@ mod tests {
     #[test]
     fn input_targets_selected_panes_when_multiple_panes_are_selected() {
         assert_eq!(input_targets_for(2, &selected(&[0, 3]), 4), vec![0, 3]);
+    }
+
+    #[test]
+    fn output_actions_use_the_focused_or_multi_selected_target_set() {
+        assert_eq!(input_targets_for(2, &selected(&[]), 4), vec![2]);
+        assert_eq!(input_targets_for(2, &selected(&[1]), 4), vec![2]);
+        assert_eq!(
+            input_targets_for(2, &selected(&[0, 1, 3]), 4),
+            vec![0, 1, 3]
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,6 +80,8 @@ pub enum GridMode {
 pub enum Command {
     /// Find and reopen a saved GridBash session.
     Resume(ResumeArgs),
+    /// Inspect or control an opted-in running GridBash session.
+    Ctl(CtlArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -94,6 +96,62 @@ pub struct ResumeArgs {
     /// Resume the most recently updated session without prompting.
     #[arg(long)]
     pub latest: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct CtlArgs {
+    /// Runtime session id or unique id prefix. Required when multiple sessions are running.
+    #[arg(long, global = true)]
+    pub session: Option<String>,
+
+    /// Session bearer token. Defaults to GRIDBASH_CONTROL_TOKEN.
+    #[arg(long, global = true)]
+    pub token: Option<String>,
+
+    /// Print machine-readable JSON.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub action: CtlAction,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum CtlAction {
+    /// List discoverable running sessions.
+    List,
+    /// List panes and stable pane identities.
+    Panes,
+    /// Send text to one or more panes.
+    Send {
+        /// Pane number or stable pane-<id>-gen-<generation> identity. Repeat for multiple panes.
+        #[arg(short = 'p', long = "pane", required = true)]
+        panes: Vec<String>,
+        /// Text to send. Quote shell-sensitive content.
+        command: String,
+        /// Write the text without pressing Enter.
+        #[arg(long)]
+        no_submit: bool,
+    },
+    /// Capture bounded recent plain-text pane output.
+    Capture {
+        /// Pane number or stable pane identity. Repeat for multiple panes.
+        #[arg(short = 'p', long = "pane", required = true)]
+        panes: Vec<String>,
+        /// Optional output directory.
+        #[arg(long)]
+        directory: Option<PathBuf>,
+    },
+    /// Replace the running session status-bar message.
+    Status {
+        /// New status text.
+        message: String,
+    },
+    /// Focus one pane by number or stable identity.
+    Focus {
+        /// Pane number or stable pane-<id>-gen-<generation> identity.
+        pane: String,
+    },
 }
 
 #[cfg(test)]
@@ -118,5 +176,30 @@ mod tests {
         assert!(cli.command.is_none());
         assert_eq!(cli.grid.as_deref(), Some("2x3"));
         assert_eq!(cli.profile.as_deref(), Some("git-bash"));
+    }
+
+    #[test]
+    fn parses_scriptable_control_commands() {
+        let cli = Cli::parse_from([
+            "gridbash",
+            "ctl",
+            "send",
+            "--session",
+            "abc",
+            "--pane",
+            "pane-4-gen-2",
+            "--no-submit",
+            "echo ready",
+        ]);
+        let Some(Command::Ctl(args)) = cli.command else {
+            panic!("expected ctl command");
+        };
+
+        assert_eq!(args.session.as_deref(), Some("abc"));
+        assert!(matches!(
+            args.action,
+            CtlAction::Send { panes, command, no_submit: true }
+                if panes == vec!["pane-4-gen-2"] && command == "echo ready"
+        ));
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,28 +1,41 @@
 use std::{
+    collections::BTreeSet,
     env,
     io::{self, BufRead, Read, Write},
-    net::{Shutdown, TcpListener, TcpStream},
+    net::{Shutdown, SocketAddr, TcpListener, TcpStream},
     path::PathBuf,
     sync::mpsc::{self, Sender},
     thread,
     time::Duration,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+
+use crate::{
+    cli::{CtlAction, CtlArgs},
+    control_discovery::{self, DiscoveryLease, DiscoveryRecord},
+    layout::PaneId,
+};
 
 const MCP_PROTOCOL_VERSION: &str = "2025-11-25";
 const CONTROL_READ_TIMEOUT: Duration = Duration::from_secs(8);
 const CONTROL_REQUEST_LIMIT_BYTES: u64 = 64 * 1024;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ControlHandle {
+    id: String,
     endpoint: String,
     token: String,
+    _discovery: DiscoveryLease,
 }
 
 impl ControlHandle {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }
@@ -32,14 +45,104 @@ impl ControlHandle {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PaneTarget {
+    Number(usize),
+    Stable { pane_id: usize, generation: u64 },
+}
+
+impl PaneTarget {
+    pub fn parse(value: &str) -> Result<Self> {
+        if let Ok(number) = value.parse::<usize>() {
+            if number == 0 {
+                bail!("pane numbers are 1-based");
+            }
+            return Ok(Self::Number(number));
+        }
+
+        let Some(value) = value.strip_prefix("pane-") else {
+            bail!("invalid pane target '{value}'; use a pane number or pane-<id>-gen-<generation>");
+        };
+        let Some((pane_id, generation)) = value.split_once("-gen-") else {
+            bail!("invalid stable pane target; expected pane-<id>-gen-<generation>");
+        };
+        Ok(Self::Stable {
+            pane_id: pane_id
+                .parse()
+                .with_context(|| format!("invalid pane id '{pane_id}'"))?,
+            generation: generation
+                .parse()
+                .with_context(|| format!("invalid pane generation '{generation}'"))?,
+        })
+    }
+
+    pub fn stable_label(pane: PaneId, generation: u64) -> String {
+        format!("pane-{}-gen-{generation}", pane.0)
+    }
+}
+
+impl From<usize> for PaneTarget {
+    fn from(number: usize) -> Self {
+        Self::Number(number)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneIdentity {
+    pub index: usize,
+    pub pane: PaneId,
+    pub generation: u64,
+}
+
+pub fn resolve_pane_targets(
+    targets: &[PaneTarget],
+    identities: &[PaneIdentity],
+) -> Result<Vec<usize>> {
+    if targets.is_empty() {
+        bail!("at least one target pane is required");
+    }
+
+    let mut resolved = BTreeSet::new();
+    for target in targets {
+        let index = match target {
+            PaneTarget::Number(number) => identities
+                .iter()
+                .find(|identity| identity.index + 1 == *number)
+                .map(|identity| identity.index)
+                .ok_or_else(|| anyhow!("pane {number} is not available"))?,
+            PaneTarget::Stable {
+                pane_id,
+                generation,
+            } => {
+                let identity = identities
+                    .iter()
+                    .find(|identity| identity.pane.0 == *pane_id)
+                    .ok_or_else(|| anyhow!("pane-{pane_id} is not available in this session"))?;
+                if identity.generation != *generation {
+                    bail!(
+                        "stale pane identity pane-{pane_id}-gen-{generation}; current generation is {}",
+                        identity.generation
+                    );
+                }
+                identity.index
+            }
+        };
+        resolved.insert(index);
+    }
+    Ok(resolved.into_iter().collect())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ControlCommand {
+    Ping,
+    Describe,
     SetStatus {
         message: String,
     },
     SendCommand {
-        panes: Vec<usize>,
+        panes: Vec<PaneTarget>,
         command: String,
         submit: bool,
     },
@@ -48,16 +151,25 @@ pub enum ControlCommand {
         title: Option<String>,
     },
     CaptureOutput {
-        panes: Vec<usize>,
+        panes: Vec<PaneTarget>,
         directory: Option<PathBuf>,
     },
     StartLogging {
-        panes: Vec<usize>,
+        panes: Vec<PaneTarget>,
         directory: Option<PathBuf>,
     },
     StopLogging {
-        panes: Vec<usize>,
+        panes: Vec<PaneTarget>,
     },
+    Focus {
+        pane: PaneTarget,
+    },
+}
+
+impl ControlCommand {
+    fn requires_token(&self) -> bool {
+        !matches!(self, Self::Ping | Self::Describe)
+    }
 }
 
 #[derive(Debug)]
@@ -102,7 +214,8 @@ impl ControlResponse {
 
 #[derive(Debug, Deserialize)]
 struct ControlWireRequest {
-    token: String,
+    #[serde(default)]
+    token: Option<String>,
     command: ControlCommand,
 }
 
@@ -116,25 +229,45 @@ pub fn start_control_server(
         .context("failed to read agent API address")?
         .to_string();
     let token = new_token()?;
+    let id = new_instance_id()?;
+    let discovery = DiscoveryLease::publish(&DiscoveryRecord::new(id.clone(), endpoint.clone()))?;
     let server_token = token.clone();
+    let server_id = id.clone();
 
     thread::spawn(move || {
         for stream in listener.incoming() {
             match stream {
-                Ok(stream) => handle_control_stream(stream, &server_token, &command_tx),
+                Ok(stream) => handle_control_stream(stream, &server_id, &server_token, &command_tx),
                 Err(error) => eprintln!("gridbash agent API accept failed: {error}"),
             }
         }
     });
 
-    Ok(ControlHandle { endpoint, token })
+    Ok(ControlHandle {
+        id,
+        endpoint,
+        token,
+        _discovery: discovery,
+    })
 }
 
-fn handle_control_stream(mut stream: TcpStream, token: &str, command_tx: &Sender<ControlEnvelope>) {
+fn handle_control_stream(
+    mut stream: TcpStream,
+    id: &str,
+    token: &str,
+    command_tx: &Sender<ControlEnvelope>,
+) {
     let _ = stream.set_read_timeout(Some(CONTROL_READ_TIMEOUT));
     let response = read_control_request(&mut stream).and_then(|request| {
-        if request.token != token {
+        if !request_authorized(&request, token) {
             return Ok(ControlResponse::error("invalid GridBash control token"));
+        }
+
+        if matches!(&request.command, ControlCommand::Ping) {
+            return Ok(ControlResponse::with_data(
+                "GridBash control session is live",
+                json!({ "id": id }),
+            ));
         }
 
         let (response_tx, response_rx) = mpsc::channel();
@@ -154,6 +287,10 @@ fn handle_control_stream(mut stream: TcpStream, token: &str, command_tx: &Sender
     let _ = stream.flush();
 }
 
+fn request_authorized(request: &ControlWireRequest, expected_token: &str) -> bool {
+    !request.command.requires_token() || request.token.as_deref() == Some(expected_token)
+}
+
 fn read_control_request(stream: &mut TcpStream) -> Result<ControlWireRequest> {
     let mut body = String::new();
     stream
@@ -168,6 +305,21 @@ fn new_token() -> Result<String> {
     getrandom::fill(&mut bytes)
         .map_err(|error| anyhow!("failed to create agent API token: {error}"))?;
     Ok(hex_encode(&bytes))
+}
+
+fn new_instance_id() -> Result<String> {
+    let mut random = [0_u8; 6];
+    getrandom::fill(&mut random)
+        .map_err(|error| anyhow!("failed to create control session id: {error}"))?;
+    Ok(format!(
+        "{}-{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+        std::process::id(),
+        hex_encode(&random)
+    ))
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
@@ -199,6 +351,181 @@ pub fn run_mcp_server() -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn run_ctl(args: &CtlArgs) -> Result<()> {
+    let sessions = control_discovery::discover_sessions(probe_discovered_session)?;
+    if matches!(&args.action, CtlAction::List) {
+        if args.json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&sessions).context("failed to serialize sessions")?
+            );
+        } else if sessions.is_empty() {
+            println!("gridbash: no opted-in running sessions found");
+        } else {
+            println!("ID\tPID\tENDPOINT\tSTARTED");
+            for session in &sessions {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    session.id, session.pid, session.endpoint, session.started_at
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    let requested_session = args
+        .session
+        .clone()
+        .or_else(|| env::var("GRIDBASH_CONTROL_SESSION").ok());
+    let session = select_discovered_session(&sessions, requested_session.as_deref())?;
+    let (command, token) = match &args.action {
+        CtlAction::List => unreachable!("list returned above"),
+        CtlAction::Panes => (ControlCommand::Describe, None),
+        CtlAction::Send {
+            panes,
+            command,
+            no_submit,
+        } => (
+            ControlCommand::SendCommand {
+                panes: parse_pane_targets(panes)?,
+                command: command.clone(),
+                submit: !no_submit,
+            },
+            Some(ctl_token(args)?),
+        ),
+        CtlAction::Capture { panes, directory } => (
+            ControlCommand::CaptureOutput {
+                panes: parse_pane_targets(panes)?,
+                directory: directory.clone().map(absolute_tool_path).transpose()?,
+            },
+            Some(ctl_token(args)?),
+        ),
+        CtlAction::Status { message } => (
+            ControlCommand::SetStatus {
+                message: message.clone(),
+            },
+            Some(ctl_token(args)?),
+        ),
+        CtlAction::Focus { pane } => (
+            ControlCommand::Focus {
+                pane: PaneTarget::parse(pane)?,
+            },
+            Some(ctl_token(args)?),
+        ),
+    };
+
+    let response = call_control(&session.endpoint, token.as_deref(), command)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&response)
+                .context("failed to serialize control response")?
+        );
+    } else if matches!(&args.action, CtlAction::Panes) && response.ok {
+        print_panes(response.data.as_ref());
+    } else {
+        println!("{}", response.message);
+    }
+    if !response.ok {
+        bail!(response.message);
+    }
+    Ok(())
+}
+
+fn probe_discovered_session(session: &DiscoveryRecord) -> bool {
+    call_control_with_timeout(
+        &session.endpoint,
+        None,
+        ControlCommand::Ping,
+        Duration::from_millis(500),
+    )
+    .ok()
+    .filter(|response| response.ok)
+    .and_then(|response| response.data)
+    .and_then(|data| data.get("id").and_then(Value::as_str).map(str::to_owned))
+    .is_some_and(|id| id == session.id)
+}
+
+fn select_discovered_session<'a>(
+    sessions: &'a [DiscoveryRecord],
+    query: Option<&str>,
+) -> Result<&'a DiscoveryRecord> {
+    if let Some(query) = query {
+        if let Some(exact) = sessions.iter().find(|session| session.id == query) {
+            return Ok(exact);
+        }
+        let matches = sessions
+            .iter()
+            .filter(|session| session.id.starts_with(query))
+            .collect::<Vec<_>>();
+        return match matches.as_slice() {
+            [] => Err(anyhow!("no running session matches '{query}'")),
+            [session] => Ok(*session),
+            _ => Err(anyhow!("running session prefix '{query}' is ambiguous")),
+        };
+    }
+
+    match sessions {
+        [] => Err(anyhow!("no opted-in running GridBash sessions found")),
+        [session] => Ok(session),
+        _ => Err(anyhow!(
+            "multiple GridBash sessions are running; pass --session <id-or-prefix>"
+        )),
+    }
+}
+
+fn ctl_token(args: &CtlArgs) -> Result<String> {
+    args.token
+        .clone()
+        .or_else(|| env::var("GRIDBASH_CONTROL_TOKEN").ok())
+        .ok_or_else(|| {
+            anyhow!(
+                "this operation requires --token or GRIDBASH_CONTROL_TOKEN from the target session"
+            )
+        })
+}
+
+fn parse_pane_targets(values: &[String]) -> Result<Vec<PaneTarget>> {
+    values
+        .iter()
+        .map(|value| PaneTarget::parse(value))
+        .collect()
+}
+
+fn print_panes(data: Option<&Value>) {
+    println!("NUMBER\tID\tSTATE\tLABEL\tCWD");
+    let panes = data
+        .and_then(|data| data.get("panes"))
+        .and_then(Value::as_array);
+    for pane in panes.into_iter().flatten() {
+        let mut states = Vec::new();
+        for (field, label) in [
+            ("focused", "focused"),
+            ("selected", "selected"),
+            ("sleeping", "sleeping"),
+            ("logging", "logging"),
+            ("exited", "exited"),
+        ] {
+            if pane.get(field).and_then(Value::as_bool) == Some(true) {
+                states.push(label);
+            }
+        }
+        let state = if states.is_empty() {
+            "running".to_string()
+        } else {
+            states.join(",")
+        };
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            pane.get("number").and_then(Value::as_u64).unwrap_or(0),
+            pane.get("id").and_then(Value::as_str).unwrap_or("unknown"),
+            state,
+            pane.get("label").and_then(Value::as_str).unwrap_or(""),
+            pane.get("cwd").and_then(Value::as_str).unwrap_or("")
+        );
+    }
 }
 
 fn handle_mcp_line(line: &str) -> Option<Value> {
@@ -428,7 +755,7 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
                 return Err(anyhow!("at least one pane is required"));
             }
             Ok(ControlCommand::SendCommand {
-                panes: args.panes,
+                panes: args.panes.into_iter().map(Into::into).collect(),
                 command: args.command,
                 submit: args.submit.unwrap_or(true),
             })
@@ -458,12 +785,12 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
             let directory = args.directory.map(absolute_tool_path).transpose()?;
             if tool_name == "gridbash_capture_output" {
                 Ok(ControlCommand::CaptureOutput {
-                    panes: args.panes,
+                    panes: args.panes.into_iter().map(Into::into).collect(),
                     directory,
                 })
             } else {
                 Ok(ControlCommand::StartLogging {
-                    panes: args.panes,
+                    panes: args.panes.into_iter().map(Into::into).collect(),
                     directory,
                 })
             }
@@ -478,7 +805,9 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
             if args.panes.is_empty() {
                 return Err(anyhow!("at least one pane is required"));
             }
-            Ok(ControlCommand::StopLogging { panes: args.panes })
+            Ok(ControlCommand::StopLogging {
+                panes: args.panes.into_iter().map(Into::into).collect(),
+            })
         }
         _ => Err(anyhow!("unknown GridBash tool: {tool_name}")),
     }
@@ -499,13 +828,33 @@ fn call_gridbash_control(command: ControlCommand) -> Result<ControlResponse> {
         .context("GRIDBASH_CONTROL_ADDR is not set; start GridBash with --agent-api")?;
     let token = env::var("GRIDBASH_CONTROL_TOKEN")
         .context("GRIDBASH_CONTROL_TOKEN is not set; start GridBash with --agent-api")?;
-    let mut stream = TcpStream::connect(&endpoint)
+    call_control(&endpoint, Some(&token), command)
+}
+
+fn call_control(
+    endpoint: &str,
+    token: Option<&str>,
+    command: ControlCommand,
+) -> Result<ControlResponse> {
+    call_control_with_timeout(endpoint, token, command, CONTROL_READ_TIMEOUT)
+}
+
+fn call_control_with_timeout(
+    endpoint: &str,
+    token: Option<&str>,
+    command: ControlCommand,
+    timeout: Duration,
+) -> Result<ControlResponse> {
+    let address = endpoint
+        .parse::<SocketAddr>()
+        .with_context(|| format!("invalid GridBash control endpoint '{endpoint}'"))?;
+    let mut stream = TcpStream::connect_timeout(&address, timeout.min(Duration::from_millis(750)))
         .with_context(|| format!("failed to connect to GridBash control API at {endpoint}"))?;
     stream
-        .set_read_timeout(Some(CONTROL_READ_TIMEOUT))
+        .set_read_timeout(Some(timeout))
         .context("failed to set GridBash control read timeout")?;
     stream
-        .set_write_timeout(Some(CONTROL_READ_TIMEOUT))
+        .set_write_timeout(Some(timeout))
         .context("failed to set GridBash control write timeout")?;
 
     serde_json::to_writer(&mut stream, &json!({ "token": token, "command": command }))
@@ -606,7 +955,7 @@ mod tests {
                 panes,
                 command,
                 submit: true
-            } if panes == vec![2] && command == "cargo test"
+            } if panes == vec![PaneTarget::Number(2)] && command == "cargo test"
         ));
     }
 
@@ -620,14 +969,110 @@ mod tests {
         assert!(matches!(
             capture,
             ControlCommand::CaptureOutput { panes, directory: Some(path) }
-                if panes == vec![1, 3] && path.is_absolute() && path.ends_with("captures")
+                if panes == vec![PaneTarget::Number(1), PaneTarget::Number(3)]
+                    && path.is_absolute() && path.ends_with("captures")
         ));
 
         let stop = tool_arguments_to_command("gridbash_stop_logging", json!({ "panes": [2] }))
             .expect("stop command");
         assert!(matches!(
             stop,
-            ControlCommand::StopLogging { panes } if panes == vec![2]
+            ControlCommand::StopLogging { panes } if panes == vec![PaneTarget::Number(2)]
         ));
+    }
+
+    #[test]
+    fn read_only_inspection_is_tokenless_but_mutations_require_authentication() {
+        let inspect = ControlWireRequest {
+            token: None,
+            command: ControlCommand::Describe,
+        };
+        let unauthenticated_write = ControlWireRequest {
+            token: None,
+            command: ControlCommand::SetStatus {
+                message: "working".into(),
+            },
+        };
+        let authenticated_write = ControlWireRequest {
+            token: Some("secret".into()),
+            command: ControlCommand::SetStatus {
+                message: "working".into(),
+            },
+        };
+
+        assert!(request_authorized(&inspect, "secret"));
+        assert!(!request_authorized(&unauthenticated_write, "secret"));
+        assert!(request_authorized(&authenticated_write, "secret"));
+    }
+
+    #[test]
+    fn stable_pane_targets_reject_stale_generations() {
+        let identities = [
+            PaneIdentity {
+                index: 0,
+                pane: PaneId(7),
+                generation: 3,
+            },
+            PaneIdentity {
+                index: 1,
+                pane: PaneId(9),
+                generation: 1,
+            },
+        ];
+
+        assert_eq!(
+            resolve_pane_targets(
+                &[
+                    PaneTarget::Number(2),
+                    PaneTarget::Stable {
+                        pane_id: 7,
+                        generation: 3,
+                    },
+                ],
+                &identities,
+            )
+            .expect("resolve targets"),
+            vec![0, 1]
+        );
+        let error = resolve_pane_targets(
+            &[PaneTarget::Stable {
+                pane_id: 7,
+                generation: 2,
+            }],
+            &identities,
+        )
+        .expect_err("stale generation");
+        assert!(error.to_string().contains("stale pane identity"));
+    }
+
+    #[test]
+    fn session_selection_rejects_ambiguity_without_an_explicit_prefix() {
+        let sessions = [
+            DiscoveryRecord::new("alpha-one".into(), "127.0.0.1:1".into()),
+            DiscoveryRecord::new("alpha-two".into(), "127.0.0.1:2".into()),
+        ];
+
+        assert!(select_discovered_session(&sessions, None).is_err());
+        assert!(select_discovered_session(&sessions, Some("alpha")).is_err());
+        assert_eq!(
+            select_discovered_session(&sessions, Some("alpha-one"))
+                .expect("exact session")
+                .id,
+            "alpha-one"
+        );
+    }
+
+    #[test]
+    fn discovery_json_is_machine_readable_and_contains_no_token() {
+        let sessions = vec![DiscoveryRecord::new(
+            "runtime".into(),
+            "127.0.0.1:4321".into(),
+        )];
+        let raw = serde_json::to_string(&sessions).expect("session json");
+        let decoded: Value = serde_json::from_str(&raw).expect("decode json");
+
+        assert_eq!(decoded[0]["id"], "runtime");
+        assert_eq!(decoded[0]["endpoint"], "127.0.0.1:4321");
+        assert!(decoded[0].get("token").is_none());
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -47,6 +47,17 @@ pub enum ControlCommand {
         path: PathBuf,
         title: Option<String>,
     },
+    CaptureOutput {
+        panes: Vec<usize>,
+        directory: Option<PathBuf>,
+    },
+    StartLogging {
+        panes: Vec<usize>,
+        directory: Option<PathBuf>,
+    },
+    StopLogging {
+        panes: Vec<usize>,
+    },
 }
 
 #[derive(Debug)]
@@ -308,6 +319,68 @@ fn tools_list_result() -> Value {
                     },
                     "required": ["message"]
                 }
+            },
+            {
+                "name": "gridbash_capture_output",
+                "title": "Capture Pane Output",
+                "description": "Save bounded recent plain-text output from one or more GridBash panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to capture.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        },
+                        "directory": {
+                            "type": "string",
+                            "description": "Optional output directory. GridBash local data storage is used by default."
+                        }
+                    },
+                    "required": ["panes"]
+                }
+            },
+            {
+                "name": "gridbash_start_logging",
+                "title": "Start Pane Logging",
+                "description": "Continuously append new plain-text output from one or more GridBash panes to separate files.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to log.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        },
+                        "directory": {
+                            "type": "string",
+                            "description": "Optional output directory. GridBash local data storage is used by default."
+                        }
+                    },
+                    "required": ["panes"]
+                }
+            },
+            {
+                "name": "gridbash_stop_logging",
+                "title": "Stop Pane Logging",
+                "description": "Stop and flush continuous output logs for one or more GridBash panes.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "panes": {
+                            "type": "array",
+                            "description": "1-based pane numbers to stop logging.",
+                            "items": { "type": "integer", "minimum": 1 },
+                            "minItems": 1
+                        }
+                    },
+                    "required": ["panes"]
+                }
             }
         ]
     })
@@ -370,6 +443,42 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
             Ok(ControlCommand::SetStatus {
                 message: args.message,
             })
+        }
+        "gridbash_capture_output" | "gridbash_start_logging" => {
+            #[derive(Deserialize)]
+            struct Args {
+                panes: Vec<usize>,
+                directory: Option<PathBuf>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid output args")?;
+            if args.panes.is_empty() {
+                return Err(anyhow!("at least one pane is required"));
+            }
+            let directory = args.directory.map(absolute_tool_path).transpose()?;
+            if tool_name == "gridbash_capture_output" {
+                Ok(ControlCommand::CaptureOutput {
+                    panes: args.panes,
+                    directory,
+                })
+            } else {
+                Ok(ControlCommand::StartLogging {
+                    panes: args.panes,
+                    directory,
+                })
+            }
+        }
+        "gridbash_stop_logging" => {
+            #[derive(Deserialize)]
+            struct Args {
+                panes: Vec<usize>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid logging args")?;
+            if args.panes.is_empty() {
+                return Err(anyhow!("at least one pane is required"));
+            }
+            Ok(ControlCommand::StopLogging { panes: args.panes })
         }
         _ => Err(anyhow!("unknown GridBash tool: {tool_name}")),
     }
@@ -472,7 +581,10 @@ mod tests {
             vec![
                 "gridbash_show_image",
                 "gridbash_send_command",
-                "gridbash_set_status"
+                "gridbash_set_status",
+                "gridbash_capture_output",
+                "gridbash_start_logging",
+                "gridbash_stop_logging"
             ]
         );
     }
@@ -495,6 +607,27 @@ mod tests {
                 command,
                 submit: true
             } if panes == vec![2] && command == "cargo test"
+        ));
+    }
+
+    #[test]
+    fn output_tools_parse_targets_and_optional_directories() {
+        let capture = tool_arguments_to_command(
+            "gridbash_capture_output",
+            json!({ "panes": [1, 3], "directory": "captures" }),
+        )
+        .expect("capture command");
+        assert!(matches!(
+            capture,
+            ControlCommand::CaptureOutput { panes, directory: Some(path) }
+                if panes == vec![1, 3] && path.is_absolute() && path.ends_with("captures")
+        ));
+
+        let stop = tool_arguments_to_command("gridbash_stop_logging", json!({ "panes": [2] }))
+            .expect("stop command");
+        assert!(matches!(
+            stop,
+            ControlCommand::StopLogging { panes } if panes == vec![2]
         ));
     }
 }

--- a/src/control_discovery.rs
+++ b/src/control_discovery.rs
@@ -1,0 +1,230 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, anyhow};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+const DISCOVERY_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiscoveryRecord {
+    pub version: u16,
+    pub id: String,
+    pub endpoint: String,
+    pub pid: u32,
+    pub started_at: u64,
+}
+
+impl DiscoveryRecord {
+    pub fn new(id: String, endpoint: String) -> Self {
+        Self {
+            version: DISCOVERY_VERSION,
+            id,
+            endpoint,
+            pid: std::process::id(),
+            started_at: now_seconds(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DiscoveryLease {
+    path: PathBuf,
+}
+
+impl DiscoveryLease {
+    pub fn publish(record: &DiscoveryRecord) -> Result<Self> {
+        let directory = discovery_directory()?;
+        publish_in(&directory, record)
+    }
+}
+
+impl Drop for DiscoveryLease {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub fn discover_sessions(
+    mut probe: impl FnMut(&DiscoveryRecord) -> bool,
+) -> Result<Vec<DiscoveryRecord>> {
+    discover_in(&discovery_directory()?, &mut probe)
+}
+
+fn discovery_directory() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "GridBash")
+        .map(|dirs| dirs.data_local_dir().join("control"))
+        .ok_or_else(|| anyhow!("failed to resolve GridBash control discovery directory"))
+}
+
+fn publish_in(directory: &Path, record: &DiscoveryRecord) -> Result<DiscoveryLease> {
+    fs::create_dir_all(directory).with_context(|| {
+        format!(
+            "failed to create control discovery directory {}",
+            directory.display()
+        )
+    })?;
+    secure_directory(directory)?;
+
+    let path = directory.join(format!("{}.json", record.id));
+    let temporary = directory.join(format!(".{}.{}.tmp", record.id, std::process::id()));
+    let bytes =
+        serde_json::to_vec_pretty(record).context("failed to serialize control discovery")?;
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    secure_file_options(&mut options);
+    let mut file = options
+        .open(&temporary)
+        .with_context(|| format!("failed to create discovery file {}", temporary.display()))?;
+    file.write_all(&bytes)
+        .with_context(|| format!("failed to write discovery file {}", temporary.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush discovery file {}", temporary.display()))?;
+    drop(file);
+    fs::rename(&temporary, &path).with_context(|| {
+        format!(
+            "failed to publish control discovery file {}",
+            path.display()
+        )
+    })?;
+    Ok(DiscoveryLease { path })
+}
+
+fn discover_in(
+    directory: &Path,
+    probe: &mut impl FnMut(&DiscoveryRecord) -> bool,
+) -> Result<Vec<DiscoveryRecord>> {
+    if !directory.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::new();
+    for entry in fs::read_dir(directory)
+        .with_context(|| format!("failed to read discovery directory {}", directory.display()))?
+    {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let record = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<DiscoveryRecord>(&raw).ok());
+        match record {
+            Some(record) if record.version == DISCOVERY_VERSION && probe(&record) => {
+                sessions.push(record);
+            }
+            _ => {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+    sessions.sort_by(|left, right| {
+        right
+            .started_at
+            .cmp(&left.started_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    Ok(sessions)
+}
+
+fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(unix)]
+fn secure_directory(directory: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(directory, fs::Permissions::from_mode(0o700)).with_context(|| {
+        format!(
+            "failed to secure discovery directory {}",
+            directory.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn secure_directory(_directory: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_file_options(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(0o600);
+}
+
+#[cfg(not(unix))]
+fn secure_file_options(_options: &mut OpenOptions) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "gridbash-discovery-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("test clock")
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&path).expect("create test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn discovery_prunes_stale_and_invalid_records() {
+        let directory = TestDirectory::new();
+        let live = DiscoveryRecord::new("live".into(), "127.0.0.1:1".into());
+        let stale = DiscoveryRecord::new("stale".into(), "127.0.0.1:2".into());
+        let live_lease = publish_in(&directory.0, &live).expect("publish live");
+        let stale_lease = publish_in(&directory.0, &stale).expect("publish stale");
+        fs::write(directory.0.join("invalid.json"), "not json").expect("invalid fixture");
+
+        let sessions = discover_in(&directory.0, &mut |record| record.id == "live")
+            .expect("discover sessions");
+
+        assert_eq!(sessions, [live]);
+        assert!(live_lease.path.exists());
+        assert!(!stale_lease.path.exists());
+        assert!(!directory.0.join("invalid.json").exists());
+    }
+
+    #[test]
+    fn published_metadata_contains_no_bearer_token_field() {
+        let directory = TestDirectory::new();
+        let record = DiscoveryRecord::new("session".into(), "127.0.0.1:4321".into());
+        let lease = publish_in(&directory.0, &record).expect("publish");
+        let raw = fs::read_to_string(&lease.path).expect("read discovery");
+
+        assert!(!raw.contains("token"));
+        assert_eq!(
+            serde_json::from_str::<DiscoveryRecord>(&raw).unwrap(),
+            record
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod image_preview;
 mod layout;
 mod manager;
 mod onboarding;
+mod output_capture;
 mod process_priority;
 mod profiles;
 mod pty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod codex_sqlite;
 mod composer;
 mod config;
 mod control;
+mod control_discovery;
 mod image_preview;
 mod layout;
 mod manager;
@@ -39,6 +40,10 @@ fn main() -> Result<()> {
 
     if cli.mcp {
         return control::run_mcp_server();
+    }
+
+    if let Some(Command::Ctl(args)) = &cli.command {
+        return control::run_ctl(args);
     }
 
     let mut config = Config::load(cli.config.as_deref())?;

--- a/src/output_capture.rs
+++ b/src/output_capture.rs
@@ -1,0 +1,343 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions},
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use directories::ProjectDirs;
+
+use crate::layout::PaneId;
+
+const OUTPUT_FILE_ATTEMPTS: usize = 1_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PaneLogKey {
+    pub pane: PaneId,
+    pub generation: u64,
+}
+
+impl PaneLogKey {
+    pub fn new(pane: PaneId, generation: u64) -> Self {
+        Self { pane, generation }
+    }
+}
+
+pub fn default_output_directory() -> Result<PathBuf> {
+    ProjectDirs::from("", "", "GridBash")
+        .map(|dirs| dirs.data_local_dir().join("output"))
+        .ok_or_else(|| anyhow!("failed to resolve GridBash output directory"))
+}
+
+pub fn prepare_output_directory(directory: Option<&Path>) -> Result<PathBuf> {
+    let directory = match directory {
+        Some(path) if path.as_os_str().is_empty() => bail!("output directory cannot be empty"),
+        Some(path) => path.to_path_buf(),
+        None => default_output_directory()?,
+    };
+
+    if directory.exists() && !directory.is_dir() {
+        bail!("output path is not a directory: {}", directory.display());
+    }
+    fs::create_dir_all(&directory)
+        .with_context(|| format!("failed to create output directory {}", directory.display()))?;
+    Ok(directory)
+}
+
+pub fn capture_output(directory: &Path, pane_number: usize, plain_text: &str) -> Result<PathBuf> {
+    let (path, mut file) = create_output_file(directory, "capture", pane_number, "txt")?;
+    file.write_all(plain_text.as_bytes())
+        .with_context(|| format!("failed to write capture {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush capture {}", path.display()))?;
+    Ok(path)
+}
+
+struct PaneLogger {
+    path: PathBuf,
+    writer: Box<dyn Write + Send>,
+}
+
+impl std::fmt::Debug for PaneLogger {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PaneLogger")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl PaneLogger {
+    fn start(directory: &Path, pane_number: usize) -> Result<Self> {
+        let (path, file) = create_output_file(directory, "log", pane_number, "log")?;
+        Ok(Self {
+            path,
+            writer: Box::new(BufWriter::new(file)),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_writer(path: PathBuf, writer: impl Write + Send + 'static) -> Self {
+        Self {
+            path,
+            writer: Box::new(writer),
+        }
+    }
+
+    fn append(&mut self, plain_text: &str) -> Result<()> {
+        if plain_text.is_empty() {
+            return Ok(());
+        }
+        self.writer
+            .write_all(plain_text.as_bytes())
+            .with_context(|| format!("failed to append log {}", self.path.display()))?;
+        self.writer
+            .flush()
+            .with_context(|| format!("failed to flush log {}", self.path.display()))
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.writer
+            .flush()
+            .with_context(|| format!("failed to flush log {}", self.path.display()))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct OutputLogs {
+    active: HashMap<PaneLogKey, PaneLogger>,
+}
+
+impl OutputLogs {
+    pub fn start(
+        &mut self,
+        key: PaneLogKey,
+        pane_number: usize,
+        directory: &Path,
+    ) -> Result<PathBuf> {
+        if let Some(logger) = self.active.get(&key) {
+            bail!(
+                "pane {pane_number} is already logging to {}",
+                logger.path.display()
+            );
+        }
+        let logger = PaneLogger::start(directory, pane_number)?;
+        let path = logger.path.clone();
+        self.active.insert(key, logger);
+        Ok(path)
+    }
+
+    pub fn stop(&mut self, key: PaneLogKey) -> Result<Option<PathBuf>> {
+        let Some(mut logger) = self.active.remove(&key) else {
+            return Ok(None);
+        };
+        let path = logger.path.clone();
+        logger.finish()?;
+        Ok(Some(path))
+    }
+
+    pub fn append(&mut self, key: PaneLogKey, plain_text: &str) -> Result<()> {
+        let result = match self.active.get_mut(&key) {
+            Some(logger) => logger.append(plain_text),
+            None => return Ok(()),
+        };
+        if result.is_err() {
+            self.active.remove(&key);
+        }
+        result
+    }
+
+    pub fn is_active(&self, key: PaneLogKey) -> bool {
+        self.active.contains_key(&key)
+    }
+
+    pub fn path(&self, key: PaneLogKey) -> Option<&Path> {
+        self.active.get(&key).map(|logger| logger.path.as_path())
+    }
+
+    #[cfg(test)]
+    fn insert_logger(&mut self, key: PaneLogKey, logger: PaneLogger) {
+        self.active.insert(key, logger);
+    }
+}
+
+fn create_output_file(
+    directory: &Path,
+    kind: &str,
+    pane_number: usize,
+    extension: &str,
+) -> Result<(PathBuf, File)> {
+    let directory = prepare_output_directory(Some(directory))?;
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_millis();
+
+    for attempt in 0..OUTPUT_FILE_ATTEMPTS {
+        let suffix = if attempt == 0 {
+            String::new()
+        } else {
+            format!("-{attempt}")
+        };
+        let path = directory.join(format!(
+            "gridbash-{kind}-{stamp}-pane-{pane_number}{suffix}.{extension}"
+        ));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to create output file {}", path.display()));
+            }
+        }
+    }
+
+    bail!(
+        "failed to allocate a unique {kind} filename in {}",
+        directory.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use super::*;
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let unique = format!(
+                "gridbash-{label}-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("test clock")
+                    .as_nanos()
+            );
+            let path = std::env::temp_dir().join(unique);
+            fs::create_dir_all(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("writer lock").extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _bytes: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("disk unavailable"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn key(generation: u64) -> PaneLogKey {
+        PaneLogKey::new(PaneId(7), generation)
+    }
+
+    #[test]
+    fn output_directory_validation_rejects_empty_and_file_paths() {
+        let directory = TestDirectory::new("path-validation");
+        let file = directory.path().join("not-a-directory");
+        fs::write(&file, "content").expect("write fixture");
+
+        assert!(prepare_output_directory(Some(Path::new(""))).is_err());
+        assert!(prepare_output_directory(Some(&file)).is_err());
+        assert_eq!(
+            prepare_output_directory(Some(directory.path())).expect("valid directory"),
+            directory.path()
+        );
+    }
+
+    #[test]
+    fn captures_use_collision_safe_paths() {
+        let directory = TestDirectory::new("capture-paths");
+        let first = capture_output(directory.path(), 1, "first").expect("first capture");
+        let second = capture_output(directory.path(), 1, "second").expect("second capture");
+
+        assert_ne!(first, second);
+        assert_eq!(fs::read_to_string(first).expect("first text"), "first");
+        assert_eq!(fs::read_to_string(second).expect("second text"), "second");
+    }
+
+    #[test]
+    fn logger_appends_output_in_order() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let writer = SharedWriter(bytes.clone());
+        let mut logger = PaneLogger::with_writer(PathBuf::from("ordered.log"), writer);
+
+        logger.append("first\n").expect("first append");
+        logger.append("second\n").expect("second append");
+
+        assert_eq!(
+            String::from_utf8(bytes.lock().expect("bytes lock").clone()).expect("utf8"),
+            "first\nsecond\n"
+        );
+    }
+
+    #[test]
+    fn logging_can_stop_and_restart_with_a_new_file() {
+        let directory = TestDirectory::new("restart");
+        let mut logs = OutputLogs::default();
+        let first = logs.start(key(1), 1, directory.path()).expect("start");
+        assert!(logs.is_active(key(1)));
+        assert_eq!(logs.stop(key(1)).expect("stop"), Some(first.clone()));
+        assert!(!logs.is_active(key(1)));
+
+        let second = logs.start(key(1), 1, directory.path()).expect("restart");
+        assert_ne!(first, second);
+        assert!(logs.is_active(key(1)));
+    }
+
+    #[test]
+    fn write_failure_removes_only_the_failed_logger() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let mut logs = OutputLogs::default();
+        logs.insert_logger(
+            key(1),
+            PaneLogger::with_writer(PathBuf::from("failed.log"), FailingWriter),
+        );
+        logs.insert_logger(
+            key(2),
+            PaneLogger::with_writer(PathBuf::from("healthy.log"), SharedWriter(bytes.clone())),
+        );
+
+        assert!(logs.append(key(1), "lost").is_err());
+        assert!(!logs.is_active(key(1)));
+        assert!(logs.append(key(2), "kept").is_ok());
+        assert!(logs.is_active(key(2)));
+        assert_eq!(&*bytes.lock().expect("bytes lock"), b"kept");
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -135,6 +135,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         let selected = app.selected().contains(&index);
         let sleeping = app.pane_sleeping(index);
         let quiet = app.activity_badges_enabled() && pane.output_quiet();
+        let logging = app.pane_logging(index);
         let chrome = pane_chrome(
             selected,
             focused,
@@ -144,6 +145,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             quiet,
             palette,
         );
+        let badge = if logging {
+            format!("{} logging", chrome.badge)
+        } else {
+            chrome.badge.to_string()
+        };
 
         let header_summary = app.pane_header_summary(index, rect.width as usize);
         let usage = app.pane_usage_label(index);
@@ -152,7 +158,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             chrome.quiet_marker,
             &header_summary,
             usage.as_deref(),
-            chrome.badge,
+            &badge,
             app.compact_titles_enabled(),
             rect.width.saturating_sub(2),
         );
@@ -2599,6 +2605,8 @@ fn render_help(frame: &mut Frame<'_>, area: Rect, palette: &GridPalette) {
         ("Alt+t", "switch to next tab"),
         ("Alt+Shift+r", "rename current tab"),
         ("Alt+c", "expand or close the command line"),
+        ("Alt+Shift+c", "capture target pane output"),
+        ("Alt+Shift+l", "start or stop pane logging"),
         ("Alt+p", "show focused-pane activity summary"),
         ("Alt+Shift+p", "show previous panes"),
         ("Alt+f", "zoom or restore focused pane"),


### PR DESCRIPTION
## Summary
- add owner-local discovery for opted-in GridBash control sessions
- add human and JSON ctl commands for listing, inspection, send, capture, status, and focus
- add stable generation-checked pane targets shared with MCP control commands

Closes #222

## Validation
- cargo fmt --all -- --check
- combined Rust validation will run under the active GridBash integration lease