### PR TITLE
feat: resume Codex conversations across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +778,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -929,6 +947,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -942,13 +961,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -959,7 +987,16 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1398,6 +1435,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2347,6 +2395,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,6 +3196,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ image = { version = "0.25", default-features = false, features = ["gif", "jpeg",
 portable-pty = "0.9"
 ratatui = "0.30"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ To keep live terminals running after GridBash closes, open Settings with
 launching shell when you quit; reconnect later with `gridbash resume --latest`
 or select the session with `gridbash resume`.
 
+Running Codex panes are also saved by conversation ID. If their live terminal
+cannot survive a restart or laptop shutdown, `gridbash resume` relaunches them
+with `codex resume <conversation-id>` instead of opening an empty terminal.
+This also covers Codex started manually inside a GridBash Git Bash pane.
+
 If the terminal or GridBash process closes unexpectedly, the next plain
 `gridbash` launch automatically recovers unfinished agent sessions. Saved panes
 are grouped into tabs by working directory, each tab is named after that

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -92,6 +92,12 @@ worktree names, auth assignments, and a pane-local view of recent submitted
 commands and output. By default, resume starts new child terminals and does not
 replay old commands into a shell.
 
+For a pane that is actively running Codex, the snapshot also stores the Codex
+conversation ID. If the original pane host is gone after a restart or laptop
+shutdown, GridBash relaunches that pane with `codex resume <conversation-id>`.
+This applies both to Codex profiles and to Codex launched inside a GridBash Git
+Bash pane. Unrelated shell commands are never replayed.
+
 Enable **Keep terminals running** in Settings to detach live pane hosts when the
 GridBash UI closes. `gridbash resume` then reconnects to the same PTYs; output
 produced while detached is added to the restored view. If a host is no longer

--- a/docs/devlogs/2026-07-20-resume-codex-conversations-across-restarts.md
+++ b/docs/devlogs/2026-07-20-resume-codex-conversations-across-restarts.md
@@ -1,0 +1,34 @@
+# Resume Codex conversations across restarts
+
+Date: 2026-07-20
+Release target: unreleased
+
+## Summary
+
+- GridBash now remembers the active Codex conversation behind each saved pane
+  and resumes it when the original terminal host no longer exists.
+
+## What Changed
+
+- Persist the active Codex thread ID alongside pane history and host metadata.
+- Detect Codex descendants launched through Git Bash as well as direct Codex
+  profiles.
+- Rebuild unavailable panes as `codex resume <conversation-id>` without
+  replaying unrelated shell history.
+- Keep older session snapshots compatible through optional serialized fields.
+
+## Why It Matters
+
+- Layout snapshots already survived `Alt+q`, but the Codex process itself could
+  not survive a laptop shutdown. Reconnecting to the conversation restores the
+  useful agent context instead of leaving seven empty terminals.
+
+## Validation
+
+- Focused Rust tests cover thread lookup, process-tree ownership, direct Codex
+  resume commands, Git Bash conversion, and existing resume wrappers.
+- Full validation is recorded on the pull request for this change.
+
+## Release Notes
+
+- Fixes #295.

--- a/src/codex_sqlite.rs
+++ b/src/codex_sqlite.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use directories::ProjectDirs;
 use fs4::{FileExt, TryLockError};
+use rusqlite::{Connection, OpenFlags};
 
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
@@ -18,6 +19,8 @@ const CODEX_SQLITE_HOME_ENV: &str = "CODEX_SQLITE_HOME";
 const GRIDBASH_MANAGED_CODEX_SQLITE_ENV: &str = "GRIDBASH_MANAGED_CODEX_SQLITE_HOME";
 const DEFAULT_CODEX_HOME_SCOPE: &str = "<default>";
 const MAX_CODEX_SQLITE_LANES: usize = 4096;
+const CODEX_STATE_DB_PREFIX: &str = "state_";
+const CODEX_STATE_DB_SUFFIX: &str = ".sqlite";
 
 pub(crate) struct CodexSqlitePool {
     root: PathBuf,
@@ -37,6 +40,7 @@ impl Drop for CodexSqliteLease {
 
 pub(crate) struct PaneCodexSqlite {
     pub(crate) env: Vec<(OsString, OsString)>,
+    pub(crate) home: Option<PathBuf>,
     pub(crate) lease: Option<CodexSqliteLease>,
 }
 
@@ -73,6 +77,7 @@ impl CodexSqlitePool {
         if has_explicit_sqlite_home(pane_env, inherited_sqlite_home, inherited_managed_home) {
             return Ok(PaneCodexSqlite {
                 env: Vec::new(),
+                home: explicit_sqlite_home(pane_env, inherited_sqlite_home),
                 lease: None,
             });
         }
@@ -86,6 +91,7 @@ impl CodexSqlitePool {
                 (CODEX_SQLITE_HOME_ENV.into(), home.clone()),
                 (GRIDBASH_MANAGED_CODEX_SQLITE_ENV.into(), home),
             ],
+            home: Some(lease.home.clone()),
             lease: Some(lease),
         })
     }
@@ -138,6 +144,98 @@ impl CodexSqlitePool {
     }
 }
 
+pub(crate) fn latest_thread_id(
+    home: &Path,
+    cwd: &Path,
+    not_before_ms: u64,
+) -> Result<Option<String>> {
+    let Some(path) = latest_state_db(home)? else {
+        return Ok(None);
+    };
+    let connection = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("failed to open Codex state DB {}", path.display()))?;
+    connection.busy_timeout(std::time::Duration::from_millis(250))?;
+
+    let columns = connection
+        .prepare("PRAGMA table_info(threads)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if !columns.iter().any(|column| column == "id") || !columns.iter().any(|column| column == "cwd")
+    {
+        return Ok(None);
+    }
+
+    let timestamp_column = [
+        "recency_at_ms",
+        "updated_at_ms",
+        "created_at_ms",
+        "updated_at",
+        "created_at",
+    ]
+    .into_iter()
+    .find(|candidate| columns.iter().any(|column| column == candidate));
+    let Some(timestamp_column) = timestamp_column else {
+        return Ok(None);
+    };
+    let seconds_column = !timestamp_column.ends_with("_ms");
+    let query = format!(
+        "SELECT id, cwd, {timestamp_column} FROM threads \
+         WHERE {timestamp_column} IS NOT NULL ORDER BY {timestamp_column} DESC LIMIT 128"
+    );
+    let mut statement = connection.prepare(&query)?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    let expected_cwd = normalized_path(cwd);
+    for row in rows {
+        let (id, row_cwd, timestamp) = row?;
+        let timestamp_ms = if seconds_column {
+            timestamp.saturating_mul(1_000)
+        } else {
+            timestamp
+        };
+        if timestamp_ms >= i64::try_from(not_before_ms).unwrap_or(i64::MAX)
+            && normalized_path(Path::new(&row_cwd)) == expected_cwd
+        {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
+fn latest_state_db(home: &Path) -> Result<Option<PathBuf>> {
+    let mut candidates = fs::read_dir(home)
+        .with_context(|| format!("failed to inspect Codex SQLite home {}", home.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|path| {
+            let name = path.file_name()?.to_str()?;
+            let version = name
+                .strip_prefix(CODEX_STATE_DB_PREFIX)?
+                .strip_suffix(CODEX_STATE_DB_SUFFIX)?
+                .parse::<u64>()
+                .ok()?;
+            Some((version, path))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(version, _)| *version);
+    Ok(candidates.pop().map(|(_, path)| path))
+}
+
+fn normalized_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase()
+}
+
 fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
     let mut builder = fs::DirBuilder::new();
     builder.recursive(true);
@@ -162,6 +260,21 @@ fn has_explicit_sqlite_home(
 
     let inherited_is_managed = inherited_home.is_some() && inherited_home == inherited_managed_home;
     inherited_home.is_some_and(non_empty_os_str) && !inherited_is_managed
+}
+
+fn explicit_sqlite_home(
+    pane_env: &BTreeMap<String, String>,
+    inherited_home: Option<&OsStr>,
+) -> Option<PathBuf> {
+    pane_env
+        .get(CODEX_SQLITE_HOME_ENV)
+        .and_then(|value| non_empty(value))
+        .map(PathBuf::from)
+        .or_else(|| {
+            inherited_home
+                .filter(|value| non_empty_os_str(value))
+                .map(PathBuf::from)
+        })
 }
 
 fn codex_home_scope(
@@ -204,6 +317,27 @@ fn stable_scope_id(value: &OsStr) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_threads(path: &Path, rows: &[(&str, &str, i64)]) {
+        let connection = Connection::open(path).expect("open test state DB");
+        connection
+            .execute_batch(
+                "CREATE TABLE threads (\
+                    id TEXT PRIMARY KEY,\
+                    cwd TEXT NOT NULL,\
+                    recency_at_ms INTEGER NOT NULL\
+                );",
+            )
+            .expect("create threads table");
+        for (id, cwd, recency_at_ms) in rows {
+            connection
+                .execute(
+                    "INSERT INTO threads (id, cwd, recency_at_ms) VALUES (?1, ?2, ?3)",
+                    (id, cwd, recency_at_ms),
+                )
+                .expect("insert thread");
+        }
+    }
 
     struct TestRoot(PathBuf);
 
@@ -303,6 +437,45 @@ mod tests {
 
         assert!(old_pane.lease.is_some());
         assert_ne!(sqlite_home(&replacement), old_home);
+    }
+
+    #[test]
+    fn finds_the_latest_matching_thread_created_after_the_pane_started() {
+        let root = TestRoot::new();
+        let lane = root.0.join("lane-1");
+        fs::create_dir_all(&lane).expect("create lane");
+        write_threads(
+            &lane.join("state_5.sqlite"),
+            &[
+                (
+                    "019f7b81-de49-7782-8186-a3dc2c644c61",
+                    r"C:\work\fluent",
+                    1_000,
+                ),
+                (
+                    "019f7b81-e026-7d12-a013-25f4763f4bce",
+                    r"\\?\C:\work\fluent",
+                    3_000,
+                ),
+                (
+                    "019f7b81-e2cd-71c1-84dd-9f09622cf74e",
+                    r"C:\work\other",
+                    4_000,
+                ),
+            ],
+        );
+
+        assert_eq!(
+            latest_thread_id(&lane, Path::new(r"C:/work/fluent"), 2_000)
+                .expect("find thread")
+                .as_deref(),
+            Some("019f7b81-e026-7d12-a013-25f4763f4bce")
+        );
+        assert_eq!(
+            latest_thread_id(&lane, Path::new(r"C:/work/fluent"), 3_001)
+                .expect("filter old thread"),
+            None
+        );
     }
 
     #[test]

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -8,7 +8,7 @@ use std::{
     process::{Command, Stdio},
     sync::{Arc, Mutex, mpsc as std_mpsc},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use std::{error::Error as StdError, fmt};
 
@@ -42,6 +42,10 @@ const PANE_HOST_PROTOCOL_VERSION: u16 = 1;
 pub struct PtyHostRef {
     pub endpoint: String,
     pub token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_sqlite_home: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -110,6 +114,10 @@ enum HostEvent {
         background_output: String,
         cwd: PathBuf,
         exited: bool,
+        #[serde(default)]
+        codex_sqlite_home: Option<PathBuf>,
+        #[serde(default)]
+        started_at_ms: Option<u64>,
     },
     Output {
         data: String,
@@ -283,6 +291,8 @@ impl PtyPane {
         let host = PtyHostRef {
             endpoint: ready.endpoint,
             token,
+            codex_sqlite_home: None,
+            started_at_ms: None,
         };
         Self::connect(
             host,
@@ -324,7 +334,7 @@ impl PtyPane {
 
     #[allow(clippy::too_many_arguments)]
     fn connect(
-        host: PtyHostRef,
+        mut host: PtyHostRef,
         id: PaneId,
         generation: u64,
         fallback_cwd: &Path,
@@ -369,19 +379,31 @@ impl PtyPane {
         }
         let ready = serde_json::from_str::<HostEvent>(&line)
             .context("failed to parse pane host handshake")?;
-        let (protocol_version, host_process_id, background_output, cwd, exited) = match ready {
+        let (
+            protocol_version,
+            host_process_id,
+            background_output,
+            cwd,
+            exited,
+            codex_sqlite_home,
+            started_at_ms,
+        ) = match ready {
             HostEvent::Ready {
                 protocol_version,
                 host_process_id,
                 background_output,
                 cwd,
                 exited,
+                codex_sqlite_home,
+                started_at_ms,
             } => (
                 protocol_version,
                 host_process_id,
                 background_output,
                 cwd,
                 exited,
+                codex_sqlite_home,
+                started_at_ms,
             ),
             HostEvent::Error { error } => {
                 return Err(PaneHostRejected { reason: error }.into());
@@ -410,6 +432,12 @@ impl PtyPane {
             view.process_output(&background_output);
         }
 
+        if codex_sqlite_home.is_some() {
+            host.codex_sqlite_home = codex_sqlite_home;
+        }
+        if started_at_ms.is_some() {
+            host.started_at_ms = started_at_ms;
+        }
         spawn_client_reader(reader, id, generation, event_tx);
         Ok(Self {
             id,
@@ -438,6 +466,14 @@ impl PtyPane {
 
     pub fn host_process_id(&self) -> Option<u32> {
         self.host_process_id
+    }
+
+    pub fn codex_thread_id(&self, cwd: &Path) -> Option<String> {
+        let home = self.host.codex_sqlite_home.as_deref()?;
+        let started_at_ms = self.host.started_at_ms?;
+        crate::codex_sqlite::latest_thread_id(home, cwd, started_at_ms)
+            .ok()
+            .flatten()
     }
 
     pub fn cwd(&self) -> &Path {
@@ -608,8 +644,10 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
 
     let PaneCodexSqlite {
         env: codex_env,
+        home: codex_sqlite_home,
         lease,
     } = CodexSqlitePool::new()?.for_pane(&spec.env)?;
+    let started_at_ms = now_millis();
     let mut extra_env = spec
         .extra_env
         .iter()
@@ -659,6 +697,8 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                         next_client_id,
                         &spec.token,
                         &pane,
+                        codex_sqlite_home.as_deref(),
+                        started_at_ms,
                         &mut background_output,
                         command_tx.clone(),
                     )? {
@@ -844,6 +884,8 @@ fn accept_client(
     client_id: u64,
     expected_token: &str,
     pane: &LocalPtyPane,
+    codex_sqlite_home: Option<&Path>,
+    started_at_ms: u64,
     background_output: &mut Vec<u8>,
     command_tx: std_mpsc::Sender<HostInput>,
 ) -> Result<Option<AcceptedClient>> {
@@ -904,6 +946,8 @@ fn accept_client(
             background_output: BASE64.encode(&*background_output),
             cwd: pane.cwd().to_path_buf(),
             exited: pane.exited,
+            codex_sqlite_home: codex_sqlite_home.map(Path::to_path_buf),
+            started_at_ms: Some(started_at_ms),
         },
     )?;
     background_output.clear();
@@ -917,6 +961,15 @@ fn accept_client(
         },
         keep_running,
     }))
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 fn spawn_host_reader(
@@ -1287,6 +1340,8 @@ mod tests {
         let host = PtyHostRef {
             endpoint: ready.endpoint,
             token: host_token,
+            codex_sqlite_home: None,
+            started_at_ms: None,
         };
         let (first_tx, mut first_rx) = mpsc::channel(32);
         let first = PtyPane::attach(
@@ -1420,6 +1475,8 @@ mod tests {
         let host = PtyHostRef {
             endpoint: ready.endpoint,
             token: host_token,
+            codex_sqlite_home: None,
+            started_at_ms: None,
         };
         let (replacement_tx, mut replacement_rx) = mpsc::channel(8);
         let mut replacement = PtyPane::attach(

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -697,8 +697,10 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                         next_client_id,
                         &spec.token,
                         &pane,
-                        codex_sqlite_home.as_deref(),
-                        started_at_ms,
+                        HostCodexMetadata {
+                            sqlite_home: codex_sqlite_home.as_deref(),
+                            started_at_ms,
+                        },
                         &mut background_output,
                         command_tx.clone(),
                     )? {
@@ -869,6 +871,11 @@ struct AcceptedClient {
     keep_running: bool,
 }
 
+struct HostCodexMetadata<'a> {
+    sqlite_home: Option<&'a Path>,
+    started_at_ms: u64,
+}
+
 struct HostInput {
     client_id: u64,
     message: HostInputMessage,
@@ -884,8 +891,7 @@ fn accept_client(
     client_id: u64,
     expected_token: &str,
     pane: &LocalPtyPane,
-    codex_sqlite_home: Option<&Path>,
-    started_at_ms: u64,
+    codex: HostCodexMetadata<'_>,
     background_output: &mut Vec<u8>,
     command_tx: std_mpsc::Sender<HostInput>,
 ) -> Result<Option<AcceptedClient>> {
@@ -946,8 +952,8 @@ fn accept_client(
             background_output: BASE64.encode(&*background_output),
             cwd: pane.cwd().to_path_buf(),
             exited: pane.exited,
-            codex_sqlite_home: codex_sqlite_home.map(Path::to_path_buf),
-            started_at_ms: Some(started_at_ms),
+            codex_sqlite_home: codex.sqlite_home.map(Path::to_path_buf),
+            started_at_ms: Some(codex.started_at_ms),
         },
     )?;
     background_output.clear();

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -50,6 +50,51 @@ pub fn terminate_process(pid: u32) -> io::Result<()> {
     terminate_process_platform(pid)
 }
 
+pub fn roots_with_descendant_named(roots: &[u32], expected_name: &str) -> io::Result<HashSet<u32>> {
+    if roots.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let processes = process_snapshot()?;
+    let roots = roots.iter().copied().collect::<HashSet<_>>();
+    let expected_name = expected_name.trim_end_matches(".exe").to_ascii_lowercase();
+    Ok(processes
+        .iter()
+        .filter(|(_, process)| {
+            let name = process
+                .name
+                .rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(&process.name)
+                .to_ascii_lowercase();
+            name.trim_end_matches(".exe") == expected_name
+        })
+        .filter_map(|(pid, _)| descendant_root(*pid, &processes, &roots))
+        .collect())
+}
+
+fn descendant_root(
+    pid: u32,
+    processes: &HashMap<u32, ProcessInfo>,
+    roots: &HashSet<u32>,
+) -> Option<u32> {
+    let mut current = pid;
+    let mut visited = HashSet::new();
+    for _ in 0..64 {
+        if !visited.insert(current) {
+            return None;
+        }
+        let parent = processes.get(&current)?.parent_pid;
+        if roots.contains(&parent) {
+            return Some(parent);
+        }
+        if parent == 0 || parent == current {
+            return None;
+        }
+        current = parent;
+    }
+    None
+}
+
 fn associate_agent_ports(
     roots: &[AgentProcessRoot],
     processes: &HashMap<u32, ProcessInfo>,
@@ -470,6 +515,37 @@ mod tests {
                 owner: "Grid 1 / Pane 2".into(),
             }]
         );
+    }
+
+    #[test]
+    fn finds_the_owning_root_for_nested_processes() {
+        let processes = HashMap::from([
+            (
+                10,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "gridbash".into(),
+                },
+            ),
+            (
+                20,
+                ProcessInfo {
+                    parent_pid: 10,
+                    name: "bash".into(),
+                },
+            ),
+            (
+                30,
+                ProcessInfo {
+                    parent_pid: 20,
+                    name: "codex".into(),
+                },
+            ),
+        ]);
+        let roots = HashSet::from([10]);
+
+        assert_eq!(descendant_root(30, &processes, &roots), Some(10));
+        assert_eq!(descendant_root(10, &processes, &roots), None);
     }
 
     #[cfg(windows)]

--- a/src/resume_picker.rs
+++ b/src/resume_picker.rs
@@ -635,9 +635,12 @@ mod tests {
             auth_name: None,
             auth_kind: None,
             history: SavedPaneHistory::default(),
+            codex_thread_id: None,
             host: host.then(|| crate::pane_host::PtyHostRef {
                 endpoint: "127.0.0.1:12345".into(),
                 token: "token".into(),
+                codex_sqlite_home: None,
+                started_at_ms: None,
             }),
         };
         SessionRecord {

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,6 +19,7 @@ use crate::{
     cli::ResumeArgs,
     layout::GridSize,
     pane_host::{PtyHostRef, PtyPane},
+    ports::roots_with_descendant_named,
     profiles::Profile,
     setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
 };
@@ -77,6 +78,8 @@ pub struct SavedPane {
     pub auth_kind: Option<AgentKind>,
     #[serde(default)]
     pub history: SavedPaneHistory,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_thread_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<PtyHostRef>,
 }
@@ -151,7 +154,7 @@ impl SavedSession {
                 .iter()
                 .enumerate()
                 .map(|(index, spec)| {
-                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None)
+                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None, None)
                 })
                 .collect(),
             background_panes: Vec::new(),
@@ -285,20 +288,7 @@ fn launch_plan_from_saved(
             saved_grid.columns
         )
     })?;
-    let panes = panes
-        .iter()
-        .map(|pane| PaneLaunchSpec {
-            profile_name: pane.profile_name.clone(),
-            command: pane.command.clone(),
-            env: BTreeMap::new(),
-            cwd: pane.cwd.clone(),
-            folder_name: pane.folder_name.clone(),
-            worktree_name: pane.worktree_name.clone(),
-            auth_name: pane.auth_name.clone(),
-            auth_kind: pane.auth_kind,
-            auth_dir: None,
-        })
-        .collect::<Vec<_>>();
+    let panes = panes.iter().map(SavedPane::launch_spec).collect::<Vec<_>>();
     if panes.is_empty() {
         bail!("saved session {id} has no panes");
     }
@@ -306,6 +296,11 @@ fn launch_plan_from_saved(
 }
 
 fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane> {
+    let host_processes = panes
+        .iter()
+        .filter_map(PtyPane::host_process_id)
+        .collect::<Vec<_>>();
+    let codex_roots = roots_with_descendant_named(&host_processes, "codex").ok();
     plan.panes
         .iter()
         .enumerate()
@@ -313,7 +308,20 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
             let live = panes.get(index);
             let history = live.map(SavedPaneHistory::from_pane).unwrap_or_default();
             let host = live.map(PtyPane::host_ref);
-            let mut saved = SavedPane::from_spec(index, spec, history, host);
+            let codex_running = live.is_some_and(|pane| {
+                pane.host_process_id().is_some_and(|process_id| {
+                    codex_roots
+                        .as_ref()
+                        .is_some_and(|roots| roots.contains(&process_id))
+                }) || (spec.command.agent_kind == Some(AgentKind::Codex) && !pane.exited)
+            });
+            let codex_thread_id = codex_running
+                .then(|| {
+                    codex_resume_id(&spec.command, &history.input_history)
+                        .or_else(|| live.and_then(|pane| pane.codex_thread_id(pane.cwd())))
+                })
+                .flatten();
+            let mut saved = SavedPane::from_spec(index, spec, history, codex_thread_id, host);
             if let Some(live) = live {
                 saved.cwd = live.cwd().to_path_buf();
                 saved.folder_name = folder_display_name(&saved.cwd);
@@ -325,9 +333,14 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
 
 impl SavedPane {
     pub fn launch_spec(&self) -> PaneLaunchSpec {
+        let (profile_name, command) = self
+            .codex_thread_id
+            .as_deref()
+            .map(|thread_id| codex_resume_profile(&self.profile_name, &self.command, thread_id))
+            .unwrap_or_else(|| (self.profile_name.clone(), self.command.clone()));
         PaneLaunchSpec {
-            profile_name: self.profile_name.clone(),
-            command: self.command.clone(),
+            profile_name,
+            command,
             env: BTreeMap::new(),
             cwd: self.cwd.clone(),
             folder_name: self.folder_name.clone(),
@@ -343,13 +356,14 @@ impl SavedPane {
         history: SavedPaneHistory,
         host: Option<PtyHostRef>,
     ) -> Self {
-        Self::from_spec(0, spec, history, host)
+        Self::from_spec(0, spec, history, None, host)
     }
 
     fn from_spec(
         index: usize,
         spec: &PaneLaunchSpec,
         history: SavedPaneHistory,
+        codex_thread_id: Option<String>,
         host: Option<PtyHostRef>,
     ) -> Self {
         Self {
@@ -362,9 +376,101 @@ impl SavedPane {
             auth_name: spec.auth_name.clone(),
             auth_kind: spec.auth_kind,
             history,
+            codex_thread_id,
             host,
         }
     }
+}
+
+fn codex_resume_profile(
+    profile_name: &str,
+    command: &Profile,
+    thread_id: &str,
+) -> (String, Profile) {
+    if command.agent_kind == Some(AgentKind::Codex) && is_direct_codex_command(&command.command) {
+        let mut command = command.clone();
+        if let Some(resume_index) = command
+            .args
+            .iter()
+            .position(|argument| argument == "resume")
+        {
+            if command
+                .args
+                .get(resume_index + 1)
+                .is_some_and(|argument| looks_like_thread_id(argument))
+            {
+                command.args[resume_index + 1] = thread_id.to_string();
+            } else {
+                command.args.insert(resume_index + 1, thread_id.to_string());
+            }
+        } else {
+            command.args.extend(["resume".into(), thread_id.into()]);
+        }
+        return (profile_name.to_string(), command);
+    }
+    if codex_resume_id(command, &[]).as_deref() == Some(thread_id) {
+        return (profile_name.to_string(), command.clone());
+    }
+
+    (
+        "codex".into(),
+        Profile {
+            command: "codex".into(),
+            args: vec!["resume".into(), thread_id.into()],
+            title: Some("Codex".into()),
+            agent_kind: Some(AgentKind::Codex),
+        },
+    )
+}
+
+fn codex_resume_id(command: &Profile, input_history: &[String]) -> Option<String> {
+    command
+        .args
+        .windows(2)
+        .find_map(|arguments| {
+            (arguments[0] == "resume" && looks_like_thread_id(&arguments[1]))
+                .then(|| arguments[1].clone())
+        })
+        .or_else(|| {
+            command
+                .args
+                .iter()
+                .rev()
+                .find_map(|argument| resume_id_in_text(argument))
+        })
+        .or_else(|| {
+            input_history
+                .iter()
+                .rev()
+                .find_map(|input| resume_id_in_text(input))
+        })
+}
+
+fn resume_id_in_text(value: &str) -> Option<String> {
+    let tokens = value
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|character: char| matches!(character, '"' | '\'' | ';' | ','))
+        })
+        .collect::<Vec<_>>();
+    tokens.windows(2).find_map(|tokens| {
+        (tokens[0] == "resume" && looks_like_thread_id(tokens[1])).then(|| tokens[1].to_string())
+    })
+}
+
+fn is_direct_codex_command(command: &str) -> bool {
+    Path::new(command)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("codex"))
+}
+
+fn looks_like_thread_id(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
 }
 
 impl SavedPaneHistory {
@@ -907,6 +1013,80 @@ mod tests {
     }
 
     #[test]
+    fn saved_codex_thread_relaunches_with_resume() {
+        let mut pane = pane("fluent", "codex");
+        pane.command.agent_kind = Some(AgentKind::Codex);
+        pane.command.args = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
+        pane.codex_thread_id = Some("019f7b81-de49-7782-8186-a3dc2c644c61".into());
+
+        let launch = pane.launch_spec();
+
+        assert_eq!(launch.profile_name, "codex");
+        assert_eq!(
+            launch.command.args,
+            [
+                "--dangerously-bypass-approvals-and-sandbox",
+                "resume",
+                "019f7b81-de49-7782-8186-a3dc2c644c61",
+            ]
+        );
+    }
+
+    #[test]
+    fn shell_running_codex_becomes_a_resumable_codex_pane() {
+        let mut pane = pane("fluent", "git-bash");
+        pane.codex_thread_id = Some("019f7b81-e026-7d12-a013-25f4763f4bce".into());
+
+        let launch = pane.launch_spec();
+
+        assert_eq!(launch.profile_name, "codex");
+        assert_eq!(launch.command.command, "codex");
+        assert_eq!(
+            launch.command.args,
+            ["resume", "019f7b81-e026-7d12-a013-25f4763f4bce"]
+        );
+        assert_eq!(launch.command.agent_kind, Some(AgentKind::Codex));
+    }
+
+    #[test]
+    fn extracts_codex_resume_id_from_shell_history() {
+        let command = Profile {
+            command: "bash".into(),
+            args: Vec::new(),
+            title: Some("Git Bash".into()),
+            agent_kind: None,
+        };
+
+        assert_eq!(
+            codex_resume_id(
+                &command,
+                &["codex resume 019f7b81-e2cd-71c1-84dd-9f09622cf74e".into()]
+            )
+            .as_deref(),
+            Some("019f7b81-e2cd-71c1-84dd-9f09622cf74e")
+        );
+    }
+
+    #[test]
+    fn preserves_a_wrapper_that_already_resumes_the_saved_thread() {
+        let thread_id = "019f7b81-de49-7782-8186-a3dc2c644c61";
+        let command = Profile {
+            command: "powershell.exe".into(),
+            args: vec![
+                "-Command".into(),
+                format!("& codex --dangerously-bypass-approvals-and-sandbox resume {thread_id}"),
+            ],
+            title: Some("Codex".into()),
+            agent_kind: Some(AgentKind::Codex),
+        };
+
+        let (profile_name, restored) = codex_resume_profile("codex", &command, thread_id);
+        assert_eq!(profile_name, "codex");
+        assert_eq!(restored.command, command.command);
+        assert_eq!(restored.args, command.args);
+    }
+
+    #[test]
     fn summarizes_unique_folders_and_profiles() {
         let session = SavedSession {
             version: SESSION_VERSION,
@@ -944,6 +1124,8 @@ mod tests {
         background_pane.host = Some(PtyHostRef {
             endpoint: "127.0.0.1:32123".into(),
             token: "secret".into(),
+            codex_sqlite_home: None,
+            started_at_ms: None,
         });
         let mut session = SavedSession {
             version: SESSION_VERSION,
@@ -1191,6 +1373,7 @@ mod tests {
             auth_name: None,
             auth_kind: None,
             history: SavedPaneHistory::default(),
+            codex_thread_id: None,
             host: None,
         }
     }


### PR DESCRIPTION
## Summary
- persist each active Codex conversation ID with its GridBash pane
- detect Codex launched directly or beneath Git Bash pane hosts
- relaunch unavailable panes with `codex resume <conversation-id>` without replaying unrelated shell commands
- retain backward compatibility with existing session and pane-host metadata

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- verified thread lookup fields against the installed Codex `state_5.sqlite` schema
- Rust build and test validation will run under the repository integration lease

Fixes #295