### PR TITLE
fix: preflight npm release ownership

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,10 +153,42 @@ jobs:
             echo "- Publish: $publish"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  build-native:
+  npm-registry-preflight:
     needs: [prepare, nightly-meta]
     if: >-
       always() &&
+      (
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_dispatch' && inputs.channel == 'release' && needs.prepare.result == 'success') ||
+        (
+          (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.channel == 'nightly')) &&
+          needs.nightly-meta.result == 'success' &&
+          needs.nightly-meta.outputs.publish == 'true'
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Use the release npm CLI
+        run: npm install --global npm@11
+
+      - name: Verify npm package ownership and repository metadata
+        run: node npm/scripts/release-preflight.js
+
+  build-native:
+    needs: [prepare, nightly-meta, npm-registry-preflight]
+    if: >-
+      always() &&
+      needs.npm-registry-preflight.result == 'success' &&
       (
         github.event_name == 'push' ||
         (github.event_name == 'workflow_dispatch' && inputs.channel == 'release' && needs.prepare.result == 'success') ||

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,6 +20,31 @@ package and all five native packages on npmjs.com to trust this repository's
 names must be bootstrapped once with a short-lived npm token before npm can
 attach their trusted publisher settings.
 
+After creating a package or receiving one from npm Support, confirm that
+`jasonmatthewsuhari` is an owner and configure the trusted publisher before the
+first GridBash release:
+
+```sh
+npm owner ls gridbash-win32-x64
+npm trust github gridbash-win32-x64 \
+  --repo jasonsuhari/gridbash \
+  --file release.yml \
+  --allow-publish
+npm trust list gridbash-win32-x64
+```
+
+Repeat the trust setup for `gridbash` and every package under `npm/platforms/`.
+The trust command requires an interactively authenticated npm account with 2FA.
+Use only the workflow filename (`release.yml`), not its full repository path.
+
+The release workflow runs `node npm/scripts/release-preflight.js` before the
+native build matrix. It fails early when a package is absent, is not owned by
+`jasonmatthewsuhari`, or advertises a different source repository. A package
+that npm transferred from its `0.0.1-security` holder is allowed once ownership
+is correct; its first GridBash publish replaces the placeholder repository
+metadata. The public preflight cannot inspect trusted-publisher settings, so
+`npm trust list` remains the authenticated setup check for each new package.
+
 As a fallback, add an npm automation token as a GitHub repository secret:
 
 ```text

--- a/docs/devlogs/2026-07-16-harden-npm-release-preflight.md
+++ b/docs/devlogs/2026-07-16-harden-npm-release-preflight.md
@@ -1,0 +1,37 @@
+# Harden npm release preflight
+
+Date: 2026-07-16
+Release target: unreleased
+
+## Summary
+
+- Added an npm registry preflight ahead of all cross-platform release builds.
+- Documented the ownership and trusted-publisher setup needed after npm creates
+  or transfers a package.
+
+## What Changed
+
+- The release workflow now verifies all six npm package names, the
+  `jasonmatthewsuhari` owner, and the GridBash GitHub repository before starting
+  the native build matrix.
+- The preflight recognizes npm's `0.0.1-security` placeholder only after the
+  expected owner controls it, allowing the first legitimate package publish to
+  replace the placeholder metadata.
+- Focused Node tests cover package discovery, owner parsing, repository
+  normalization, transferred placeholders, and drift failures.
+
+## Why It Matters
+
+- Registry ownership problems now fail in seconds instead of after five native
+  builds. The documented trust audit also closes the authentication step that
+  remains after npm Support transfers a blocked name.
+
+## Validation
+
+- `npm run test:release-preflight`
+- `node npm/scripts/release-preflight.js`
+- `npm run test:version`
+
+## Release Notes
+
+- Release automation now checks npm ownership before building publish artifacts.

--- a/npm/scripts/release-preflight.js
+++ b/npm/scripts/release-preflight.js
@@ -1,0 +1,196 @@
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const projectRoot = path.resolve(__dirname, "..", "..");
+const defaultOwner = "jasonmatthewsuhari";
+const defaultRepository = "jasonsuhari/gridbash";
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function expectedPackageNames(root) {
+  const rootPackage = readJson(path.join(root, "package.json"));
+  const dependencyNames = Object.keys(rootPackage.optionalDependencies || {});
+  const platformRoot = path.join(root, "npm", "platforms");
+  const nativeNames = fs
+    .readdirSync(platformRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => readJson(path.join(platformRoot, entry.name, "package.json")).name)
+    .sort();
+
+  const dependencySet = new Set(dependencyNames);
+  const nativeSet = new Set(nativeNames);
+  const missingDependencies = nativeNames.filter((name) => !dependencySet.has(name));
+  const missingManifests = dependencyNames.filter((name) => !nativeSet.has(name));
+
+  if (missingDependencies.length || missingManifests.length) {
+    const details = [
+      missingDependencies.length
+        ? `native manifests missing from optionalDependencies: ${missingDependencies.join(", ")}`
+        : undefined,
+      missingManifests.length
+        ? `optionalDependencies missing native manifests: ${missingManifests.join(", ")}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join("; ");
+    throw new Error(details);
+  }
+
+  return [rootPackage.name, ...dependencyNames];
+}
+
+function commandInvocation(command, args) {
+  if (process.platform !== "win32" || !command.endsWith(".cmd")) {
+    return { command, args };
+  }
+
+  const quote = (value) =>
+    /[ \t"&|<>^]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+  return {
+    command: process.env.ComSpec || "cmd.exe",
+    args: ["/d", "/s", "/c", [command, ...args].map(quote).join(" ")],
+  };
+}
+
+function runNpm(args) {
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  const invocation = commandInvocation(npm, args);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: projectRoot,
+    encoding: "utf8",
+    shell: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || "npm command failed").trim());
+  }
+  return result.stdout.trim();
+}
+
+function parseOwners(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => /^(@?[^\s<]+)/.exec(line.trim())?.[1])
+    .filter(Boolean);
+}
+
+function repositorySlug(repository) {
+  let value = typeof repository === "string" ? repository : repository?.url;
+  if (!value) {
+    return undefined;
+  }
+
+  value = value.trim();
+  if (value === "npm/security-holder") {
+    return value;
+  }
+
+  return value
+    .replace(/^git\+/, "")
+    .replace(/^github:/, "")
+    .replace(/^git@github\.com:/, "")
+    .replace(/^ssh:\/\/git@github\.com\//, "")
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/\.git\/?$/, "")
+    .replace(/\/$/, "")
+    .toLowerCase();
+}
+
+function validatePackage({ expectedName, expectedOwner, expectedRepository, metadata, owners }) {
+  const errors = [];
+  if (metadata.name !== expectedName) {
+    errors.push(`registry returned package name ${metadata.name || "<missing>"}`);
+  }
+  if (!owners.includes(expectedOwner)) {
+    errors.push(
+      `expected owner ${expectedOwner}; current owners: ${owners.join(", ") || "<none>"}`,
+    );
+  }
+
+  const actualRepository = repositorySlug(metadata.repository);
+  const expectedSlug = repositorySlug(expectedRepository);
+  const reclaimedSecurityPlaceholder =
+    metadata.version === "0.0.1-security" &&
+    actualRepository === "npm/security-holder" &&
+    owners.includes(expectedOwner);
+
+  if (actualRepository !== expectedSlug && !reclaimedSecurityPlaceholder) {
+    errors.push(
+      `expected repository ${expectedSlug}; registry reports ${actualRepository || "<missing>"}`,
+    );
+  }
+
+  return { errors, reclaimedSecurityPlaceholder };
+}
+
+function auditRegistry({
+  root = projectRoot,
+  expectedOwner = defaultOwner,
+  expectedRepository = defaultRepository,
+  npm = runNpm,
+} = {}) {
+  const reports = [];
+  for (const name of expectedPackageNames(root)) {
+    try {
+      const metadata = JSON.parse(npm(["view", name, "name", "version", "repository", "--json"]));
+      const owners = parseOwners(npm(["owner", "ls", name]));
+      const result = validatePackage({
+        expectedName: name,
+        expectedOwner,
+        expectedRepository,
+        metadata,
+        owners,
+      });
+      reports.push({ name, ...result });
+    } catch (error) {
+      reports.push({ name, errors: [error.message], reclaimedSecurityPlaceholder: false });
+    }
+  }
+  return reports;
+}
+
+function main() {
+  const reports = auditRegistry({
+    expectedOwner: process.env.GRIDBASH_NPM_OWNER || defaultOwner,
+    expectedRepository: process.env.GRIDBASH_NPM_REPOSITORY || defaultRepository,
+  });
+  let failed = false;
+
+  for (const report of reports) {
+    if (report.errors.length) {
+      failed = true;
+      console.error(`npm release preflight: ${report.name} failed`);
+      for (const error of report.errors) {
+        console.error(`  - ${error}`);
+      }
+    } else if (report.reclaimedSecurityPlaceholder) {
+      console.log(
+        `npm release preflight: ${report.name} is a reclaimed npm security placeholder; the first GridBash publish will replace its repository metadata.`,
+      );
+    } else {
+      console.log(`npm release preflight: ${report.name} ownership and repository verified.`);
+    }
+  }
+
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  auditRegistry,
+  expectedPackageNames,
+  parseOwners,
+  repositorySlug,
+  validatePackage,
+};

--- a/npm/scripts/release-preflight.test.js
+++ b/npm/scripts/release-preflight.test.js
@@ -1,0 +1,105 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  expectedPackageNames,
+  parseOwners,
+  repositorySlug,
+  validatePackage,
+} = require("./release-preflight");
+
+const root = path.resolve(__dirname, "..", "..");
+
+test("expectedPackageNames covers the launcher and every native package", () => {
+  assert.deepEqual(expectedPackageNames(root), [
+    "gridbash",
+    "gridbash-win32-x64",
+    "gridbash-linux-x64",
+    "gridbash-linux-arm64",
+    "gridbash-darwin-arm64",
+    "gridbash-darwin-x64",
+  ]);
+});
+
+test("release workflow gates native builds on the registry preflight", () => {
+  const workflow = fs.readFileSync(path.join(root, ".github", "workflows", "release.yml"), "utf8");
+  const preflight = workflow.indexOf("  npm-registry-preflight:");
+  const nativeBuild = workflow.indexOf("  build-native:");
+
+  assert.ok(preflight >= 0, "npm registry preflight job is missing");
+  assert.ok(nativeBuild > preflight, "npm registry preflight must precede native builds");
+  assert.match(workflow, /needs: \[prepare, nightly-meta, npm-registry-preflight\]/);
+  assert.match(workflow, /needs\.npm-registry-preflight\.result == 'success'/);
+});
+
+test("repositorySlug normalizes npm repository formats", () => {
+  assert.equal(
+    repositorySlug({ url: "git+https://github.com/jasonsuhari/gridbash.git" }),
+    "jasonsuhari/gridbash",
+  );
+  assert.equal(repositorySlug("git@github.com:jasonsuhari/gridbash.git"), "jasonsuhari/gridbash");
+  assert.equal(repositorySlug("github:jasonsuhari/gridbash"), "jasonsuhari/gridbash");
+});
+
+test("parseOwners extracts npm usernames", () => {
+  assert.deepEqual(
+    parseOwners(
+      "jasonmatthewsuhari <jasonmatthewsuhari@gmail.com>\nrelease-bot <bot@example.com>",
+    ),
+    ["jasonmatthewsuhari", "release-bot"],
+  );
+});
+
+test("validatePackage accepts the expected owner and repository", () => {
+  assert.deepEqual(
+    validatePackage({
+      expectedName: "gridbash-win32-x64",
+      expectedOwner: "jasonmatthewsuhari",
+      expectedRepository: "jasonsuhari/gridbash",
+      metadata: {
+        name: "gridbash-win32-x64",
+        version: "0.2.0",
+        repository: { url: "git+https://github.com/jasonsuhari/gridbash.git" },
+      },
+      owners: ["jasonmatthewsuhari"],
+    }),
+    { errors: [], reclaimedSecurityPlaceholder: false },
+  );
+});
+
+test("validatePackage permits a transferred npm security placeholder", () => {
+  assert.deepEqual(
+    validatePackage({
+      expectedName: "gridbash-win32-x64",
+      expectedOwner: "jasonmatthewsuhari",
+      expectedRepository: "jasonsuhari/gridbash",
+      metadata: {
+        name: "gridbash-win32-x64",
+        version: "0.0.1-security",
+        repository: "npm/security-holder",
+      },
+      owners: ["jasonmatthewsuhari"],
+    }),
+    { errors: [], reclaimedSecurityPlaceholder: true },
+  );
+});
+
+test("validatePackage reports ownership and repository drift", () => {
+  const result = validatePackage({
+    expectedName: "gridbash-win32-x64",
+    expectedOwner: "jasonmatthewsuhari",
+    expectedRepository: "jasonsuhari/gridbash",
+    metadata: {
+      name: "gridbash-win32-x64",
+      version: "0.2.0",
+      repository: "someone-else/gridbash",
+    },
+    owners: ["someone-else"],
+  });
+
+  assert.equal(result.reclaimedSecurityPlaceholder, false);
+  assert.match(result.errors.join("\n"), /expected owner jasonmatthewsuhari/);
+  assert.match(result.errors.join("\n"), /expected repository jasonsuhari\/gridbash/);
+});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "release": "node npm/scripts/release.js",
     "test:issue-labeler": "node --test npm/scripts/issue-labeler.test.js",
     "test:launcher": "node --test npm/scripts/gridbash-launcher.test.js",
+    "test:release-preflight": "node --test npm/scripts/release-preflight.test.js",
     "test:review-agent": "node --test npm/scripts/review-agent.test.js",
     "test:star-history": "node --test npm/scripts/update-star-history.test.js",
     "test:version": "node --test npm/scripts/version.test.js",


### PR DESCRIPTION
## Summary
- add an npm registry ownership/repository preflight before native release builds
- allow the one-time npm security-holder recovery state only after expected ownership is present
- document trusted publisher setup and add focused regression tests

## Validation
- `npm run test:release-preflight`
- `npm run test:version`
- `node npm/scripts/release-preflight.js`
- `git diff --check`

Closes #267