### PR TITLE
feat: recover interrupted sessions into tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ To keep live terminals running after GridBash closes, open Settings with
 launching shell when you quit; reconnect later with `gridbash resume --latest`
 or select the session with `gridbash resume`.
 
+If the terminal or GridBash process closes unexpectedly, the next plain
+`gridbash` launch automatically recovers unfinished agent sessions. Saved panes
+are grouped into tabs by working directory, each tab is named after that
+directory, and `Alt+t` moves to the next tab. Explicit launch arguments still
+start the workspace you requested, and older snapshots remain available through
+`gridbash resume`.
+
 ## Profiles and configuration
 
 A bare `gridbash` opens the agent-workspace setup. Detected agent profiles are

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -76,7 +76,9 @@ terminal panes retain their normal shell environment.
 
 ## Sessions and resume
 
-GridBash writes bounded session snapshots to local app data when grids launch and exit. Resume interactively, resume the latest snapshot, list snapshots, or select a session by its full ID or unique prefix:
+GridBash writes bounded session snapshots to local app data when grids launch,
+while they run, and when they exit. Resume interactively, resume the latest
+snapshot, list snapshots, or select a session by its full ID or unique prefix:
 
 ```powershell
 gridbash resume
@@ -96,6 +98,19 @@ produced while detached is added to the restored view. If a host is no longer
 available, GridBash starts a replacement terminal and retains the saved context.
 The background hosts are local, authenticated, and accept one GridBash client at
 a time.
+
+Session snapshots record whether their GridBash owner is still running and
+whether it exited cleanly. On a plain `gridbash` launch, snapshots left by a
+dead owner are claimed once and reopened automatically. GridBash groups their
+visible, tabbed, and background panes by working directory, names each recovered
+tab after the directory, and preserves the bounded command/output context. It
+does not claim sessions owned by another live GridBash process. Use `Alt+t` to
+cycle through the recovered tabs.
+
+Automatic recovery only applies to a plain launch. Grid, profile, count, cwd,
+worktree, layout, and agent-API launch options take precedence, while every
+saved snapshot remains available through the explicit `gridbash resume`
+commands above.
 
 ## Managed git worktrees
 

--- a/docs/devlogs/2026-07-18-recover-interrupted-conversations-into-tabs.md
+++ b/docs/devlogs/2026-07-18-recover-interrupted-conversations-into-tabs.md
@@ -1,0 +1,41 @@
+# Recover interrupted conversations into tabs
+
+Date: 2026-07-18
+Release target: unreleased
+
+## Summary
+
+- Recover agent conversations left behind when GridBash or its host terminal
+  closes unexpectedly.
+
+## What Changed
+
+- Added running-owner and clean-exit metadata to backward-compatible session
+  snapshots.
+- Autosave active grids every five seconds so an abrupt close retains recent
+  pane input, output, host references, tabs, and background jobs.
+- On a plain launch, atomically claim sessions whose owner process is gone,
+  group every saved pane by working directory, and reopen the groups as
+  directory-named tabs.
+- Skip sessions owned by live GridBash processes and keep explicit launch
+  arguments and `gridbash resume` behavior unchanged.
+- Added an `Alt+t switch` hint directly to the tab bar.
+
+## Why It Matters
+
+- Interrupted multi-project work returns as one coherent workspace without
+  making people remember session IDs or rebuild grids by hand.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo test session::tests`
+- `cargo test cli::tests`
+- `cargo test`
+- `cargo clippy --all-targets -- -D warnings`
+- `npm run install:local` from merged `main`
+
+## Release Notes
+
+- Automatically recover interrupted agent sessions into directory-named tabs;
+  press `Alt+t` to switch between them.

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,7 +50,8 @@ use crate::{
     profiles::{default_profile_name, find_profile},
     pty::{PtyEvent, PtyWriteToken},
     session::{
-        SavedBackgroundPane, SavedPane, SavedPaneHistory, SavedTab, SessionRecord, SessionRecorder,
+        InterruptedRecovery, SavedBackgroundPane, SavedPane, SavedPaneHistory, SavedTab,
+        SessionRecord, SessionRecorder,
     },
     setup::{LaunchPlan, PaneLaunchSpec},
     ui,
@@ -68,6 +69,7 @@ const PTY_DRAIN_MAX_EVENTS: usize = 64;
 const PTY_DRAIN_MAX_BYTES: usize = 512 * 1024;
 const PTY_DRAIN_MAX_TIME: Duration = Duration::from_millis(4);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const SESSION_AUTOSAVE_INTERVAL: Duration = Duration::from_secs(5);
 const PANE_GOAL_OUTPUT_MAX_BYTES: usize = 12_000;
 const PANE_GOAL_REVIEW_IDLE: Duration = Duration::from_secs(2);
 const PANE_GOAL_RETRY_DELAY: Duration = Duration::from_secs(30);
@@ -185,6 +187,7 @@ pub struct App {
     api_spend_label: Option<String>,
     last_activity_decay: Instant,
     last_exit_poll: Instant,
+    last_session_autosave: Instant,
 }
 
 struct AppInit {
@@ -256,18 +259,21 @@ impl BackgroundJob {
     }
 
     fn saved(&self) -> SavedBackgroundPane {
+        let live = self.pane.as_ref();
+        let mut pane = SavedPane::from_background(
+            &self.spec,
+            self.history(),
+            live.map(PtyPane::host_ref).or_else(|| self.host.clone()),
+        );
+        if let Some(live) = live {
+            pane.cwd = live.cwd().to_path_buf();
+            pane.folder_name = crate::setup::folder_display_name(&pane.cwd);
+        }
         SavedBackgroundPane {
             id: self.id,
             source_tab: self.source_tab.clone(),
             name: self.name.clone(),
-            pane: SavedPane::from_background(
-                &self.spec,
-                self.history(),
-                self.pane
-                    .as_ref()
-                    .map(PtyPane::host_ref)
-                    .or_else(|| self.host.clone()),
-            ),
+            pane,
         }
     }
 }
@@ -2486,6 +2492,60 @@ impl App {
         })
     }
 
+    pub fn recover_interrupted(
+        config: Config,
+        recovery: InterruptedRecovery,
+        mouse_enabled: bool,
+    ) -> Result<Self> {
+        let InterruptedRecovery {
+            mut tabs,
+            session_count,
+            pane_count,
+        } = recovery;
+        let active = if tabs.is_empty() {
+            return Err(anyhow!("interrupted recovery has no tabs"));
+        } else {
+            tabs.remove(0)
+        };
+        let mut launch_plan = active.launch_plan()?;
+        apply_auth_defaults(&mut launch_plan, &config)?;
+        let grid = launch_plan.grid;
+        let restored_histories = active.pane_histories();
+        let restored_hosts = active.pane_hosts();
+        let settings = SettingsState::from_config(&config);
+        let command_cwd = launch_plan
+            .panes
+            .first()
+            .map(|pane| pane.cwd.clone())
+            .unwrap_or(resolved_current_dir()?);
+        let tab_count = tabs.len() + 1;
+
+        Self::from_parts(AppInit {
+            config,
+            config_path: None,
+            worktrees: None,
+            launch_plan: Some(launch_plan),
+            grid,
+            mouse_enabled,
+            command_cwd,
+            control_handle: None,
+            control_rx: None,
+            settings,
+            tab_title: active.title,
+            restored_histories,
+            restored_background_panes: Vec::new(),
+            restored_hosts,
+            restored_tabs: tabs,
+            session_recorder: None,
+            status: format!(
+                "recovered {pane_count} pane{} from {session_count} interrupted session{} into {tab_count} tab{} | Alt+t switches tabs",
+                if pane_count == 1 { "" } else { "s" },
+                if session_count == 1 { "" } else { "s" },
+                if tab_count == 1 { "" } else { "s" },
+            ),
+        })
+    }
+
     fn from_parts(init: AppInit) -> Result<Self> {
         let (event_tx, event_rx) = mpsc::channel(PTY_EVENT_CHANNEL_CAPACITY);
         let (usage_tx, usage_rx) = std_mpsc::channel();
@@ -2597,6 +2657,7 @@ impl App {
             api_spend_label: None,
             last_activity_decay: Instant::now(),
             last_exit_poll: Instant::now(),
+            last_session_autosave: Instant::now(),
         })
     }
 
@@ -2634,7 +2695,11 @@ impl App {
         self.sync_initial_pane_sizes(terminal)?;
 
         let run_result = self.run_loop(terminal);
-        let save_result = self.save_session_snapshot();
+        let save_result = if run_result.is_ok() {
+            self.finish_session()
+        } else {
+            self.save_session_snapshot()
+        };
         match (run_result, save_result) {
             (Err(error), _) => Err(error),
             (Ok(()), Err(error)) => Err(error),
@@ -3052,6 +3117,7 @@ impl App {
             immediate_render |= self.update_follow_up_prompt();
             immediate_render |= self.schedule_goal_reviews();
             immediate_render |= self.schedule_activity_summaries();
+            immediate_render |= self.autosave_session_if_due();
             if immediate_render {
                 immediate_render |= self.refresh_workload_classes();
             }
@@ -9272,6 +9338,26 @@ impl App {
             .collect();
         recorder.update(&self.tab_title, &plan, &self.panes, tabs, background_panes);
         recorder.save()
+    }
+
+    fn autosave_session_if_due(&mut self) -> bool {
+        if self.last_session_autosave.elapsed() < SESSION_AUTOSAVE_INTERVAL {
+            return false;
+        }
+        self.last_session_autosave = Instant::now();
+        if let Err(error) = self.save_session_snapshot() {
+            self.status = format!("session autosave failed: {error:#}");
+            return true;
+        }
+        false
+    }
+
+    fn finish_session(&mut self) -> Result<()> {
+        self.save_session_snapshot()?;
+        if let Some(recorder) = self.session_recorder.as_mut() {
+            recorder.finish()?;
+        }
+        Ok(())
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,24 @@ pub struct Cli {
     pub layout: GridMode,
 }
 
+impl Cli {
+    pub fn allows_automatic_recovery(&self) -> bool {
+        self.command.is_none()
+            && self.grid.is_none()
+            && self.count.is_none()
+            && self.profile.is_none()
+            && self.cwd.is_none()
+            && !self.worktrees
+            && self.layout == GridMode::Grid
+            && !self.agent_api
+            && self.agent_api_port == 0
+            && self.set_default_profile.is_none()
+            && !self.list_profiles
+            && !self.mcp
+            && self.pane_host.is_none()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum GridMode {
     Grid,
@@ -180,6 +198,19 @@ mod tests {
         assert!(cli.command.is_none());
         assert_eq!(cli.grid.as_deref(), Some("2x3"));
         assert_eq!(cli.profile.as_deref(), Some("git-bash"));
+        assert!(!cli.allows_automatic_recovery());
+    }
+
+    #[test]
+    fn automatic_recovery_only_applies_to_plain_launches() {
+        let plain = Cli::parse_from(["gridbash"]);
+        assert!(plain.allows_automatic_recovery());
+
+        let worktrees = Cli::parse_from(["gridbash", "--worktrees"]);
+        assert!(!worktrees.allows_automatic_recovery());
+
+        let agent_api = Cli::parse_from(["gridbash", "--agent-api"]);
+        assert!(!agent_api.allows_automatic_recovery());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use crate::{
     cli::{Cli, Command},
     config::Config,
     profiles::{find_profile, profile_diagnostics},
-    session::select_resume_session,
+    session::{claim_interrupted_recovery, select_resume_session},
 };
 
 fn main() -> Result<()> {
@@ -86,6 +86,13 @@ fn main() -> Result<()> {
         };
 
         let mut app = App::resume(config, record, !cli.no_mouse)?;
+        return app.run();
+    }
+
+    if cli.allows_automatic_recovery()
+        && let Some(recovery) = claim_interrupted_recovery()?
+    {
+        let mut app = App::recover_interrupted(config, recovery, !cli.no_mouse)?;
         return app.run();
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,12 +2,13 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
 use directories::ProjectDirs;
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(unix)]
@@ -19,11 +20,12 @@ use crate::{
     layout::GridSize,
     pane_host::{PtyHostRef, PtyPane},
     profiles::Profile,
-    setup::{LaunchPlan, PaneLaunchSpec},
+    setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
 };
 
 const SESSION_VERSION: u16 = 1;
 const MAX_SAVED_SESSIONS: usize = 50;
+const MAX_RECOVERED_PANES_PER_TAB: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct SessionRecord {
@@ -46,6 +48,12 @@ pub struct SavedSession {
     pub background_panes: Vec<SavedBackgroundPane>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tabs: Vec<SavedTab>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovered_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -98,6 +106,13 @@ pub struct SavedPaneHistory {
     pub output_tail: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct InterruptedRecovery {
+    pub tabs: Vec<SavedTab>,
+    pub session_count: usize,
+    pub pane_count: usize,
+}
+
 pub struct SessionRecorder {
     path: PathBuf,
     session: SavedSession,
@@ -141,7 +156,37 @@ impl SavedSession {
                 .collect(),
             background_panes: Vec::new(),
             tabs: Vec::new(),
+            running: true,
+            owner_pid: Some(std::process::id()),
+            recovered_at: None,
         }
+    }
+
+    fn begin_run(&mut self) {
+        self.running = true;
+        self.owner_pid = Some(std::process::id());
+        self.recovered_at = None;
+        self.updated_at = now_seconds();
+    }
+
+    fn finish_run(&mut self) {
+        self.running = false;
+        self.owner_pid = None;
+        self.updated_at = now_seconds();
+    }
+
+    fn mark_recovered(&mut self) {
+        self.running = false;
+        self.owner_pid = None;
+        self.recovered_at = Some(now_seconds());
+    }
+
+    fn has_agent_pane(&self) -> bool {
+        self.panes
+            .iter()
+            .chain(self.tabs.iter().flat_map(|tab| tab.panes.iter()))
+            .chain(self.background_panes.iter().map(|job| &job.pane))
+            .any(|pane| pane.launch_spec().agent_label().is_some())
     }
 
     fn update_from_live(
@@ -265,12 +310,15 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
         .iter()
         .enumerate()
         .map(|(index, spec)| {
-            let history = panes
-                .get(index)
-                .map(SavedPaneHistory::from_pane)
-                .unwrap_or_default();
-            let host = panes.get(index).map(PtyPane::host_ref);
-            SavedPane::from_spec(index, spec, history, host)
+            let live = panes.get(index);
+            let history = live.map(SavedPaneHistory::from_pane).unwrap_or_default();
+            let host = live.map(PtyPane::host_ref);
+            let mut saved = SavedPane::from_spec(index, spec, history, host);
+            if let Some(live) = live {
+                saved.cwd = live.cwd().to_path_buf();
+                saved.folder_name = folder_display_name(&saved.cwd);
+            }
+            saved
         })
         .collect()
 }
@@ -350,7 +398,8 @@ impl SessionRecorder {
         Ok(recorder)
     }
 
-    pub fn continue_record(record: SessionRecord) -> Self {
+    pub fn continue_record(mut record: SessionRecord) -> Self {
+        record.session.begin_run();
         Self {
             path: record.path,
             session: record.session,
@@ -370,16 +419,127 @@ impl SessionRecorder {
     }
 
     pub fn save(&self) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            create_private_dir_all(parent).with_context(|| {
-                format!("failed to create session directory {}", parent.display())
-            })?;
-        }
-
-        let raw = toml::to_string_pretty(&self.session).context("failed to serialize session")?;
-        write_private_file(&self.path, raw.as_bytes())
-            .with_context(|| format!("failed to write session {}", self.path.display()))
+        save_session_to_path(&self.path, &self.session)
     }
+
+    pub fn finish(&mut self) -> Result<()> {
+        self.session.finish_run();
+        self.save()
+    }
+}
+
+pub fn claim_interrupted_recovery() -> Result<Option<InterruptedRecovery>> {
+    let directory = sessions_dir()?;
+    create_private_dir_all(&directory)
+        .with_context(|| format!("failed to create session directory {}", directory.display()))?;
+    let lock_path = directory.join(".recovery.lock");
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let lock = options
+        .open(&lock_path)
+        .with_context(|| format!("failed to open recovery lock {}", lock_path.display()))?;
+    FileExt::lock(&lock)
+        .with_context(|| format!("failed to lock recovery state {}", lock_path.display()))?;
+
+    let result = claim_interrupted_recovery_locked();
+    let unlock_result = FileExt::unlock(&lock)
+        .with_context(|| format!("failed to unlock recovery state {}", lock_path.display()));
+    match (result, unlock_result) {
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(recovery), Ok(())) => Ok(recovery),
+    }
+}
+
+fn claim_interrupted_recovery_locked() -> Result<Option<InterruptedRecovery>> {
+    let mut records = load_recent_sessions()?
+        .into_iter()
+        .filter(is_interrupted_agent_session)
+        .collect::<Vec<_>>();
+    let Some(recovery) = build_interrupted_recovery(&records) else {
+        return Ok(None);
+    };
+
+    for record in &mut records {
+        record.session.mark_recovered();
+        save_session_to_path(&record.path, &record.session)?;
+    }
+    Ok(Some(recovery))
+}
+
+fn is_interrupted_agent_session(record: &SessionRecord) -> bool {
+    let session = &record.session;
+    session.running
+        && session.recovered_at.is_none()
+        && session
+            .owner_pid
+            .is_some_and(|owner_pid| !process_is_running(owner_pid))
+        && session.has_agent_pane()
+}
+
+fn build_interrupted_recovery(records: &[SessionRecord]) -> Option<InterruptedRecovery> {
+    let mut groups = Vec::<(String, PathBuf, Vec<SavedPane>)>::new();
+    for record in records {
+        let session = &record.session;
+        let panes = session
+            .panes
+            .iter()
+            .chain(session.tabs.iter().flat_map(|tab| tab.panes.iter()))
+            .chain(session.background_panes.iter().map(|job| &job.pane));
+        for pane in panes {
+            let key = directory_group_key(&pane.cwd);
+            if let Some((_, _, panes)) = groups.iter_mut().find(|(group, _, _)| group == &key) {
+                panes.push(pane.clone());
+            } else {
+                groups.push((key, pane.cwd.clone(), vec![pane.clone()]));
+            }
+        }
+    }
+
+    let pane_count = groups.iter().map(|(_, _, panes)| panes.len()).sum();
+    if pane_count == 0 {
+        return None;
+    }
+
+    let mut title_counts = BTreeMap::<String, usize>::new();
+    let mut tabs = Vec::new();
+    for (_, cwd, panes) in groups {
+        let base_title = folder_display_name(&cwd);
+        for chunk in panes.chunks(MAX_RECOVERED_PANES_PER_TAB) {
+            let occurrence = title_counts.entry(base_title.clone()).or_default();
+            *occurrence += 1;
+            let title = if *occurrence == 1 {
+                base_title.clone()
+            } else {
+                format!("{base_title} ({occurrence})")
+            };
+            let mut panes = chunk.to_vec();
+            for (index, pane) in panes.iter_mut().enumerate() {
+                pane.index = index;
+            }
+            tabs.push(SavedTab {
+                title,
+                grid: GridSize::from_count(panes.len()).into(),
+                panes,
+            });
+        }
+    }
+
+    Some(InterruptedRecovery {
+        tabs,
+        session_count: records.len(),
+        pane_count,
+    })
+}
+
+fn directory_group_key(path: &Path) -> String {
+    #[cfg(windows)]
+    return path.to_string_lossy().replace('\\', "/").to_lowercase();
+
+    #[cfg(not(windows))]
+    path.to_string_lossy().into_owned()
 }
 
 pub fn select_resume_session(args: &ResumeArgs) -> Result<Option<SessionRecord>> {
@@ -534,16 +694,47 @@ fn create_private_dir_all(path: &std::path::Path) -> io::Result<()> {
 }
 
 fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("session.toml");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let temporary = parent.join(format!(".{file_name}.{}.{}.tmp", std::process::id(), nonce));
     let mut options = OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create_new(true);
     #[cfg(unix)]
     options.mode(0o600);
-    let mut file = options.open(path)?;
-    file.write_all(bytes)?;
-    file.flush()?;
+    let mut file = options.open(&temporary)?;
+    if let Err(error) = file.write_all(bytes).and_then(|()| file.flush()) {
+        drop(file);
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    drop(file);
     #[cfg(unix)]
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    Ok(())
+    fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+    match fs::rename(&temporary, path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = fs::remove_file(&temporary);
+            Err(error)
+        }
+    }
+}
+
+fn save_session_to_path(path: &Path, session: &SavedSession) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        create_private_dir_all(parent)
+            .with_context(|| format!("failed to create session directory {}", parent.display()))?;
+    }
+
+    let raw = toml::to_string_pretty(session).context("failed to serialize session")?;
+    write_private_file(path, raw.as_bytes())
+        .with_context(|| format!("failed to write session {}", path.display()))
 }
 
 fn session_file_path(id: &str) -> Result<PathBuf> {
@@ -563,6 +754,49 @@ fn now_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[cfg(unix)]
+fn process_is_running(process_id: u32) -> bool {
+    let Ok(process_id) = i32::try_from(process_id) else {
+        return false;
+    };
+    if process_id <= 0 {
+        return false;
+    }
+
+    let result = unsafe { libc::kill(process_id, 0) };
+    result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn process_is_running(process_id: u32) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, ERROR_ACCESS_DENIED, STILL_ACTIVE},
+        System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION},
+    };
+
+    if process_id == 0 {
+        return false;
+    }
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
+    if process.is_null() {
+        return io::Error::last_os_error().raw_os_error() == Some(ERROR_ACCESS_DENIED as i32);
+    }
+
+    let mut exit_code = 0;
+    let queried = unsafe { GetExitCodeProcess(process, &mut exit_code) };
+    unsafe { CloseHandle(process) };
+    queried != 0 && exit_code == STILL_ACTIVE as u32
+}
+
+#[cfg(not(any(unix, windows)))]
+fn process_is_running(_process_id: u32) -> bool {
+    true
 }
 
 fn age_label(updated_at: u64) -> String {
@@ -658,6 +892,9 @@ mod tests {
             ],
             background_panes: Vec::new(),
             tabs: Vec::new(),
+            running: false,
+            owner_pid: None,
+            recovered_at: None,
         };
 
         let summary = session.summary();
@@ -695,6 +932,9 @@ mod tests {
                 },
                 panes: vec![background_pane],
             }],
+            running: false,
+            owner_pid: None,
+            recovered_at: None,
         };
 
         let raw = toml::to_string(&session).expect("serialize session");
@@ -733,6 +973,9 @@ mod tests {
                 pane: pane("hidden", "codex"),
             }],
             tabs: Vec::new(),
+            running: false,
+            owner_pid: None,
+            recovered_at: None,
         };
         session.background_panes[0].pane.history.output_tail = "tests passing".into();
 
@@ -753,6 +996,132 @@ mod tests {
         let restored: SavedSession =
             toml::from_str(without_background).expect("restore old session");
         assert!(restored.background_panes.is_empty());
+    }
+
+    #[test]
+    fn running_metadata_defaults_to_closed_for_older_sessions() {
+        let plan = LaunchPlan::legacy(
+            "codex".into(),
+            Profile {
+                command: "codex".into(),
+                args: Vec::new(),
+                title: Some("Codex".into()),
+                agent_kind: Some(AgentKind::Codex),
+            },
+            env::current_dir().expect("cwd"),
+            1,
+            GridSize::from_count(1),
+        );
+        let session = SavedSession::new("running-test".into(), "Grid 1", &plan);
+        assert!(session.running);
+        assert_eq!(session.owner_pid, Some(std::process::id()));
+
+        let raw = toml::to_string(&session)
+            .expect("serialize")
+            .lines()
+            .filter(|line| !line.starts_with("running =") && !line.starts_with("owner_pid ="))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let old_session: SavedSession = toml::from_str(&raw).expect("parse old session");
+        assert!(!old_session.running);
+        assert!(old_session.owner_pid.is_none());
+        assert!(old_session.recovered_at.is_none());
+    }
+
+    #[test]
+    fn interruption_detection_ignores_live_owners() {
+        let mut session = recovery_session("live", vec![pane("alpha", "codex")]);
+        session.panes[0].command.agent_kind = Some(AgentKind::Codex);
+        session.running = true;
+        session.owner_pid = Some(std::process::id());
+        let mut record = SessionRecord {
+            path: PathBuf::from("live.toml"),
+            session,
+        };
+        assert!(!is_interrupted_agent_session(&record));
+
+        record.session.owner_pid = Some(u32::MAX);
+        assert!(is_interrupted_agent_session(&record));
+
+        record.session.recovered_at = Some(now_seconds());
+        assert!(!is_interrupted_agent_session(&record));
+    }
+
+    #[test]
+    fn interrupted_sessions_are_grouped_into_directory_named_tabs() {
+        let alpha = PathBuf::from("workspaces").join("alpha");
+        let beta = PathBuf::from("workspaces").join("beta");
+        let mut alpha_one = pane("ignored", "codex");
+        alpha_one.cwd = alpha.clone();
+        alpha_one.history.output_tail = "first conversation".into();
+        let mut beta_one = pane("ignored", "claude");
+        beta_one.cwd = beta.clone();
+        let mut alpha_two = pane("ignored", "codex");
+        alpha_two.cwd = alpha;
+        let mut beta_two = pane("ignored", "claude");
+        beta_two.cwd = beta;
+
+        let mut first = recovery_session("first", vec![alpha_one]);
+        first.tabs.push(SavedTab {
+            title: "old title".into(),
+            grid: GridSize::from_count(1).into(),
+            panes: vec![beta_one],
+        });
+        let mut second = recovery_session("second", vec![alpha_two]);
+        second.background_panes.push(SavedBackgroundPane {
+            id: 4,
+            source_tab: "other".into(),
+            name: None,
+            pane: beta_two,
+        });
+        let records = vec![
+            SessionRecord {
+                path: PathBuf::from("first.toml"),
+                session: first,
+            },
+            SessionRecord {
+                path: PathBuf::from("second.toml"),
+                session: second,
+            },
+        ];
+
+        let recovery = build_interrupted_recovery(&records).expect("recovery");
+
+        assert_eq!(recovery.session_count, 2);
+        assert_eq!(recovery.pane_count, 4);
+        assert_eq!(
+            recovery
+                .tabs
+                .iter()
+                .map(|tab| tab.title.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(recovery.tabs[0].panes.len(), 2);
+        assert_eq!(recovery.tabs[1].panes.len(), 2);
+        assert_eq!(recovery.tabs[0].panes[0].index, 0);
+        assert_eq!(recovery.tabs[0].panes[1].index, 1);
+        assert_eq!(
+            recovery.tabs[0].panes[0].history.output_tail,
+            "first conversation"
+        );
+    }
+
+    fn recovery_session(id: &str, panes: Vec<SavedPane>) -> SavedSession {
+        SavedSession {
+            version: SESSION_VERSION,
+            id: id.into(),
+            started_at: now_seconds(),
+            updated_at: now_seconds(),
+            title: "Grid 1".into(),
+            grid: GridSize::from_count(panes.len()).into(),
+            panes,
+            background_panes: Vec::new(),
+            tabs: Vec::new(),
+            running: false,
+            owner_pid: None,
+            recovered_at: None,
+        }
     }
 
     fn pane(folder_name: &str, profile_name: &str) -> SavedPane {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -438,7 +438,12 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
     ));
     spans.push(Span::raw(" "));
     spans.push(Span::styled(
-        "Alt+Shift+r rename tab",
+        "Alt+t switch",
+        Style::default().fg(Color::DarkGray),
+    ));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        "Alt+Shift+r rename",
         Style::default().fg(Color::DarkGray),
     ));
 


### PR DESCRIPTION
## Summary
- mark saved sessions as running until GridBash exits cleanly
- autosave snapshots atomically every five seconds
- recover dead-owner agent sessions once on the next plain launch
- regroup visible, tabbed, and background panes into directory-named tabs
- show `Alt+t switch` in the tab bar and document recovery behavior

## Local validation
- `cargo fmt --all -- --check`
- `git diff --check`
- Rust tests and clippy will run locally under the repository integration lease because GitHub Actions quota is exhausted

Refs #272