### PR TITLE
feat: add agent port inspector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ whisper-rs = "0.16"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ agents and shells.
 | `Alt+d` | Chat with BashBot across all open grids and panes |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
 | `Alt+p` | Open focused-pane activity |
+| `Ctrl+Alt+p` | Inspect and stop localhost ports launched by agents |
 | `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |
 | `Alt+f` | Zoom or restore the focused pane |
 | `Alt+b` | Search, select, and copy focused-pane scrollback |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -231,6 +231,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
 | Alt+p | Open the focused-pane activity summary. |
+| Ctrl+Alt+p | Open the agent port inspector. |
 | Alt+Shift+P | Open the previous-panes list. |
 | Alt+Shift+A | Open Auth Profiles to manage accounts or assign one to the focused pane. |
 | Alt+Shift+B | Move selected panes, or the focused pane, into the background and launch fresh replacements. |
@@ -274,6 +275,8 @@ The command palette lists the available pane, tab, grid, manager, settings, help
 
 Pane Activity provides auth, rename, refresh, sleep/wake, deactivate, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `d` to deactivate, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+Shift+A opens Auth Profiles and Alt+o switches to overall settings.
 
+The bottom-right **Ports** control counts TCP listeners launched inside GridBash agent process trees. Click it or press Ctrl+Alt+p to see each port, process name, PID, and owning pane or tab. Use Up/Down to select a listener, `R` to refresh, and Enter or Delete followed by Enter to terminate its process. GridBash excludes unrelated system listeners and its own pane-host control sockets from this view.
+
 Deactivating a pane ends its terminal process, compacts the remaining panes, and shrinks the grid whenever a smaller dimension can still hold them. Columns are removed before rows, so deactivating two panes from a `2x3` grid compacts it to `2x2`. The final pane cannot be deactivated.
 
 Alt+Shift+B backgrounds every explicitly selected pane, or the focused pane when the selected set is empty. GridBash first launches fresh panes with the same profile, command, auth, folder, and worktree; only after all replacements succeed are the original PTYs moved into the session-wide pool. Custom pane names follow the original jobs, while fresh replacements return to numbered labels.
@@ -297,7 +300,7 @@ settings = "f8"
 Supported actions are `quit`, `help`, `focus-left`, `focus-right`, `focus-up`,
 `focus-down`, `toggle-selection`, `select-all`, `sleep-panes`, `restart-panes`,
 `next-tab`, `new-tab`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
-`command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`,
+`command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`, `ports`,
 `pane-activity`, `copy-mode`, `auth-profiles`, `capture-output`,
 `toggle-output-logging`, `rename-tab`, and `rename-pane`. Unlisted actions retain their
 defaults. Duplicate chords and unmodified terminal keys are rejected. F1 and

--- a/docs/devlogs/2026-07-20-add-agent-port-inspector.md
+++ b/docs/devlogs/2026-07-20-add-agent-port-inspector.md
@@ -1,0 +1,32 @@
+# Add agent port inspector
+
+Date: 2026-07-20
+Release target: unreleased
+Issue: #278
+
+## Summary
+
+- GridBash now surfaces agent-owned localhost listeners in a footer-backed port inspector.
+- The inspector identifies the owning process and pane, and can terminate a stale development server after confirmation.
+
+## What Changed
+
+- Added a live `Ports N` control at the bottom-right of the workspace and a configurable `Ctrl+Alt+P` shortcut.
+- Added a modal listing TCP port, process name, PID, and owning pane or tab, with mouse selection and keyboard navigation.
+- Added asynchronous Windows, macOS, and Linux listener discovery by matching socket PIDs to authenticated pane-host ancestry.
+- Added guarded termination that re-scans and verifies ownership immediately before signaling the process.
+
+## Why It Matters
+
+- Coding agents frequently start development servers and leave them running. The inspector makes port conflicts visible without leaving GridBash or guessing which pane owns a process.
+- Filtering by pane-host ancestry keeps unrelated system services and GridBash's private control listeners out of the termination surface.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- Focused port parser, ancestry, shortcut, state, and footer layout tests.
+- Repository Cargo validation under the shared integration lease.
+
+## Release Notes
+
+- Added an agent port inspector with safe process termination from the GridBash footer.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -16,6 +16,7 @@ fn search_keywords(action: Action) -> &'static str {
         Action::ZoomPane => "maximize fullscreen restore",
         Action::RestartPanes => "exited dead",
         Action::PreviousPanes => "history list switch",
+        Action::Ports => "localhost server listener process pid terminate",
         Action::VoiceInput => "microphone speech",
         Action::AuthProfiles => "accounts credentials profiles",
         Action::CaptureOutput | Action::ToggleOutputLogging => "save terminal logs",

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,7 @@ use crate::{
     manager::{self, ActivitySummary, AssistantReply, ManagerCommand, ManagerDecision},
     output_capture::{self, OutputLogs, PaneLogKey},
     pane_host::{PaneHostBusy, PaneHostIncompatible, PaneHostRejected, PtyHostRef, PtyPane},
+    ports::{self, AgentPort, AgentProcessRoot},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile, is_terminal_profile, startup_profiles},
     pty::{PtyEvent, PtyWriteToken},
@@ -69,6 +70,7 @@ const PTY_DRAIN_MAX_EVENTS: usize = 64;
 const PTY_DRAIN_MAX_BYTES: usize = 512 * 1024;
 const PTY_DRAIN_MAX_TIME: Duration = Duration::from_millis(4);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const PORT_SCAN_INTERVAL: Duration = Duration::from_secs(2);
 const SESSION_AUTOSAVE_INTERVAL: Duration = Duration::from_secs(5);
 const PANE_GOAL_OUTPUT_MAX_BYTES: usize = 12_000;
 const PANE_GOAL_REVIEW_IDLE: Duration = Duration::from_secs(2);
@@ -151,6 +153,9 @@ pub struct App {
     previous_panes: PreviousPanesState,
     background_jobs: Vec<BackgroundJob>,
     background_picker: BackgroundPickerState,
+    port_inspector: PortInspectorState,
+    port_scan_tx: std_mpsc::Sender<Result<Vec<AgentPort>, String>>,
+    port_scan_rx: std_mpsc::Receiver<Result<Vec<AgentPort>, String>>,
     follow_up: Option<FollowUpPromptState>,
     auth_profiles: Vec<AuthProfile>,
     auth_refresh_rx: Option<std_mpsc::Receiver<Result<Vec<AuthProfile>, String>>>,
@@ -175,6 +180,8 @@ pub struct App {
     pane_settings_stop_goal_button: Option<Rect>,
     background_jobs_button: Option<Rect>,
     background_job_rows: Vec<(usize, Rect)>,
+    ports_button: Option<Rect>,
+    port_rows: Vec<(usize, Rect)>,
     event_tx: mpsc::Sender<PtyEvent>,
     event_rx: mpsc::Receiver<PtyEvent>,
     pane_render_cache: RefCell<HashMap<PaneId, ui::PaneRenderCache>>,
@@ -1054,6 +1061,62 @@ pub struct BackgroundJobsView {
     pub cursor: usize,
     pub pending_delete: Option<u64>,
     pub jobs: Vec<BackgroundJobView>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PortInspectorView {
+    pub ports: Vec<AgentPortView>,
+    pub cursor: usize,
+    pub pending_terminate: Option<u32>,
+    pub refreshing: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentPortView {
+    pub port: u16,
+    pub pid: u32,
+    pub process: String,
+    pub owner: String,
+}
+
+#[derive(Debug, Default)]
+struct PortInspectorState {
+    open: bool,
+    ports: Vec<AgentPort>,
+    cursor: usize,
+    pending_terminate: Option<u32>,
+    refreshing: bool,
+    last_scan: Option<Instant>,
+    error: Option<String>,
+}
+
+impl PortInspectorState {
+    fn close(&mut self) {
+        self.open = false;
+        self.pending_terminate = None;
+    }
+
+    fn move_cursor(&mut self, delta: isize) {
+        if self.ports.is_empty() {
+            self.cursor = 0;
+        } else {
+            self.cursor = (self.cursor as isize + delta)
+                .clamp(0, self.ports.len().saturating_sub(1) as isize)
+                as usize;
+        }
+        self.pending_terminate = None;
+    }
+
+    fn clamp_cursor(&mut self) {
+        self.cursor = self.cursor.min(self.ports.len().saturating_sub(1));
+        if self
+            .pending_terminate
+            .is_some_and(|pid| !self.ports.iter().any(|port| port.pid == pid))
+        {
+            self.pending_terminate = None;
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2376,10 +2439,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -2563,6 +2626,7 @@ impl App {
             .unwrap_or(0)
             .saturating_add(1);
         let (activity_summary_tx, activity_summary_rx) = std_mpsc::channel();
+        let (port_scan_tx, port_scan_rx) = std_mpsc::channel();
         let keybindings = KeyBindings::from_overrides(&init.config.keys)?;
         let (assistant_tx, assistant_rx) = std_mpsc::channel();
 
@@ -2621,6 +2685,9 @@ impl App {
             previous_panes: PreviousPanesState::default(),
             background_jobs,
             background_picker: BackgroundPickerState::default(),
+            port_inspector: PortInspectorState::default(),
+            port_scan_tx,
+            port_scan_rx,
             follow_up: None,
             auth_profiles: Vec::new(),
             auth_refresh_rx: None,
@@ -2645,6 +2712,8 @@ impl App {
             pane_settings_stop_goal_button: None,
             background_jobs_button: None,
             background_job_rows: Vec::new(),
+            ports_button: None,
+            port_rows: Vec::new(),
             event_tx,
             event_rx,
             pane_render_cache: RefCell::new(HashMap::new()),
@@ -2880,6 +2949,7 @@ impl App {
         self.tab_rename.close();
         self.previous_panes.close();
         self.background_picker.close();
+        self.port_inspector.close();
         self.pane_settings.close();
         self.follow_up = None;
         self.goal_editor = None;
@@ -3108,6 +3178,7 @@ impl App {
             immediate_render |= self.drain_usage_events();
             immediate_render |= self.drain_auth_refresh();
             immediate_render |= self.drain_command_events();
+            immediate_render |= self.drain_port_scan();
             immediate_render |= self.drain_goal_reviews();
             immediate_render |= self.drain_activity_summary_events();
             immediate_render |= self.drain_assistant_events();
@@ -3118,6 +3189,7 @@ impl App {
             immediate_render |= self.schedule_goal_reviews();
             immediate_render |= self.schedule_activity_summaries();
             immediate_render |= self.autosave_session_if_due();
+            immediate_render |= self.schedule_port_scan();
             if immediate_render {
                 immediate_render |= self.refresh_workload_classes();
             }
@@ -3139,6 +3211,8 @@ impl App {
                     self.pane_settings_stop_goal_button = draw_state.pane_settings_stop_goal_button;
                     self.background_jobs_button = draw_state.background_jobs_button;
                     self.background_job_rows = draw_state.background_job_rows;
+                    self.ports_button = draw_state.ports_button;
+                    self.port_rows = draw_state.port_rows;
                 })?;
                 self.sync_pane_sizes();
                 immediate_render = false;
@@ -3220,6 +3294,7 @@ impl App {
                     && !self.rename.open
                     && !self.background_picker.open
                     && !self.previous_panes.open
+                    && !self.port_inspector.open
                     && !self.pane_settings.open
                     && self.image_overlay.is_none()
                     && self.follow_up.is_none()
@@ -4362,6 +4437,94 @@ impl App {
         changed
     }
 
+    fn schedule_port_scan(&mut self) -> bool {
+        if self.port_inspector.refreshing
+            || self
+                .port_inspector
+                .last_scan
+                .is_some_and(|last| last.elapsed() < PORT_SCAN_INTERVAL)
+        {
+            return false;
+        }
+
+        let roots = self.agent_process_roots();
+        if roots.is_empty() {
+            let changed = !self.port_inspector.ports.is_empty()
+                || self.port_inspector.error.is_some()
+                || self.port_inspector.refreshing;
+            self.port_inspector.ports.clear();
+            self.port_inspector.error = None;
+            self.port_inspector.refreshing = false;
+            self.port_inspector.last_scan = Some(Instant::now());
+            self.port_inspector.clamp_cursor();
+            return changed;
+        }
+
+        self.port_inspector.refreshing = true;
+        let sender = self.port_scan_tx.clone();
+        thread::spawn(move || {
+            let result = ports::discover_agent_ports(&roots).map_err(|error| error.to_string());
+            let _ = sender.send(result);
+        });
+        self.port_inspector.open
+    }
+
+    fn drain_port_scan(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(result) = self.port_scan_rx.try_recv() {
+            self.port_inspector.refreshing = false;
+            self.port_inspector.last_scan = Some(Instant::now());
+            match result {
+                Ok(ports) => {
+                    changed |= self.port_inspector.ports != ports;
+                    self.port_inspector.ports = ports;
+                    self.port_inspector.error = None;
+                }
+                Err(error) => {
+                    let error = bounded_prefix(&error, 240);
+                    changed |= self.port_inspector.error.as_deref() != Some(error.as_str());
+                    self.port_inspector.error = Some(error);
+                }
+            }
+            self.port_inspector.clamp_cursor();
+            changed |= self.port_inspector.open;
+        }
+        changed
+    }
+
+    fn agent_process_roots(&self) -> Vec<AgentProcessRoot> {
+        let mut roots = Vec::new();
+        roots.extend(self.panes.iter().enumerate().filter_map(|(index, pane)| {
+            pane.host_process_id().map(|pid| AgentProcessRoot {
+                pid,
+                label: port_owner_label(&self.tab_title, &self.pane_names, index),
+            })
+        }));
+        for tab in self.tabs.iter().filter_map(Option::as_ref) {
+            roots.extend(tab.panes.iter().enumerate().filter_map(|(index, pane)| {
+                pane.host_process_id().map(|pid| AgentProcessRoot {
+                    pid,
+                    label: port_owner_label(&tab.title, &tab.pane_names, index),
+                })
+            }));
+        }
+        roots.extend(self.background_jobs.iter().filter_map(|job| {
+            job.pane
+                .as_ref()?
+                .host_process_id()
+                .map(|pid| AgentProcessRoot {
+                    pid,
+                    label: format!(
+                        "Background / {}",
+                        job.name
+                            .clone()
+                            .unwrap_or_else(|| format!("job {}", job.id))
+                    ),
+                })
+        }));
+        roots
+    }
+
     fn drain_voice_events(&mut self) -> Result<bool> {
         let Some(outcome) = self.voice.poll() else {
             return Ok(false);
@@ -5038,6 +5201,10 @@ impl App {
             self.status = "pane activity closed".into();
             return Ok(KeyOutcome::Render);
         }
+        if self.port_inspector.open && action == Some(Action::Ports) {
+            self.close_port_inspector();
+            return Ok(KeyOutcome::Render);
+        }
         if self.settings.open && action == Some(Action::Settings) {
             self.settings.open = false;
             self.status = "settings closed".into();
@@ -5079,6 +5246,11 @@ impl App {
 
         if self.pane_settings.open {
             let outcome = self.handle_pane_settings_key(key)?;
+            return Ok(render_if_selection_cleared(outcome, selection_cleared));
+        }
+
+        if self.port_inspector.open {
+            let outcome = self.handle_port_inspector_key(key);
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
@@ -5609,6 +5781,9 @@ impl App {
             Action::PaneActivity => {
                 self.toggle_pane_settings();
             }
+            Action::Ports => {
+                self.open_port_inspector();
+            }
             Action::CopyMode => {
                 self.open_copy_mode();
             }
@@ -5938,6 +6113,139 @@ impl App {
     fn close_background_jobs(&mut self) {
         self.background_picker.close();
         self.status = "background agents closed".into();
+    }
+
+    fn open_port_inspector(&mut self) {
+        self.close_tab_modals();
+        self.settings.open = false;
+        self.image_overlay = None;
+        self.help_open = false;
+        self.port_inspector.open = true;
+        self.port_inspector.pending_terminate = None;
+        self.port_inspector.last_scan = None;
+        self.status = if self.port_inspector.ports.is_empty() {
+            "looking for agent-owned localhost ports".into()
+        } else {
+            format!(
+                "{} agent-owned localhost port(s)",
+                self.port_inspector.ports.len()
+            )
+        };
+    }
+
+    fn close_port_inspector(&mut self) {
+        self.port_inspector.close();
+        self.status = "agent ports closed".into();
+    }
+
+    fn handle_port_inspector_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return KeyOutcome::Quit;
+        }
+        let changed = match key.code {
+            KeyCode::Esc if self.port_inspector.pending_terminate.is_some() => {
+                self.port_inspector.pending_terminate = None;
+                self.status = "port termination canceled".into();
+                true
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.close_port_inspector();
+                true
+            }
+            KeyCode::Up => {
+                self.port_inspector.move_cursor(-1);
+                true
+            }
+            KeyCode::Down => {
+                self.port_inspector.move_cursor(1);
+                true
+            }
+            KeyCode::Home => {
+                self.port_inspector.cursor = 0;
+                self.port_inspector.pending_terminate = None;
+                true
+            }
+            KeyCode::End => {
+                self.port_inspector.cursor = self.port_inspector.ports.len().saturating_sub(1);
+                self.port_inspector.pending_terminate = None;
+                true
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.port_inspector.last_scan = None;
+                self.port_inspector.error = None;
+                self.status = "refreshing agent-owned localhost ports".into();
+                true
+            }
+            KeyCode::Delete | KeyCode::Enter => {
+                self.confirm_or_terminate_selected_port();
+                true
+            }
+            _ => false,
+        };
+        if changed {
+            KeyOutcome::Render
+        } else {
+            KeyOutcome::Continue
+        }
+    }
+
+    fn confirm_or_terminate_selected_port(&mut self) {
+        let Some(port) = self
+            .port_inspector
+            .ports
+            .get(self.port_inspector.cursor)
+            .cloned()
+        else {
+            self.status = "no agent-owned port selected".into();
+            return;
+        };
+        if self.port_inspector.pending_terminate != Some(port.pid) {
+            self.port_inspector.pending_terminate = Some(port.pid);
+            self.status = format!(
+                "press Enter to terminate {} (PID {}) on port {}",
+                port.process, port.pid, port.port
+            );
+            return;
+        }
+
+        let roots = self.agent_process_roots();
+        let verified = match ports::discover_agent_ports(&roots) {
+            Ok(current) => current
+                .iter()
+                .any(|listener| listener.pid == port.pid && listener.port == port.port),
+            Err(error) => {
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.status = format!("could not verify port before termination: {error}");
+                return;
+            }
+        };
+        if !verified {
+            self.port_inspector.pending_terminate = None;
+            self.port_inspector.last_scan = None;
+            self.status = format!("port {} is no longer owned by PID {}", port.port, port.pid);
+            return;
+        }
+
+        match ports::terminate_process(port.pid) {
+            Ok(()) => {
+                self.port_inspector
+                    .ports
+                    .retain(|listener| listener.pid != port.pid);
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.port_inspector.clamp_cursor();
+                self.status = format!(
+                    "terminated {} (PID {}) from port {}",
+                    port.process, port.pid, port.port
+                );
+            }
+            Err(error) => {
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.status = format!("failed to terminate PID {}: {error}", port.pid);
+            }
+        }
     }
 
     fn handle_background_jobs_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -7140,6 +7448,18 @@ impl App {
 
         if self.mouse_enabled
             && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && self.ports_button_at(mouse.column, mouse.row)
+        {
+            if self.port_inspector.open {
+                self.close_port_inspector();
+            } else {
+                self.open_port_inspector();
+            }
+            return Ok(true);
+        }
+
+        if self.mouse_enabled
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
             && self.background_jobs_button_at(mouse.column, mouse.row)
         {
             if self.background_picker.open {
@@ -7176,6 +7496,14 @@ impl App {
             } else {
                 Ok(false)
             };
+        }
+
+        if self.port_inspector.open {
+            return Ok(if self.mouse_enabled {
+                self.handle_port_inspector_mouse(mouse)
+            } else {
+                false
+            });
         }
 
         if self.previous_panes.open {
@@ -7333,6 +7661,24 @@ impl App {
         self.background_picker.pending_delete = None;
         self.insert_background_job(index)?;
         Ok(true)
+    }
+
+    fn handle_port_inspector_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+        let Some(index) = self.port_row_at(mouse.column, mouse.row) else {
+            return false;
+        };
+        self.port_inspector.cursor = index;
+        self.port_inspector.pending_terminate = None;
+        if let Some(port) = self.port_inspector.ports.get(index) {
+            self.status = format!(
+                "port {} | {} | PID {} | {}",
+                port.port, port.process, port.pid, port.owner
+            );
+        }
+        true
     }
 
     fn handle_pane_settings_mouse(&mut self, mouse: MouseEvent) -> bool {
@@ -8868,6 +9214,48 @@ impl App {
             .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
     }
 
+    fn ports_button_at(&self, x: u16, y: u16) -> bool {
+        self.ports_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn port_row_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.port_rows
+            .iter()
+            .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
+    }
+
+    pub fn port_inspector_view(&self) -> Option<PortInspectorView> {
+        self.port_inspector.open.then(|| PortInspectorView {
+            ports: self
+                .port_inspector
+                .ports
+                .iter()
+                .map(|port| AgentPortView {
+                    port: port.port,
+                    pid: port.pid,
+                    process: port.process.clone(),
+                    owner: port.owner.clone(),
+                })
+                .collect(),
+            cursor: self
+                .port_inspector
+                .cursor
+                .min(self.port_inspector.ports.len().saturating_sub(1)),
+            pending_terminate: self.port_inspector.pending_terminate,
+            refreshing: self.port_inspector.refreshing,
+            error: self.port_inspector.error.clone(),
+        })
+    }
+
+    pub fn agent_port_count(&self) -> usize {
+        self.port_inspector.ports.len()
+    }
+
+    pub fn port_inspector_open(&self) -> bool {
+        self.port_inspector.open
+    }
+
     pub fn background_jobs_view(&self) -> Option<BackgroundJobsView> {
         self.background_picker.open.then(|| BackgroundJobsView {
             cursor: self
@@ -9500,6 +9888,16 @@ fn agent_shell_fallback_spec(
     shell_spec.auth_kind = None;
     shell_spec.auth_dir = None;
     Ok(Some((shell_spec, agent_label, shell_label)))
+}
+
+fn port_owner_label(tab_title: &str, pane_names: &[Option<String>], index: usize) -> String {
+    let pane = pane_names
+        .get(index)
+        .and_then(|name| name.as_deref())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Pane {}", index + 1));
+    format!("{tab_title} / {pane}")
 }
 
 fn adaptive_output_frame_interval(refresh_ms: i32, pane_count: usize) -> Duration {
@@ -13223,5 +13621,31 @@ mod selection_tests {
             .find(|row| row.label == "AI activity summaries")
             .expect("AI activity summary row");
         assert_eq!(summaries.value, "on");
+    }
+
+    #[test]
+    fn port_inspector_navigation_clears_termination_confirmation() {
+        let mut inspector = PortInspectorState {
+            open: true,
+            ports: vec![
+                AgentPort {
+                    port: 3000,
+                    pid: 30,
+                    process: "node".into(),
+                    owner: "Grid 1 / Pane 1".into(),
+                },
+                AgentPort {
+                    port: 8080,
+                    pid: 80,
+                    process: "python".into(),
+                    owner: "Grid 1 / Pane 2".into(),
+                },
+            ],
+            pending_terminate: Some(30),
+            ..PortInspectorState::default()
+        };
+        inspector.move_cursor(1);
+        assert_eq!(inspector.cursor, 1);
+        assert_eq!(inspector.pending_terminate, None);
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -31,6 +31,7 @@ pub enum Action {
     Settings,
     PreviousPanes,
     PaneActivity,
+    Ports,
     CopyMode,
     BackgroundPanes,
     BackgroundJobs,
@@ -55,6 +56,7 @@ const ACTIONS: &[Action] = &[
     Action::CaptureOutput,
     Action::ToggleOutputLogging,
     Action::PaneActivity,
+    Action::Ports,
     Action::PreviousPanes,
     Action::CopyMode,
     Action::BackgroundPanes,
@@ -107,6 +109,7 @@ impl Action {
             Self::Settings => "settings",
             Self::PreviousPanes => "previous-panes",
             Self::PaneActivity => "pane-activity",
+            Self::Ports => "ports",
             Self::CopyMode => "copy-mode",
             Self::BackgroundPanes => "background-panes",
             Self::BackgroundJobs => "background-jobs",
@@ -144,6 +147,7 @@ impl Action {
             Self::Settings => "open settings and profiles",
             Self::PreviousPanes => "show previous panes",
             Self::PaneActivity => "show focused-pane activity",
+            Self::Ports => "show ports used by coding agents",
             Self::CopyMode => "search and copy pane scrollback",
             Self::BackgroundPanes => "background selected or focused panes",
             Self::BackgroundJobs => "show background agents",
@@ -185,6 +189,7 @@ impl Action {
             Self::Settings => "alt+o",
             Self::PreviousPanes => "alt+shift+p",
             Self::PaneActivity => "alt+p",
+            Self::Ports => "ctrl+alt+p",
             Self::CopyMode => "alt+b",
             Self::BackgroundPanes => "alt+shift+b",
             Self::BackgroundJobs => "ctrl+alt+b",
@@ -509,5 +514,17 @@ mod tests {
             .map(|action| action.name())
             .collect::<BTreeSet<_>>();
         assert_eq!(names.len(), ACTIONS.len());
+    }
+
+    #[test]
+    fn agent_ports_has_a_modeless_default_shortcut() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            )),
+            Some(Action::Ports)
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod layout;
 mod manager;
 mod output_capture;
 mod pane_host;
+mod ports;
 mod process_priority;
 mod profiles;
 mod pty;

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -102,6 +102,8 @@ enum HostEvent {
     Ready {
         #[serde(default)]
         protocol_version: u16,
+        #[serde(default)]
+        host_process_id: Option<u32>,
         background_output: String,
         cwd: PathBuf,
         exited: bool,
@@ -177,6 +179,7 @@ pub struct PtyPane {
     generation: u64,
     connection: Arc<Mutex<TcpStream>>,
     host: PtyHostRef,
+    host_process_id: Option<u32>,
     view: PtyView,
     keep_running: bool,
     pub active: bool,
@@ -358,13 +361,20 @@ impl PtyPane {
         }
         let ready = serde_json::from_str::<HostEvent>(&line)
             .context("failed to parse pane host handshake")?;
-        let (protocol_version, background_output, cwd, exited) = match ready {
+        let (protocol_version, host_process_id, background_output, cwd, exited) = match ready {
             HostEvent::Ready {
                 protocol_version,
+                host_process_id,
                 background_output,
                 cwd,
                 exited,
-            } => (protocol_version, background_output, cwd, exited),
+            } => (
+                protocol_version,
+                host_process_id,
+                background_output,
+                cwd,
+                exited,
+            ),
             HostEvent::Error { error } => {
                 return Err(PaneHostRejected { reason: error }.into());
             }
@@ -398,6 +408,7 @@ impl PtyPane {
             generation,
             connection: Arc::new(Mutex::new(stream)),
             host,
+            host_process_id,
             view,
             keep_running,
             active: !background_output.is_empty(),
@@ -415,6 +426,10 @@ impl PtyPane {
 
     pub fn host_ref(&self) -> PtyHostRef {
         self.host.clone()
+    }
+
+    pub fn host_process_id(&self) -> Option<u32> {
+        self.host_process_id
     }
 
     pub fn cwd(&self) -> &Path {
@@ -858,6 +873,7 @@ fn accept_client(
         &mut stream,
         &HostEvent::Ready {
             protocol_version: PANE_HOST_PROTOCOL_VERSION,
+            host_process_id: Some(std::process::id()),
             background_output: BASE64.encode(&*background_output),
             cwd: pane.cwd().to_path_buf(),
             exited: pane.exited,

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1,0 +1,520 @@
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    process::Command,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentProcessRoot {
+    pub pid: u32,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentPort {
+    pub port: u16,
+    pub pid: u32,
+    pub process: String,
+    pub owner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessInfo {
+    parent_pid: u32,
+    name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListeningSocket {
+    port: u16,
+    pid: u32,
+    process: Option<String>,
+}
+
+pub fn discover_agent_ports(roots: &[AgentProcessRoot]) -> io::Result<Vec<AgentPort>> {
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+    let processes = process_snapshot()?;
+    let listeners = listening_sockets()?;
+    Ok(associate_agent_ports(roots, &processes, listeners))
+}
+
+pub fn terminate_process(pid: u32) -> io::Result<()> {
+    if pid == 0 || pid == std::process::id() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "refusing to terminate an invalid or current process",
+        ));
+    }
+    terminate_process_platform(pid)
+}
+
+fn associate_agent_ports(
+    roots: &[AgentProcessRoot],
+    processes: &HashMap<u32, ProcessInfo>,
+    listeners: Vec<ListeningSocket>,
+) -> Vec<AgentPort> {
+    let roots = roots
+        .iter()
+        .filter(|root| {
+            processes
+                .get(&root.pid)
+                .is_some_and(|process| is_gridbash_host(&process.name))
+        })
+        .map(|root| (root.pid, root.label.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut seen = HashSet::new();
+    let mut ports = listeners
+        .into_iter()
+        .filter_map(|listener| {
+            let owner = process_root(listener.pid, processes, &roots)?;
+            seen.insert((listener.port, listener.pid))
+                .then(|| AgentPort {
+                    port: listener.port,
+                    pid: listener.pid,
+                    process: listener
+                        .process
+                        .filter(|name| !name.is_empty())
+                        .or_else(|| {
+                            processes
+                                .get(&listener.pid)
+                                .map(|process| process.name.clone())
+                        })
+                        .unwrap_or_else(|| "unknown".into()),
+                    owner: owner.to_string(),
+                })
+        })
+        .collect::<Vec<_>>();
+    ports.sort_by(|left, right| {
+        left.port
+            .cmp(&right.port)
+            .then_with(|| left.pid.cmp(&right.pid))
+    });
+    ports
+}
+
+fn is_gridbash_host(process_name: &str) -> bool {
+    process_name
+        .rsplit(['/', '\\'])
+        .next()
+        .is_some_and(|name| name.to_ascii_lowercase().starts_with("gridbash"))
+}
+
+fn process_root<'a>(
+    pid: u32,
+    processes: &HashMap<u32, ProcessInfo>,
+    roots: &HashMap<u32, &'a str>,
+) -> Option<&'a str> {
+    let mut current = pid;
+    let mut visited = HashSet::new();
+    for _ in 0..64 {
+        if !visited.insert(current) {
+            return None;
+        }
+        let parent = processes.get(&current)?.parent_pid;
+        if let Some(label) = roots.get(&parent) {
+            return Some(*label);
+        }
+        if parent == 0 || parent == current {
+            return None;
+        }
+        current = parent;
+    }
+    None
+}
+
+fn endpoint_port(endpoint: &str) -> Option<u16> {
+    endpoint
+        .trim()
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.trim_end_matches(']').parse().ok())
+}
+
+#[cfg(windows)]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    let output = Command::new("netstat")
+        .args(["-ano", "-p", "tcp"])
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other("netstat failed while listing TCP ports"));
+    }
+    Ok(parse_windows_netstat(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+#[cfg(windows)]
+fn parse_windows_netstat(output: &str) -> Vec<ListeningSocket> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            if fields.len() < 5
+                || !fields[0].eq_ignore_ascii_case("TCP")
+                || !fields[3].eq_ignore_ascii_case("LISTENING")
+            {
+                return None;
+            }
+            Some(ListeningSocket {
+                port: endpoint_port(fields[1])?,
+                pid: fields[4].parse().ok()?,
+                process: None,
+            })
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    use std::mem;
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+            TH32CS_SNAPPROCESS,
+        },
+    };
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let mut entry = unsafe { mem::zeroed::<PROCESSENTRY32W>() };
+    entry.dwSize = mem::size_of::<PROCESSENTRY32W>() as u32;
+    let mut processes = HashMap::new();
+    let mut success = unsafe { Process32FirstW(snapshot, &mut entry) };
+    while success != 0 {
+        let length = entry
+            .szExeFile
+            .iter()
+            .position(|unit| *unit == 0)
+            .unwrap_or(entry.szExeFile.len());
+        let name = String::from_utf16_lossy(&entry.szExeFile[..length]);
+        processes.insert(
+            entry.th32ProcessID,
+            ProcessInfo {
+                parent_pid: entry.th32ParentProcessID,
+                name,
+            },
+        );
+        success = unsafe { Process32NextW(snapshot, &mut entry) };
+    }
+    unsafe { CloseHandle(snapshot) };
+    Ok(processes)
+}
+
+#[cfg(windows)]
+fn terminate_process_platform(pid: u32) -> io::Result<()> {
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess},
+    };
+    let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if process.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let result = unsafe { TerminateProcess(process, 1) };
+    let error = (result == 0).then(io::Error::last_os_error);
+    unsafe { CloseHandle(process) };
+    error.map_or(Ok(()), Err)
+}
+
+#[cfg(unix)]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    let lsof = if cfg!(target_os = "macos") {
+        "/usr/sbin/lsof"
+    } else {
+        "lsof"
+    };
+    match Command::new(lsof)
+        .args(["-nP", "-iTCP", "-sTCP:LISTEN", "-Fpcn"])
+        .output()
+    {
+        Ok(output) if output.status.success() || !output.stdout.is_empty() => {
+            return Ok(parse_lsof(&String::from_utf8_lossy(&output.stdout)));
+        }
+        _ => {}
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let output = Command::new("ss").args(["-H", "-ltnp"]).output()?;
+        if output.status.success() {
+            return Ok(parse_linux_ss(&String::from_utf8_lossy(&output.stdout)));
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "neither lsof nor a supported socket inspector is available",
+    ))
+}
+
+#[cfg(unix)]
+fn parse_lsof(output: &str) -> Vec<ListeningSocket> {
+    let mut pid = None;
+    let mut process = None::<String>;
+    let mut listeners = Vec::new();
+    for line in output.lines() {
+        let Some(tag) = line.get(..1) else {
+            continue;
+        };
+        let value = &line[1..];
+        match tag {
+            "p" => {
+                pid = value.parse().ok();
+                process = None;
+            }
+            "c" => process = Some(value.to_string()),
+            "n" => {
+                if let (Some(pid), Some(port)) = (pid, endpoint_port(value)) {
+                    listeners.push(ListeningSocket {
+                        port,
+                        pid,
+                        process: process.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    listeners
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_ss(output: &str) -> Vec<ListeningSocket> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            let local = *fields.get(3)?;
+            let details = fields.get(5..)?.join(" ");
+            let pid_start = details.find("pid=")? + 4;
+            let pid_end = details[pid_start..]
+                .find(|ch: char| !ch.is_ascii_digit())
+                .map(|offset| pid_start + offset)
+                .unwrap_or(details.len());
+            let pid = details[pid_start..pid_end].parse().ok()?;
+            let process = details
+                .split_once("((\"")
+                .and_then(|(_, tail)| tail.split_once('"'))
+                .map(|(name, _)| name.to_string());
+            Some(ListeningSocket {
+                port: endpoint_port(local)?,
+                pid,
+                process,
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    let mut processes = HashMap::new();
+    for entry in std::fs::read_dir("/proc")? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some(name_start) = stat.find('(') else {
+            continue;
+        };
+        let Some(name_end) = stat.rfind(')') else {
+            continue;
+        };
+        let Some(parent_pid) = stat[name_end + 1..]
+            .split_whitespace()
+            .nth(1)
+            .and_then(|value| value.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        processes.insert(
+            pid,
+            ProcessInfo {
+                parent_pid,
+                name: stat[name_start + 1..name_end].to_string(),
+            },
+        );
+    }
+    Ok(processes)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,comm="])
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other("ps failed while listing processes"));
+    }
+    Ok(parse_ps(&String::from_utf8_lossy(&output.stdout)))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn parse_ps(output: &str) -> HashMap<u32, ProcessInfo> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse().ok()?;
+            let parent_pid = fields.next()?.parse().ok()?;
+            let name = fields.next()?.rsplit('/').next()?.to_string();
+            Some((pid, ProcessInfo { parent_pid, name }))
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn terminate_process_platform(pid: u32) -> io::Result<()> {
+    let pid = i32::try_from(pid)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "process ID is too large"))?;
+    let result = unsafe { libc::kill(pid, libc::SIGTERM) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "port discovery is not supported on this platform",
+    ))
+}
+
+#[cfg(not(any(windows, unix)))]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    Ok(HashMap::new())
+}
+
+#[cfg(not(any(windows, unix)))]
+fn terminate_process_platform(_pid: u32) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "process termination is not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn associates_only_descendants_of_agent_roots() {
+        let roots = vec![AgentProcessRoot {
+            pid: 10,
+            label: "Grid 1 / Pane 2".into(),
+        }];
+        let processes = HashMap::from([
+            (
+                10,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "gridbash".into(),
+                },
+            ),
+            (
+                20,
+                ProcessInfo {
+                    parent_pid: 10,
+                    name: "codex".into(),
+                },
+            ),
+            (
+                30,
+                ProcessInfo {
+                    parent_pid: 20,
+                    name: "node".into(),
+                },
+            ),
+            (
+                40,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "postgres".into(),
+                },
+            ),
+        ]);
+        let listeners = vec![
+            ListeningSocket {
+                port: 41_000,
+                pid: 10,
+                process: None,
+            },
+            ListeningSocket {
+                port: 3000,
+                pid: 30,
+                process: None,
+            },
+            ListeningSocket {
+                port: 5432,
+                pid: 40,
+                process: None,
+            },
+        ];
+        assert_eq!(
+            associate_agent_ports(&roots, &processes, listeners),
+            vec![AgentPort {
+                port: 3000,
+                pid: 30,
+                process: "node".into(),
+                owner: "Grid 1 / Pane 2".into(),
+            }]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parses_windows_tcp_listeners() {
+        let output = r#"
+  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       1234
+  TCP    [::1]:8080             [::]:0                 LISTENING       4321
+  TCP    127.0.0.1:5000         127.0.0.1:6000         ESTABLISHED     9999
+"#;
+        assert_eq!(
+            parse_windows_netstat(output),
+            vec![
+                ListeningSocket {
+                    port: 3000,
+                    pid: 1234,
+                    process: None,
+                },
+                ListeningSocket {
+                    port: 8080,
+                    pid: 4321,
+                    process: None,
+                },
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_lsof_machine_output() {
+        let output = "p1234\ncnode\nf19\nPIPv4\nn*:3000\nn127.0.0.1:3001\n";
+        assert_eq!(
+            parse_lsof(output),
+            vec![
+                ListeningSocket {
+                    port: 3000,
+                    pid: 1234,
+                    process: Some("node".into()),
+                },
+                ListeningSocket {
+                    port: 3001,
+                    pid: 1234,
+                    process: Some("node".into()),
+                },
+            ]
+        );
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Widget},
@@ -12,9 +12,9 @@ use crate::{
     app::{
         App, AssistantMessageRole, BackgroundJobState, BackgroundJobView, BackgroundJobsView,
         CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView, GridPalette,
-        PaneSelection, PaneSettingsTarget, PaneSettingsView, PreviousPaneView, PreviousPanesView,
-        RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind,
-        TabLabel, WorkspaceAssistantView,
+        PaneSelection, PaneSettingsTarget, PaneSettingsView, PortInspectorView, PreviousPaneView,
+        PreviousPanesView, RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab,
+        SettingsValueKind, TabLabel, WorkspaceAssistantView,
     },
     auth::{AgentKind, AuthProfile},
     composer::GridPickerMode,
@@ -45,6 +45,8 @@ pub struct DrawState {
     pub pane_settings_stop_goal_button: Option<Rect>,
     pub background_jobs_button: Option<Rect>,
     pub background_job_rows: Vec<(usize, Rect)>,
+    pub ports_button: Option<Rect>,
+    pub port_rows: Vec<(usize, Rect)>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -91,6 +93,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let tab_rename_view = app.rename_tab_view();
     let previous_panes_view = app.previous_panes_view();
     let background_jobs_view = app.background_jobs_view();
+    let port_inspector_view = app.port_inspector_view();
     let follow_up_dialog = app.follow_up_dialog();
     let goal_editor_view = app.goal_editor_view();
     let pane_settings_view = app.pane_settings_view();
@@ -107,6 +110,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || app.settings_open()
         || previous_panes_view.is_some()
         || background_jobs_view.is_some()
+        || port_inspector_view.is_some()
         || pane_settings_open
         || rename_view.is_some()
         || tab_rename_view.is_some()
@@ -126,6 +130,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || app.settings_open()
         || previous_panes_view.is_some()
         || background_jobs_view.is_some()
+        || port_inspector_view.is_some()
         || pane_settings_open
         || rename_view.is_some()
         || tab_rename_view.is_some()
@@ -214,6 +219,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let pane_settings_button = pane_settings_button_rect(status_area);
     let background_jobs_button =
         background_jobs_button_rect(status_area, app.background_job_count());
+    let ports_button = ports_button_rect(status_area, app.agent_port_count());
     let status = Line::from(vec![
         Span::styled(
             STATUS_BRAND,
@@ -275,6 +281,18 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Paragraph::new(status).style(Style::default().bg(APP_BG)),
         status_area,
     );
+    if let Some(button) = ports_button {
+        frame.render_widget(
+            Paragraph::new(ports_button_label(app.agent_port_count()))
+                .alignment(Alignment::Center)
+                .style(ports_button_style(
+                    app.port_inspector_open(),
+                    app.agent_port_count(),
+                    palette,
+                )),
+            button,
+        );
+    }
 
     if app.settings_open() {
         render_settings(frame, area, app, palette);
@@ -296,6 +314,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     };
     let background_job_rows = if let Some(view) = background_jobs_view.as_ref() {
         render_background_jobs(frame, area, view, palette)
+    } else {
+        Vec::new()
+    };
+    let port_rows = if let Some(view) = port_inspector_view.as_ref() {
+        render_port_inspector(frame, area, view, palette)
     } else {
         Vec::new()
     };
@@ -341,6 +364,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         pane_settings_stop_goal_button,
         background_jobs_button,
         background_job_rows,
+        ports_button,
+        port_rows,
     }
 }
 
@@ -750,6 +775,42 @@ fn background_jobs_button_style(open: bool, palette: &GridPalette) -> Style {
     } else {
         Style::default()
             .fg(palette.accent())
+            .add_modifier(Modifier::BOLD)
+    }
+}
+
+fn ports_button_label(count: usize) -> String {
+    format!(" Ports {count} ")
+}
+
+fn ports_button_rect(status_area: Rect, count: usize) -> Option<Rect> {
+    let width = ports_button_label(count).len() as u16;
+    if status_area.height == 0 || status_area.width < width {
+        return None;
+    }
+    Some(Rect {
+        x: status_area.right().saturating_sub(width),
+        y: status_area.y,
+        width,
+        height: 1,
+    })
+}
+
+fn ports_button_style(open: bool, count: usize, palette: &GridPalette) -> Style {
+    if open {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else if count > 0 {
+        Style::default()
+            .fg(Color::Black)
+            .bg(palette.accent())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(Color::DarkGray)
+            .bg(APP_BG)
             .add_modifier(Modifier::BOLD)
     }
 }
@@ -1784,6 +1845,209 @@ fn previous_panes_command_bar(width: u16) -> Line<'static> {
         Span::styled(" move  ", Style::default().fg(Color::Gray)),
         command_key("Enter"),
         Span::styled(" focus  ", Style::default().fg(Color::Gray)),
+        command_key("Esc"),
+        Span::styled(" close", Style::default().fg(Color::Gray)),
+    ])
+}
+
+fn render_port_inspector(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    view: &PortInspectorView,
+    palette: &GridPalette,
+) -> Vec<(usize, Rect)> {
+    let modal = previous_panes_modal_rect(area, view.ports.len().max(1));
+    let shadow = settings_shadow_rect(area, modal);
+    let mut row_hits = Vec::new();
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.accent())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Agent Ports ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+    if inner.width == 0 || inner.height == 0 {
+        return row_hits;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+    let count = match view.ports.len() {
+        1 => "1 TCP listener".to_string(),
+        count => format!("{count} TCP listeners"),
+    };
+    let scan_state = if view.refreshing {
+        "  refreshing..."
+    } else {
+        "  launched by GridBash agents"
+    };
+    let header = vec![
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                count,
+                Style::default()
+                    .fg(palette.accent())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(scan_state, Style::default().fg(Color::Gray)),
+        ]),
+        Line::from(Span::styled(
+            view.error
+                .as_deref()
+                .map(|error| format!("  Scan error: {error}"))
+                .unwrap_or_else(|| "  PORT   PROCESS              PID  PANE / TAB".into()),
+            Style::default().fg(if view.error.is_some() {
+                Color::LightRed
+            } else {
+                SETTINGS_MUTED
+            }),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(header).style(settings_panel_style()),
+        chunks[0],
+    );
+
+    let list_area = chunks[1];
+    if view.ports.is_empty() {
+        let message = if view.refreshing {
+            "  Looking for localhost listeners in agent process trees..."
+        } else {
+            "  No agent-owned localhost listeners are active."
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(message, Style::default().fg(SETTINGS_MUTED)))
+                .style(settings_panel_style()),
+            list_area,
+        );
+    } else {
+        let visible =
+            visible_previous_pane_range(view.ports.len(), view.cursor, list_area.height as usize);
+        let mut rows = Vec::new();
+        for (row_offset, index) in visible.enumerate() {
+            let Some(port) = view.ports.get(index) else {
+                continue;
+            };
+            let row_area = Rect {
+                x: list_area.x,
+                y: list_area.y.saturating_add(row_offset as u16),
+                width: list_area.width,
+                height: 1,
+            };
+            row_hits.push((index, row_area));
+            rows.push(agent_port_line(
+                port.port,
+                port.pid,
+                &port.process,
+                &port.owner,
+                view.cursor == index,
+                view.pending_terminate == Some(port.pid),
+                list_area.width,
+            ));
+        }
+        frame.render_widget(
+            Paragraph::new(rows).style(settings_panel_style()),
+            list_area,
+        );
+    }
+
+    frame.render_widget(
+        Paragraph::new(port_inspector_command_bar(
+            chunks[2].width,
+            view.pending_terminate.is_some(),
+        ))
+        .style(settings_panel_style()),
+        chunks[2],
+    );
+    row_hits
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agent_port_line(
+    port: u16,
+    pid: u32,
+    process: &str,
+    owner: &str,
+    active: bool,
+    pending_terminate: bool,
+    width: u16,
+) -> Line<'static> {
+    let process_width = if width < 62 { 12 } else { 18 };
+    let owner = if active && pending_terminate {
+        "Press Enter to terminate"
+    } else {
+        owner
+    };
+    let text = format!(
+        "{} {:>5}   {:<process_width$} {:>7}  {}",
+        if active { ">" } else { " " },
+        port,
+        truncate_text(process, process_width),
+        pid,
+        owner,
+    );
+    let fg = if active && pending_terminate {
+        Color::LightRed
+    } else if active {
+        SETTINGS_TEXT
+    } else {
+        Color::LightCyan
+    };
+    Line::from(Span::styled(
+        fixed_width(&text, width as usize),
+        row_style(fg, active.then_some(SETTINGS_ROW_ACTIVE), active),
+    ))
+}
+
+fn port_inspector_command_bar(width: u16, pending_terminate: bool) -> Line<'static> {
+    if pending_terminate {
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" terminate process  ", Style::default().fg(Color::LightRed)),
+            command_key("Esc"),
+            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+        ]);
+    }
+    if width < 60 {
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" stop  ", Style::default().fg(Color::Gray)),
+            command_key("R"),
+            Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
+            command_key("Esc"),
+            Span::styled(" close", Style::default().fg(Color::Gray)),
+        ]);
+    }
+    Line::from(vec![
+        Span::raw("  "),
+        command_key("Up/Down"),
+        Span::styled(" move  ", Style::default().fg(Color::Gray)),
+        command_key("Enter/Delete"),
+        Span::styled(" terminate  ", Style::default().fg(Color::Gray)),
+        command_key("R"),
+        Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
         command_key("Esc"),
         Span::styled(" close", Style::default().fg(Color::Gray)),
     ])
@@ -4511,5 +4775,13 @@ mod tests {
         assert_eq!(target[(3, 2)].symbol(), "C");
         assert_eq!(target[(4, 2)].symbol(), "D");
         assert_eq!(target[(2, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn ports_button_stays_anchored_to_footer_right_edge() {
+        let footer = Rect::new(4, 20, 80, 1);
+        let button = ports_button_rect(footer, 3).expect("ports button");
+        assert_eq!(button.right(), footer.right());
+        assert_eq!(button.width, ports_button_label(3).len() as u16);
     }
 }


### PR DESCRIPTION
## Summary
- add a live bottom-right port count and agent port inspector
- map TCP listeners to GridBash pane-host process ancestry on Windows, macOS, and Linux
- re-verify ownership before confirmed process termination
- add a configurable Ctrl+Alt+P action, tests, docs, and devlog

## Validation
- cargo fmt --all -- --check
- cargo metadata --no-deps --format-version 1
- git diff --check
- focused and broad Cargo validation will run under the shared integration lease

Closes #278