### PR TITLE
fix: hide command line by default

### DIFF
--- a/docs/devlogs/2026-07-19-hide-command-line-by-default.md
+++ b/docs/devlogs/2026-07-19-hide-command-line-by-default.md
@@ -1,0 +1,29 @@
+# Hide command line by default
+
+Date: 2026-07-19
+Release target: unreleased
+
+## Summary
+
+- Hide the dedicated command line until the user opens it with Alt+C.
+
+## What Changed
+
+- The terminal layout reserves no command-line row while the command line is closed.
+- Opening the command line restores its input row and output area, and closing it returns the space to the pane grid.
+- Added a focused regression test for the hidden and visible row heights.
+
+## Why It Matters
+
+- Pane grids get an extra row of usable terminal space by default without changing the Alt+C workflow.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo test command_line_is_hidden_until_focused --lib`
+- `cargo check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+
+## Release Notes
+
+- The Alt+C command line is now hidden by default and appears only while open.

--- a/docs/devlogs/2026-07-19-hide-command-line-by-default.md
+++ b/docs/devlogs/2026-07-19-hide-command-line-by-default.md
@@ -20,9 +20,9 @@ Release target: unreleased
 ## Validation
 
 - `cargo fmt --all -- --check`
-- `cargo test command_line_is_hidden_until_focused --lib`
-- `cargo check`
-- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test command_line_is_hidden_until_focused`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
 
 ## Release Notes
 

--- a/docs/devlogs/2026-07-19-hide-command-line-by-default.md
+++ b/docs/devlogs/2026-07-19-hide-command-line-by-default.md
@@ -11,7 +11,7 @@ Release target: unreleased
 
 - The terminal layout reserves no command-line row while the command line is closed.
 - Opening the command line restores its input row and output area, and closing it returns the space to the pane grid.
-- Added a focused regression test for the hidden and visible row heights.
+- Added focused regression tests for hidden and visible row heights and small-terminal rendering while hidden.
 
 ## Why It Matters
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -63,6 +63,7 @@ const PANE_SETTINGS_BUTTON: &str = " Summary ";
 
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
+    let command_height = command_line_height(app.command_focused());
     let output_height = if app.command_output_expanded() {
         command_output_height(area.height, app.command_output_lines().len())
     } else {
@@ -74,7 +75,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             Constraint::Length(1),
             Constraint::Min(1),
             Constraint::Length(output_height),
-            Constraint::Length(1),
+            Constraint::Length(command_height),
             Constraint::Length(1),
         ])
         .split(area);
@@ -452,6 +453,10 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
         area,
     );
 }
+fn command_line_height(focused: bool) -> u16 {
+    u16::from(focused)
+}
+
 fn command_output_height(total_height: u16, line_count: usize) -> u16 {
     let available = total_height.saturating_sub(3);
     if available < 3 {
@@ -3900,6 +3905,12 @@ mod tests {
         let rendered = buffer_text(&terminal);
         assert!(rendered.contains("GridBash Commands"));
         assert!(rendered.contains("No matching"));
+    }
+
+    #[test]
+    fn command_line_is_hidden_until_focused() {
+        assert_eq!(command_line_height(false), 0);
+        assert_eq!(command_line_height(true), 1);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3873,6 +3873,8 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{cli::Cli, config::Config};
+    use clap::Parser;
     use ratatui::{Terminal, backend::TestBackend};
 
     fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
@@ -3911,6 +3913,24 @@ mod tests {
     fn command_line_is_hidden_until_focused() {
         assert_eq!(command_line_height(false), 0);
         assert_eq!(command_line_height(true), 1);
+    }
+
+    #[test]
+    fn hidden_command_line_renders_safely_at_small_terminal_sizes() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let app = App::new(cli, Config::default()).expect("app");
+
+        for (width, height) in [(1, 1), (2, 2), (40, 6)] {
+            let backend = TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).expect("test terminal");
+            terminal
+                .draw(|frame| {
+                    draw(frame, &app);
+                })
+                .expect("render hidden command line");
+
+            assert!(!buffer_text(&terminal).contains(" > "));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- hide the Alt+C command line until it is opened
- return the closed command-line row to the pane grid
- add a regression test for hidden and visible row heights

Closes #276

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`