### PR TITLE
feat: improve resume picker recovery

### DIFF
--- a/docs/devlogs/2026-07-20-improve-resume-picker-and-stale-client-recovery.md
+++ b/docs/devlogs/2026-07-20-improve-resume-picker-and-stale-client-recovery.md
@@ -1,0 +1,33 @@
+# Improve resume picker and stale-client recovery
+
+Date: 2026-07-20
+Release target: unreleased
+
+## Summary
+
+- Rebuilt `gridbash resume` as a full-screen, stacked terminal-green picker.
+- Made interrupted sessions recoverable without allowing two live clients to attach.
+- Hardened pane-host sockets against inherited handles after an unexpected client exit.
+
+## What Changed
+
+- Added a selected-session detail panel above the recent-session list, with concise status badges for open, recoverable, detached, and saved workspaces.
+- Added keyboard navigation, pagination, cancellation, and an inline explanation when a session is still open elsewhere.
+- Made `resume --latest` skip sessions owned by a live GridBash process when another recoverable session exists.
+- Added an optional client PID to the pane-host handshake. Older clients remain compatible, while a new client can replace an attachment whose owning process is gone.
+- Marked pane-host listener and client sockets non-inheritable on Windows so spawned shells cannot accidentally keep a dead connection alive.
+
+## Why It Matters
+
+- A terminal or GridBash client can disappear without making its workspace permanently report that it is open elsewhere.
+- The resume flow exposes the information needed to choose a workspace without compressing it into a hard-to-scan one-line prompt.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- Focused resume-picker, session, and pane-host tests.
+- Full Rust test suite before merge.
+
+## Release Notes
+
+- Fixes [#279](https://github.com/jasonsuhari/gridbash/issues/279).

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod pane_host;
 mod process_priority;
 mod profiles;
 mod pty;
+mod resume_picker;
 mod session;
 mod setup;
 mod ui;

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     ffi::{OsString, OsString as PlatformString},
     fs::{self, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::{self, BufRead, BufReader, Write},
     net::{Shutdown, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -28,6 +28,7 @@ use crate::{
     layout::PaneId,
     process_priority::PaneWorkloadClass,
     pty::{PtyEvent, PtyPane as LocalPtyPane, PtyView, PtyWriteToken},
+    session::process_is_running,
 };
 
 const HOST_START_TIMEOUT: Duration = Duration::from_secs(8);
@@ -73,6 +74,8 @@ enum HostCommand {
         protocol_version: u16,
         token: String,
         keep_running: bool,
+        #[serde(default)]
+        client_pid: Option<u32>,
     },
     Write {
         data: String,
@@ -334,6 +337,8 @@ impl PtyPane {
             .with_context(|| format!("invalid pane host endpoint {}", host.endpoint))?;
         let mut stream = TcpStream::connect_timeout(&endpoint, HANDSHAKE_TIMEOUT)
             .with_context(|| format!("failed to connect to pane host {}", host.endpoint))?;
+        prevent_stream_inheritance(&stream)
+            .context("failed to protect pane host connection from child-process inheritance")?;
         stream.set_nodelay(true).ok();
         stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT)).ok();
         send_json(
@@ -342,12 +347,15 @@ impl PtyPane {
                 protocol_version: PANE_HOST_PROTOCOL_VERSION,
                 token: host.token.clone(),
                 keep_running,
+                client_pid: Some(std::process::id()),
             },
         )?;
 
         let reader_stream = stream
             .try_clone()
             .context("failed to clone pane host connection")?;
+        prevent_stream_inheritance(&reader_stream)
+            .context("failed to protect pane host reader from child-process inheritance")?;
         let mut reader = BufReader::new(reader_stream);
         let mut line = String::new();
         reader
@@ -564,6 +572,8 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
     let _ = fs::remove_file(spec_path);
 
     let listener = TcpListener::bind(("127.0.0.1", 0)).context("failed to bind pane host")?;
+    prevent_listener_inheritance(&listener)
+        .context("failed to protect pane host listener from child-process inheritance")?;
     listener
         .set_nonblocking(true)
         .context("failed to make pane host listener nonblocking")?;
@@ -610,6 +620,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
 
     let (command_tx, command_rx) = std_mpsc::channel::<HostInput>();
     let mut client = None::<HostClient>;
+    let mut active_client_id = None::<u64>;
     let mut next_client_id = 1_u64;
     let mut keep_running = spec.keep_running;
     let mut background_output = Vec::new();
@@ -618,6 +629,15 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
     loop {
         match listener.accept() {
             Ok((mut stream, _)) => {
+                prevent_stream_inheritance(&stream).context(
+                    "failed to protect accepted pane host connection from child-process inheritance",
+                )?;
+                if client
+                    .as_ref()
+                    .is_some_and(|client| client_process_is_gone(client.owner_pid))
+                {
+                    disconnect_client(&mut client);
+                }
                 if client.is_none() {
                     if let Some(connected) = accept_client(
                         stream,
@@ -628,6 +648,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                         command_tx.clone(),
                     )? {
                         keep_running = connected.keep_running;
+                        active_client_id = Some(connected.client.id);
                         client = Some(connected.client);
                         next_client_id = next_client_id.wrapping_add(1);
                     }
@@ -650,7 +671,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
         }
 
         while let Ok(input) = command_rx.try_recv() {
-            if client.as_ref().map(|value| value.id) != Some(input.client_id) {
+            if active_client_id != Some(input.client_id) {
                 continue;
             }
             match input.message {
@@ -708,6 +729,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                     } => {
                         keep_running = value;
                         disconnect_client(&mut client);
+                        active_client_id = None;
                         if !keep_running {
                             pane.terminate();
                             return Ok(());
@@ -721,6 +743,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                 },
                 HostInputMessage::Closed => {
                     disconnect_client(&mut client);
+                    active_client_id = None;
                     if !keep_running {
                         pane.terminate();
                         return Ok(());
@@ -783,6 +806,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
 struct HostClient {
     id: u64,
     stream: TcpStream,
+    owner_pid: Option<u32>,
 }
 
 struct AcceptedClient {
@@ -816,6 +840,8 @@ fn accept_client(
     let reader_stream = stream
         .try_clone()
         .context("failed to clone pane host client")?;
+    prevent_stream_inheritance(&reader_stream)
+        .context("failed to protect pane host client reader from child-process inheritance")?;
     let mut reader = BufReader::new(reader_stream);
     let mut line = String::new();
     reader
@@ -825,6 +851,7 @@ fn accept_client(
         protocol_version,
         token,
         keep_running,
+        client_pid,
     }) = serde_json::from_str::<HostCommand>(&line)
     else {
         let _ = send_json(
@@ -870,6 +897,7 @@ fn accept_client(
         client: HostClient {
             id: client_id,
             stream,
+            owner_pid: client_pid,
         },
         keep_running,
     }))
@@ -1001,6 +1029,44 @@ fn disconnect_client(client: &mut Option<HostClient>) {
     }
 }
 
+fn client_process_is_gone(owner_pid: Option<u32>) -> bool {
+    owner_pid.is_some_and(|owner_pid| !process_is_running(owner_pid))
+}
+
+#[cfg(windows)]
+fn prevent_stream_inheritance(stream: &TcpStream) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    prevent_socket_inheritance(stream.as_raw_socket())
+}
+
+#[cfg(not(windows))]
+fn prevent_stream_inheritance(_stream: &TcpStream) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prevent_listener_inheritance(listener: &TcpListener) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    prevent_socket_inheritance(listener.as_raw_socket())
+}
+
+#[cfg(not(windows))]
+fn prevent_listener_inheritance(_listener: &TcpListener) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prevent_socket_inheritance(socket: std::os::windows::io::RawSocket) -> io::Result<()> {
+    use windows_sys::Win32::Foundation::{HANDLE, HANDLE_FLAG_INHERIT, SetHandleInformation};
+
+    let result = unsafe { SetHandleInformation(socket as HANDLE, HANDLE_FLAG_INHERIT, 0) };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 fn append_background_output(buffer: &mut Vec<u8>, bytes: &[u8]) {
     buffer.extend_from_slice(bytes);
     if buffer.len() > BACKGROUND_OUTPUT_LIMIT {
@@ -1093,6 +1159,8 @@ fn spawn_detached_host(spec_path: &Path) -> Result<std::process::Child> {
 mod tests {
     use super::*;
 
+    static PANE_HOST_TEST_LOCK: Mutex<()> = Mutex::new(());
+
     struct TestHostFiles {
         directory: PathBuf,
         spec: PathBuf,
@@ -1136,6 +1204,23 @@ mod tests {
     }
 
     #[test]
+    fn hello_protocol_accepts_clients_without_owner_pid() {
+        let raw = r#"{"type":"hello","protocol_version":1,"token":"secret","keep_running":true}"#;
+        let command = serde_json::from_str::<HostCommand>(raw).expect("parse legacy hello");
+        let HostCommand::Hello { client_pid, .. } = command else {
+            panic!("wrong command kind");
+        };
+        assert_eq!(client_pid, None);
+    }
+
+    #[test]
+    fn stale_client_detection_requires_a_known_dead_owner() {
+        assert!(!client_process_is_gone(None));
+        assert!(!client_process_is_gone(Some(std::process::id())));
+        assert!(client_process_is_gone(Some(u32::MAX)));
+    }
+
+    #[test]
     fn background_output_keeps_a_bounded_tail() {
         let mut output = vec![b'a'; BACKGROUND_OUTPUT_LIMIT];
         append_background_output(&mut output, b"latest");
@@ -1145,6 +1230,7 @@ mod tests {
 
     #[test]
     fn pane_host_survives_disconnect_and_accepts_reattach() {
+        let _guard = PANE_HOST_TEST_LOCK.lock().expect("lock pane host test");
         let files = TestHostFiles::new();
         let host_token = random_token().expect("host token");
         #[cfg(windows)]
@@ -1254,6 +1340,101 @@ mod tests {
             .expect("pane host exits cleanly");
     }
 
+    #[test]
+    fn pane_host_replaces_a_client_owned_by_a_dead_process() {
+        let _guard = PANE_HOST_TEST_LOCK.lock().expect("lock pane host test");
+        let files = TestHostFiles::new();
+        let host_token = random_token().expect("host token");
+        #[cfg(windows)]
+        let (profile_name, command, args, line_ending) = (
+            "cmd",
+            PathBuf::from("cmd.exe"),
+            vec!["/d".to_string(), "/q".to_string()],
+            "\r",
+        );
+        #[cfg(unix)]
+        let (profile_name, command, args, line_ending) =
+            ("sh", PathBuf::from("/bin/sh"), vec!["-i".to_string()], "\n");
+        let spec = HostLaunchSpec {
+            token: host_token.clone(),
+            ready_path: files.ready.clone(),
+            profile_name: profile_name.into(),
+            pane_id: 8,
+            generation: 0,
+            command,
+            args,
+            env: BTreeMap::new(),
+            cwd: std::env::current_dir().expect("current directory"),
+            extra_env: Vec::new(),
+            scrollback_rows: 1_000,
+            process_priority: PaneProcessPriority::Normal,
+            workload_policy: PaneWorkloadPolicy::Unrestricted,
+            keep_running: true,
+        };
+        fs::write(
+            &files.spec,
+            serde_json::to_vec(&spec).expect("serialize host spec"),
+        )
+        .expect("write host spec");
+        let spec_path = files.spec.clone();
+        let host_thread = thread::spawn(move || run_pane_host(&spec_path));
+
+        let ready = wait_for_ready(&files.ready);
+        let mut stale = TcpStream::connect(&ready.endpoint).expect("connect stale client");
+        send_json(
+            &mut stale,
+            &HostCommand::Hello {
+                protocol_version: PANE_HOST_PROTOCOL_VERSION,
+                token: host_token.clone(),
+                keep_running: true,
+                client_pid: Some(u32::MAX),
+            },
+        )
+        .expect("send stale hello");
+        let mut stale_reader = BufReader::new(stale.try_clone().expect("clone stale client"));
+        let mut hello = String::new();
+        stale_reader
+            .read_line(&mut hello)
+            .expect("read stale client handshake");
+        assert!(matches!(
+            serde_json::from_str::<HostEvent>(&hello).expect("parse stale handshake"),
+            HostEvent::Ready { .. }
+        ));
+
+        let host = PtyHostRef {
+            endpoint: ready.endpoint,
+            token: host_token,
+        };
+        let (replacement_tx, mut replacement_rx) = mpsc::channel(8);
+        let mut replacement = PtyPane::attach(
+            host,
+            PaneId(8),
+            0,
+            &spec.cwd,
+            1_000,
+            true,
+            "",
+            &[],
+            replacement_tx,
+        )
+        .expect("replacement client takes over");
+        replacement
+            .write(format!("exit{line_ending}").as_bytes())
+            .expect("exit replacement shell");
+        assert_pane_exits(&mut replacement_rx);
+        replacement
+            .set_keep_running(false)
+            .expect("disable host persistence");
+        drop(replacement);
+        drop(stale_reader);
+        drop(stale);
+
+        host_thread
+            .join()
+            .expect("join pane host")
+            .expect("pane host exits cleanly");
+    }
+
     fn wait_for_ready(path: &Path) -> HostReadyFile {
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
@@ -1286,5 +1467,20 @@ mod tests {
             }
         }
         panic!("expected output {expected:?}, got {output:?}");
+    }
+
+    fn assert_pane_exits(receiver: &mut mpsc::Receiver<PtyEvent>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            match receiver.try_recv() {
+                Ok(PtyEvent::Exited { .. }) => return,
+                Ok(PtyEvent::WriteFailed { error, .. }) => panic!("pane write failed: {error}"),
+                Ok(_) | Err(mpsc::error::TryRecvError::Empty) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        panic!("expected pane to exit");
     }
 }

--- a/src/resume_picker.rs
+++ b/src/resume_picker.rs
@@ -1,0 +1,664 @@
+use std::{
+    collections::BTreeSet,
+    io::{self, Stdout},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::session::{SessionRecord, process_is_running};
+
+type ResumeTerminal = Terminal<CrosstermBackend<Stdout>>;
+
+const CANVAS_BG: Color = Color::Rgb(0, 5, 2);
+const PANEL_BG: Color = Color::Rgb(1, 10, 5);
+const RAISED_BG: Color = Color::Rgb(2, 16, 8);
+const SELECTED_BG: Color = Color::Rgb(5, 35, 18);
+const HAIRLINE: Color = Color::Rgb(18, 76, 40);
+const MUTED: Color = Color::Rgb(72, 128, 88);
+const DIM_GREEN: Color = Color::Rgb(50, 176, 92);
+const TERMINAL_GREEN: Color = Color::Rgb(91, 255, 139);
+const SOFT_GREEN: Color = Color::Rgb(159, 255, 183);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionState {
+    Open(u32),
+    Interrupted,
+    Detached,
+    Saved,
+}
+
+impl SessionState {
+    fn for_record(record: &SessionRecord) -> Self {
+        let session = &record.session;
+        if session.running {
+            if let Some(owner_pid) = session.owner_pid
+                && process_is_running(owner_pid)
+            {
+                return Self::Open(owner_pid);
+            }
+            return Self::Interrupted;
+        }
+
+        if all_panes(record).any(|pane| pane.host.is_some()) {
+            Self::Detached
+        } else {
+            Self::Saved
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Open(_) => "OPEN",
+            Self::Interrupted => "RECOVER",
+            Self::Detached => "DETACHED",
+            Self::Saved => "SAVED",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::Open(_) => DIM_GREEN,
+            Self::Interrupted => TERMINAL_GREEN,
+            Self::Detached => SOFT_GREEN,
+            Self::Saved => MUTED,
+        }
+    }
+
+    fn description(self) -> String {
+        match self {
+            Self::Open(owner_pid) => {
+                format!("Already attached to a live GridBash client (PID {owner_pid}).")
+            }
+            Self::Interrupted => {
+                "The previous client stopped. GridBash will recover this workspace.".into()
+            }
+            Self::Detached => "Saved pane hosts are ready to reconnect.".into(),
+            Self::Saved => "Recreates terminals from the saved layout and history.".into(),
+        }
+    }
+}
+
+enum PickerAction {
+    Continue,
+    Select(usize),
+    Cancel,
+}
+
+struct ResumePicker<'a> {
+    sessions: &'a [SessionRecord],
+    list_state: ListState,
+    page_size: usize,
+    notice: Option<String>,
+}
+
+pub fn select_session(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
+    let mut terminal = setup_terminal()?;
+    let mut picker = ResumePicker::new(sessions);
+    let result = picker.run(&mut terminal);
+    let teardown_result = teardown_terminal(&mut terminal);
+
+    match (result, teardown_result) {
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(selection), Ok(())) => Ok(selection),
+    }
+}
+
+impl<'a> ResumePicker<'a> {
+    fn new(sessions: &'a [SessionRecord]) -> Self {
+        let mut list_state = ListState::default();
+        list_state.select((!sessions.is_empty()).then_some(0));
+        Self {
+            sessions,
+            list_state,
+            page_size: 1,
+            notice: None,
+        }
+    }
+
+    fn run(&mut self, terminal: &mut ResumeTerminal) -> Result<Option<SessionRecord>> {
+        loop {
+            terminal.draw(|frame| self.draw(frame))?;
+            if !event::poll(Duration::from_millis(100))? {
+                continue;
+            }
+
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            match self.handle_key(key) {
+                PickerAction::Continue => {}
+                PickerAction::Cancel => return Ok(None),
+                PickerAction::Select(index) => return Ok(Some(self.sessions[index].clone())),
+            }
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> PickerAction {
+        let Some(selected) = self.list_state.selected() else {
+            return PickerAction::Cancel;
+        };
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => PickerAction::Cancel,
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.select(selected.saturating_sub(1));
+                PickerAction::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.select((selected + 1).min(self.sessions.len().saturating_sub(1)));
+                PickerAction::Continue
+            }
+            KeyCode::Home => {
+                self.select(0);
+                PickerAction::Continue
+            }
+            KeyCode::End => {
+                self.select(self.sessions.len().saturating_sub(1));
+                PickerAction::Continue
+            }
+            KeyCode::PageUp => {
+                self.select(selected.saturating_sub(self.page_size));
+                PickerAction::Continue
+            }
+            KeyCode::PageDown => {
+                self.select((selected + self.page_size).min(self.sessions.len().saturating_sub(1)));
+                PickerAction::Continue
+            }
+            KeyCode::Enter => {
+                if let SessionState::Open(owner_pid) =
+                    SessionState::for_record(&self.sessions[selected])
+                {
+                    self.notice = Some(format!(
+                        "Session is already open in PID {owner_pid}. Switch to that GridBash window or close it before resuming."
+                    ));
+                    PickerAction::Continue
+                } else {
+                    PickerAction::Select(selected)
+                }
+            }
+            _ => PickerAction::Continue,
+        }
+    }
+
+    fn select(&mut self, index: usize) {
+        self.list_state.select(Some(index));
+        self.notice = None;
+    }
+
+    fn draw(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(CANVAS_BG)),
+            area,
+        );
+
+        let panel = if area.width >= 84 && area.height >= 20 {
+            inset(area, 1, 1)
+        } else {
+            area
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .title(Line::from(vec![
+                Span::styled(" $ ", Style::default().fg(TERMINAL_GREEN)),
+                Span::styled(
+                    "gridbash resume",
+                    Style::default()
+                        .fg(TERMINAL_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" ", Style::default()),
+            ]))
+            .border_style(Style::default().fg(TERMINAL_GREEN))
+            .style(Style::default().fg(SOFT_GREEN).bg(PANEL_BG));
+        let inner = inset(block.inner(panel), 1, 0);
+        frame.render_widget(block, panel);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let (header_height, detail_height, controls_height) = if inner.height >= 22 {
+            (3, 9, 3)
+        } else {
+            (2, 7, 2)
+        };
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(header_height),
+                Constraint::Length(detail_height),
+                Constraint::Min(4),
+                Constraint::Length(controls_height),
+            ])
+            .split(inner);
+        self.draw_header(frame, chunks[0]);
+        self.draw_details(frame, chunks[1]);
+        self.draw_sessions(frame, chunks[2]);
+        self.draw_controls(frame, chunks[3]);
+    }
+
+    fn draw_header(&self, frame: &mut Frame<'_>, area: Rect) {
+        let selected = self.list_state.selected().unwrap_or(0) + 1;
+        let selected_state = self
+            .list_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+            .map(SessionState::for_record)
+            .unwrap_or(SessionState::Saved);
+        let right_width = area.width.min(24);
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(20), Constraint::Length(right_width)])
+            .split(area);
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "SELECT A WORKSPACE TO RESUME",
+                    Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(Span::styled(
+                    "Saved terminals, layout, and working context.",
+                    Style::default().fg(MUTED),
+                )),
+            ])
+            .style(Style::default().bg(PANEL_BG)),
+            columns[0],
+        );
+
+        if columns[1].width > 0 {
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(state_badge(selected_state)),
+                    Line::from(Span::styled(
+                        format!("{selected} of {}", self.sessions.len()),
+                        Style::default().fg(MUTED),
+                    )),
+                ])
+                .alignment(Alignment::Right)
+                .style(Style::default().bg(PANEL_BG)),
+                columns[1],
+            );
+        }
+    }
+
+    fn draw_details(&self, frame: &mut Frame<'_>, area: Rect) {
+        let block = panel_block("SELECTED SESSION");
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        let Some(record) = self
+            .list_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+        else {
+            return;
+        };
+
+        let state = SessionState::for_record(record);
+        let session = &record.session;
+        let panes = all_panes(record).count();
+        let tabs = session.tabs.len() + 1;
+        let folders = compact_labels(all_panes(record).map(|pane| pane.folder_name.as_str()));
+        let profiles = compact_labels(all_panes(record).map(|pane| pane.profile_name.as_str()));
+        let host_count = all_panes(record).filter(|pane| pane.host.is_some()).count();
+        let resume_mode = if host_count > 0 {
+            format!(
+                "reconnect {host_count} PTY host{}",
+                if host_count == 1 { "" } else { "s" }
+            )
+        } else {
+            "recreate from snapshot".into()
+        };
+        let lines = vec![
+            Line::from(vec![
+                Span::styled(
+                    session_title(record),
+                    Style::default()
+                        .fg(TERMINAL_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                state_badge(state),
+            ]),
+            Line::from(Span::styled(
+                state.description(),
+                Style::default().fg(MUTED),
+            )),
+            detail_row("SESSION ID", session.id.clone()),
+            detail_row(
+                "WORKSPACE",
+                format!(
+                    "{}x{} | {panes} pane{} | {tabs} tab{} | {resume_mode}",
+                    session.grid.rows,
+                    session.grid.columns,
+                    if panes == 1 { "" } else { "s" },
+                    if tabs == 1 { "" } else { "s" },
+                ),
+            ),
+            detail_row("FOLDERS", folders.unwrap_or_else(|| "Unknown".into())),
+            detail_row("PROFILES", profiles.unwrap_or_else(|| "Unknown".into())),
+        ];
+        frame.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: true })
+                .style(Style::default().bg(RAISED_BG)),
+            inner,
+        );
+    }
+
+    fn draw_sessions(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let block = panel_block("RECENT SESSIONS");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        self.page_size = usize::from((inner.height / 2).max(1));
+
+        let items = self
+            .sessions
+            .iter()
+            .map(|record| {
+                let state = SessionState::for_record(record);
+                ListItem::new(vec![
+                    Line::from(vec![
+                        state_badge(state),
+                        Span::raw(" "),
+                        Span::styled(
+                            session_title(record),
+                            Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("           ", Style::default().fg(MUTED)),
+                        Span::styled(record.summary(), Style::default().fg(MUTED)),
+                    ]),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let list = List::new(items)
+            .highlight_symbol("> ")
+            .highlight_style(Style::default().fg(TERMINAL_GREEN).bg(SELECTED_BG))
+            .style(Style::default().bg(RAISED_BG));
+        frame.render_stateful_widget(list, inner, &mut self.list_state);
+    }
+
+    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect) {
+        let line = if let Some(notice) = &self.notice {
+            Line::from(vec![
+                Span::styled("[!]", Style::default().fg(TERMINAL_GREEN)),
+                Span::raw("  "),
+                Span::styled(notice.clone(), Style::default().fg(SOFT_GREEN)),
+            ])
+        } else {
+            Line::from(vec![
+                keycap("UP/DOWN or J/K"),
+                Span::styled(" NAVIGATE   ", Style::default().fg(MUTED)),
+                launch_keycap("ENTER"),
+                Span::styled(" RESUME   ", Style::default().fg(MUTED)),
+                keycap("Q or ESC"),
+                Span::styled(" CANCEL", Style::default().fg(MUTED)),
+            ])
+        };
+        frame.render_widget(
+            Paragraph::new(line)
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true })
+                .style(Style::default().bg(PANEL_BG)),
+            area,
+        );
+    }
+}
+
+fn all_panes(record: &SessionRecord) -> impl Iterator<Item = &crate::session::SavedPane> {
+    record
+        .session
+        .panes
+        .iter()
+        .chain(record.session.tabs.iter().flat_map(|tab| tab.panes.iter()))
+        .chain(record.session.background_panes.iter().map(|job| &job.pane))
+}
+
+fn session_title(record: &SessionRecord) -> String {
+    if record.session.title.trim().is_empty() {
+        record
+            .session
+            .panes
+            .first()
+            .map(|pane| pane.folder_name.clone())
+            .filter(|title| !title.is_empty())
+            .unwrap_or_else(|| "Untitled workspace".into())
+    } else {
+        record.session.title.clone()
+    }
+}
+
+fn compact_labels<'a>(labels: impl Iterator<Item = &'a str>) -> Option<String> {
+    let unique = labels
+        .filter(|label| !label.is_empty())
+        .collect::<BTreeSet<_>>();
+    if unique.is_empty() {
+        return None;
+    }
+    let shown = unique.iter().take(3).copied().collect::<Vec<_>>();
+    let extra = unique.len().saturating_sub(shown.len());
+    let mut label = shown.join(", ");
+    if extra > 0 {
+        label.push_str(&format!(" +{extra}"));
+    }
+    Some(label)
+}
+
+fn detail_row(label: &'static str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<12}"),
+            Style::default().fg(MUTED).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(value, Style::default().fg(SOFT_GREEN)),
+    ])
+}
+
+fn state_badge(state: SessionState) -> Span<'static> {
+    Span::styled(
+        format!("[{:<8}]", state.label()),
+        Style::default()
+            .fg(state.color())
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn panel_block(label: &'static str) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .title(Line::from(Span::styled(
+            format!(" {label} "),
+            Style::default()
+                .fg(TERMINAL_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .border_style(Style::default().fg(HAIRLINE))
+        .style(Style::default().bg(RAISED_BG))
+}
+
+fn keycap(label: &'static str) -> Span<'static> {
+    Span::styled(
+        format!("[{label}]"),
+        Style::default()
+            .fg(TERMINAL_GREEN)
+            .bg(RAISED_BG)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn launch_keycap(label: &'static str) -> Span<'static> {
+    Span::styled(
+        format!(" {label} "),
+        Style::default()
+            .fg(Color::Black)
+            .bg(TERMINAL_GREEN)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn inset(area: Rect, x: u16, y: u16) -> Rect {
+    Rect {
+        x: area.x.saturating_add(x.min(area.width)),
+        y: area.y.saturating_add(y.min(area.height)),
+        width: area.width.saturating_sub(x.saturating_mul(2)),
+        height: area.height.saturating_sub(y.saturating_mul(2)),
+    }
+}
+
+fn setup_terminal() -> Result<ResumeTerminal> {
+    enable_raw_mode().context("failed to enable raw terminal mode")?;
+    let mut stdout = io::stdout();
+    if let Err(error) = execute!(stdout, EnterAlternateScreen) {
+        let _ = disable_raw_mode();
+        return Err(error).context("failed to enter alternate screen");
+    }
+    let backend = CrosstermBackend::new(stdout);
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(error) => {
+            let _ = disable_raw_mode();
+            let mut stdout = io::stdout();
+            let _ = execute!(stdout, LeaveAlternateScreen);
+            Err(error).context("failed to create resume terminal")
+        }
+    }
+}
+
+fn teardown_terminal(terminal: &mut ResumeTerminal) -> Result<()> {
+    disable_raw_mode().context("failed to disable raw terminal mode")?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)
+        .context("failed to leave alternate screen")?;
+    terminal.show_cursor().context("failed to restore cursor")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use ratatui::{Terminal, backend::TestBackend};
+
+    use super::*;
+    use crate::{
+        profiles::Profile,
+        session::{SavedGrid, SavedPane, SavedPaneHistory, SavedSession},
+    };
+
+    #[test]
+    fn marks_live_and_interrupted_sessions() {
+        let mut record = record("active", true, Some(std::process::id()), false);
+        assert_eq!(
+            SessionState::for_record(&record),
+            SessionState::Open(std::process::id())
+        );
+
+        record.session.owner_pid = Some(u32::MAX);
+        assert_eq!(SessionState::for_record(&record), SessionState::Interrupted);
+    }
+
+    #[test]
+    fn marks_detached_sessions_with_saved_hosts() {
+        let record = record("detached", false, None, true);
+        assert_eq!(SessionState::for_record(&record), SessionState::Detached);
+    }
+
+    #[test]
+    fn renders_terminal_green_stacked_resume_picker() {
+        let sessions = vec![record("Fluent workspace", false, None, true)];
+        let mut picker = ResumePicker::new(&sessions);
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame))
+            .expect("draw resume picker");
+
+        let buffer = terminal.backend().buffer();
+        let rendered = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        let details_at = rendered.find("SELECTED SESSION").expect("details panel");
+        let sessions_at = rendered.find("RECENT SESSIONS").expect("sessions panel");
+        assert!(
+            details_at < sessions_at,
+            "details should render above sessions"
+        );
+        assert!(rendered.contains("gridbash resume"));
+        assert!(rendered.contains("Fluent workspace"));
+        assert!(rendered.contains("DETACHED"));
+        assert!(!rendered.contains("01 /"));
+        assert!(!rendered.contains("02 /"));
+        assert!(
+            buffer
+                .content()
+                .iter()
+                .any(|cell| cell.fg == TERMINAL_GREEN)
+        );
+    }
+
+    fn record(title: &str, running: bool, owner_pid: Option<u32>, host: bool) -> SessionRecord {
+        let pane = SavedPane {
+            index: 0,
+            profile_name: "codex".into(),
+            command: Profile {
+                command: "codex".into(),
+                args: Vec::new(),
+                title: Some("Codex".into()),
+                agent_kind: None,
+            },
+            cwd: PathBuf::from("fluent"),
+            folder_name: "fluent".into(),
+            worktree_name: None,
+            auth_name: None,
+            auth_kind: None,
+            history: SavedPaneHistory::default(),
+            host: host.then(|| crate::pane_host::PtyHostRef {
+                endpoint: "127.0.0.1:12345".into(),
+                token: "token".into(),
+            }),
+        };
+        SessionRecord {
+            path: PathBuf::from("session.toml"),
+            session: SavedSession {
+                version: 1,
+                id: "session-id".into(),
+                started_at: 1,
+                updated_at: 1,
+                title: title.into(),
+                grid: SavedGrid {
+                    rows: 1,
+                    columns: 1,
+                },
+                panes: vec![pane],
+                background_panes: Vec::new(),
+                tabs: Vec::new(),
+                running,
+                owner_pid,
+                recovered_at: None,
+            },
+        }
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -554,15 +554,21 @@ pub fn select_resume_session(args: &ResumeArgs) -> Result<Option<SessionRecord>>
         return Ok(None);
     }
 
-    if let Some(query) = args.session.as_deref() {
-        return find_session(&sessions, query).map(Some);
-    }
+    let selected = if let Some(query) = args.session.as_deref() {
+        Some(find_session(&sessions, query)?)
+    } else if args.latest {
+        sessions
+            .iter()
+            .find(|record| live_owner_pid(record).is_none())
+            .cloned()
+            .or_else(|| sessions.first().cloned())
+    } else if sessions.len() == 1 {
+        sessions.first().cloned()
+    } else {
+        prompt_for_session(&sessions)?
+    };
 
-    if args.latest || sessions.len() == 1 {
-        return Ok(sessions.into_iter().next());
-    }
-
-    prompt_for_session(&sessions)
+    selected.map(ensure_session_is_resumable).transpose()
 }
 
 pub fn load_recent_sessions() -> Result<Vec<SessionRecord>> {
@@ -631,6 +637,33 @@ fn find_session(sessions: &[SessionRecord], query: &str) -> Result<SessionRecord
 }
 
 fn prompt_for_session(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
+    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+        return crate::resume_picker::select_session(sessions);
+    }
+
+    prompt_for_session_plain(sessions)
+}
+
+fn live_owner_pid(record: &SessionRecord) -> Option<u32> {
+    record
+        .session
+        .running
+        .then_some(record.session.owner_pid)
+        .flatten()
+        .filter(|owner_pid| process_is_running(*owner_pid))
+}
+
+fn ensure_session_is_resumable(record: SessionRecord) -> Result<SessionRecord> {
+    if let Some(owner_pid) = live_owner_pid(&record) {
+        bail!(
+            "session {} is already open in GridBash (PID {owner_pid}); switch to that client or close it before resuming",
+            record.session.id
+        );
+    }
+    Ok(record)
+}
+
+fn prompt_for_session_plain(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
     println!("Recent GridBash sessions:");
     for (index, record) in sessions.iter().take(20).enumerate() {
         println!(
@@ -761,7 +794,7 @@ fn is_false(value: &bool) -> bool {
 }
 
 #[cfg(unix)]
-fn process_is_running(process_id: u32) -> bool {
+pub(crate) fn process_is_running(process_id: u32) -> bool {
     let Ok(process_id) = i32::try_from(process_id) else {
         return false;
     };
@@ -774,7 +807,7 @@ fn process_is_running(process_id: u32) -> bool {
 }
 
 #[cfg(windows)]
-fn process_is_running(process_id: u32) -> bool {
+pub(crate) fn process_is_running(process_id: u32) -> bool {
     use windows_sys::Win32::{
         Foundation::{CloseHandle, ERROR_ACCESS_DENIED, STILL_ACTIVE},
         System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION},
@@ -795,7 +828,7 @@ fn process_is_running(process_id: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn process_is_running(_process_id: u32) -> bool {
+pub(crate) fn process_is_running(_process_id: u32) -> bool {
     true
 }
 
@@ -1045,6 +1078,24 @@ mod tests {
 
         record.session.recovered_at = Some(now_seconds());
         assert!(!is_interrupted_agent_session(&record));
+    }
+
+    #[test]
+    fn resume_rejects_only_sessions_with_live_owners() {
+        let mut session = recovery_session("live", vec![pane("alpha", "codex")]);
+        session.running = true;
+        session.owner_pid = Some(std::process::id());
+        let record = SessionRecord {
+            path: PathBuf::from("live.toml"),
+            session,
+        };
+
+        let error = ensure_session_is_resumable(record.clone()).expect_err("live owner rejected");
+        assert!(error.to_string().contains("already open"));
+
+        let mut interrupted = record;
+        interrupted.session.owner_pid = Some(u32::MAX);
+        ensure_session_is_resumable(interrupted).expect("dead owner can be recovered");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the one-line resume selector with a stacked terminal-green TUI
- guard sessions owned by live GridBash clients while allowing interrupted-session recovery
- let pane hosts replace dead client owners and prevent Windows socket handle inheritance
- retain backward compatibility for clients without a PID in the handshake

## Validation
- `cargo fmt --all -- --check`
- focused Rust tests and full suite will run under the repository integration lease before merge

Refs #279