### PR TITLE
fix: resize panes before rendering switched tabs

### DIFF
--- a/docs/devlogs/2026-07-20-fix-torn-pane-rendering-when-switching-tabs.md
+++ b/docs/devlogs/2026-07-20-fix-torn-pane-rendering-when-switching-tabs.md
@@ -1,0 +1,34 @@
+# Fix torn pane rendering when switching tabs
+
+Date: 2026-07-20
+Release target: unreleased
+
+## Summary
+
+- Fixed torn or partially blank terminal content after switching tabs with
+  different grid geometries.
+
+## What Changed
+
+- Recomputed pane rectangles from the currently visible grid immediately after
+  restoring a tab.
+- Resized restored PTYs before the switched tab's first rendered frame.
+- Reused the same layout synchronization helper during initial pane sizing.
+
+## Why It Matters
+
+- Dense grids use smaller PTY dimensions than tabs with a few large panes.
+  Rendering a restored pane before resizing it could mix the old screen bounds
+  with the new rectangle, leaving content scrambled until another full redraw.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo check`
+
+## Release Notes
+
+- Switching grids with `Alt+t` now keeps terminal content intact when the tabs
+  use different layouts.
+
+Closes #282.

--- a/src/app.rs
+++ b/src/app.rs
@@ -5932,6 +5932,7 @@ impl App {
         if !recovered_agent {
             self.status = format!("active tab {}", self.tab_title);
         }
+        self.sync_pane_sizes_for_current_layout();
     }
 
     fn begin_tab_rename(&mut self) {
@@ -9549,11 +9550,15 @@ impl App {
         }
     }
 
+    fn sync_pane_sizes_for_current_layout(&mut self) {
+        self.rects = self.pane_rects(self.grid_area);
+        self.sync_pane_sizes();
+    }
+
     fn sync_initial_pane_sizes(&mut self, terminal: &Tui) -> Result<()> {
         let size = terminal.size().context("failed to read terminal size")?;
         self.grid_area = Rect::new(0, 1, size.width, size.height.saturating_sub(3));
-        self.rects = self.pane_rects(self.grid_area);
-        self.sync_pane_sizes();
+        self.sync_pane_sizes_for_current_layout();
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- recompute pane rectangles after restoring a tab
- resize restored PTYs before the first switched-tab frame
- reuse the layout synchronization helper for initial sizing

## Validation
- cargo fmt --all -- --check
- cargo check (pending shared integration lease)

Closes #282