### PR TITLE
feat: close the current grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ agents and shells.
 | `Alt+Shift+L` | Start or stop continuous target-pane logging |
 | `Alt+d` | Chat with BashBot across all open grids and panes |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
+| `Alt+w` | Close the current grid after confirmation |
 | `Alt+p` | Open focused-pane activity |
 | `Ctrl+Alt+p` | Inspect and stop localhost ports launched by agents |
 | `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -226,6 +226,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+x | Swap the two selected panes. |
 | Alt+n | Open the startup picker and launch a new tab. |
 | Alt+t | Switch to the next tab. |
+| Alt+w | Open the current-grid close confirmation. |
 | Alt+s | Toggle selection of the focused pane. |
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
@@ -279,6 +280,13 @@ Alt+D opens BashBot in a compact dock at the bottom-right. BashBot uses bounded,
 
 The command palette lists the available pane, tab, grid, manager, settings, help, and quit actions together with their configured shortcuts. Its query supports tolerant subsequence matching, pasted Unicode text, and cursor editing. Palette input is never sent to a child terminal; press Esc or the configured command-palette shortcut to close it without running anything.
 
+The close-grid confirmation names the grid, reports its pane count, and requires
+Enter or Y before GridBash terminates all of its visible panes, even when **Keep
+terminals running** is enabled. Escape or N cancels. After confirmation,
+GridBash removes the tab and activates the next grid or the previous grid when
+the closed one was last. GridBash never closes the only remaining grid; use
+Alt+q to quit the workspace. Managed worktrees and their branches are preserved.
+
 Pane Activity provides auth, rename, refresh, sleep/wake, deactivate, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `d` to deactivate, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+Shift+A opens Auth Profiles and Alt+o switches to overall settings.
 
 The bottom-right **Ports** control counts TCP listeners launched inside GridBash agent process trees. Click it or press Ctrl+Alt+p to see each port, process name, PID, and owning pane or tab. Use Up/Down to select a listener, `R` to refresh, and Enter or Delete followed by Enter to terminate its process. GridBash excludes unrelated system listeners and its own pane-host control sockets from this view.
@@ -305,7 +313,7 @@ settings = "f8"
 
 Supported actions are `quit`, `help`, `focus-left`, `focus-right`, `focus-up`,
 `focus-down`, `toggle-selection`, `select-all`, `sleep-panes`, `restart-panes`,
-`next-tab`, `new-tab`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
+`next-tab`, `new-tab`, `close-grid`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
 `command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`, `ports`,
 `pane-activity`, `copy-mode`, `auth-profiles`, `capture-output`,
 `toggle-output-logging`, `rename-tab`, and `rename-pane`. Unlisted actions retain their

--- a/docs/devlogs/2026-07-20-close-the-current-grid.md
+++ b/docs/devlogs/2026-07-20-close-the-current-grid.md
@@ -1,0 +1,28 @@
+# Close the current grid
+
+Date: 2026-07-20
+Release target: unreleased
+
+## Summary
+
+- Added a safe way to close one grid without quitting the whole GridBash workspace.
+
+## What Changed
+
+- Added the configurable `close-grid` action with the default `Alt+w` shortcut.
+- Added a confirmation dialog that names the grid and pane count before stopping processes.
+- Terminated pane hosts, cleared grid-local runtime state, activated an adjacent grid, and saved the updated session.
+- Prevented the only remaining grid from being closed.
+
+## Why It Matters
+
+- Multi-grid sessions can retire finished work without rebuilding or exiting the rest of the workspace.
+
+## Validation
+
+- Focused Rust tests for action matching, shortcuts, close selection, confirmation input, and dialog rendering.
+- Repository formatting, lint, and test checks before merge.
+
+## Release Notes
+
+- Press `Alt+w`, then Enter or Y, to close the current grid. Press Escape or N to cancel.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -16,6 +16,7 @@ fn search_keywords(action: Action) -> &'static str {
         Action::ZoomPane => "maximize fullscreen restore",
         Action::RestartPanes => "exited dead",
         Action::PreviousPanes => "history list switch",
+        Action::CloseGrid => "remove delete tab workspace terminate",
         Action::Ports => "localhost server listener process pid terminate",
         Action::VoiceInput => "microphone speech",
         Action::AuthProfiles => "accounts credentials profiles",
@@ -67,6 +68,7 @@ mod tests {
         assert!(fuzzy_match_score("rn pane", Action::RenamePane).is_some());
         assert!(fuzzy_match_score("orchestrate", Action::EditGoal).is_some());
         assert!(fuzzy_match_score("tab next", Action::NextTab).is_some());
+        assert!(fuzzy_match_score("delete grid", Action::CloseGrid).is_some());
         assert!(fuzzy_match_score("unrelated", Action::NextTab).is_none());
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -16,7 +16,7 @@ fn search_keywords(action: Action) -> &'static str {
         Action::ZoomPane => "maximize fullscreen restore",
         Action::RestartPanes => "exited dead",
         Action::PreviousPanes => "history list switch",
-        Action::CloseGrid => "remove delete tab workspace terminate",
+        Action::CloseGrid => "remove delete grid tab workspace terminate",
         Action::Ports => "localhost server listener process pid terminate",
         Action::VoiceInput => "microphone speech",
         Action::AuthProfiles => "accounts credentials profiles",

--- a/src/app.rs
+++ b/src/app.rs
@@ -147,6 +147,7 @@ pub struct App {
     grid_resizer: Option<GridPicker>,
     help_open: bool,
     quit_confirmation_pending: bool,
+    close_grid_confirmation_pending: bool,
     settings: SettingsState,
     rename: RenamePaneState,
     tab_rename: RenameTabState,
@@ -299,6 +300,13 @@ enum KeyOutcome {
     Render,
     AuthLogin(AuthProfile),
     Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloseGridConfirmationAction {
+    Confirm,
+    Cancel,
+    Continue,
 }
 
 #[derive(Debug, Clone)]
@@ -915,6 +923,12 @@ pub struct FollowUpDialog {
     pub todo_position: usize,
     pub todo_count: usize,
     pub quiet_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloseGridConfirmationView {
+    pub title: String,
+    pub pane_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2439,10 +2453,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+w close grid | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+w close grid | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -2679,6 +2693,7 @@ impl App {
             grid_resizer: None,
             help_open: false,
             quit_confirmation_pending: false,
+            close_grid_confirmation_pending: false,
             settings: init.settings,
             rename: RenamePaneState::default(),
             tab_rename: RenameTabState::default(),
@@ -2957,6 +2972,7 @@ impl App {
         self.copy_mode = None;
         self.command_line.focused = false;
         self.grid_resizer = None;
+        self.close_grid_confirmation_pending = false;
     }
 
     fn activate_plan_as_tab(&mut self, title: String, mut plan: LaunchPlan) -> Result<()> {
@@ -5152,6 +5168,9 @@ impl App {
 
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
         let action = self.keybindings.action_for(&key);
+        if self.close_grid_confirmation_pending {
+            return self.handle_close_grid_confirmation_key(key);
+        }
         if is_quit_recovery(&key) || action == Some(Action::Quit) {
             return Ok(self.request_quit());
         }
@@ -5740,6 +5759,9 @@ impl App {
             Action::NewTab => {
                 self.open_new_tab(terminal)?;
             }
+            Action::CloseGrid => {
+                self.request_close_current_grid()?;
+            }
             Action::ToggleOutputLogging => {
                 self.toggle_target_output_logging();
             }
@@ -5912,6 +5934,91 @@ impl App {
 
         let next = (self.active_tab + 1) % self.tabs.len();
         self.switch_to_tab(next);
+    }
+
+    fn request_close_current_grid(&mut self) -> Result<()> {
+        if self.tabs.len() <= 1 {
+            self.close_grid_confirmation_pending = false;
+            self.status = "the only grid cannot be closed; use Alt+q to quit GridBash".into();
+            return Ok(());
+        }
+
+        self.close_tab_modals();
+        self.close_grid_confirmation_pending = true;
+        self.status = format!("close grid confirmation open for {}", self.tab_title);
+        Ok(())
+    }
+
+    fn handle_close_grid_confirmation_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
+        match close_grid_confirmation_action(key) {
+            CloseGridConfirmationAction::Confirm => {
+                self.close_grid_confirmation_pending = false;
+                self.close_current_grid()?;
+            }
+            CloseGridConfirmationAction::Cancel => {
+                self.close_grid_confirmation_pending = false;
+                self.status = "close grid canceled".into();
+            }
+            CloseGridConfirmationAction::Continue => return Ok(KeyOutcome::Continue),
+        }
+        Ok(KeyOutcome::Render)
+    }
+
+    fn close_current_grid(&mut self) -> Result<()> {
+        let closing_title = self.tab_title.clone();
+        let closing_index = self.active_tab;
+        let Some(next_index) = tab_index_after_close(closing_index, self.tabs.len()) else {
+            self.status = "the only grid cannot be closed; use Alt+q to quit GridBash".into();
+            return Ok(());
+        };
+
+        self.close_tab_modals();
+        let mut termination_failures = 0usize;
+        for mut pane in mem::take(&mut self.panes) {
+            let pane_id = pane.id();
+            let log_key = PaneLogKey::new(pane_id, pane.generation());
+            if self.output_logs.stop(log_key).is_err() {
+                termination_failures += 1;
+            }
+            self.pane_render_cache.borrow_mut().remove(&pane_id);
+            self.applied_workloads.remove(&pane_id);
+            self.activity_summary_states.remove(&pane_id);
+            if pane.terminate().is_err() {
+                termination_failures += 1;
+            }
+        }
+        self.voice.cancel();
+        self.voice_destination = None;
+
+        self.tabs.remove(closing_index);
+        let snapshot = self.tabs[next_index]
+            .take()
+            .ok_or_else(|| anyhow!("surviving grid {} is unavailable", next_index + 1))?;
+        self.active_tab = next_index;
+        self.restore_tab_snapshot(snapshot);
+        let recovered_agent = self.recover_exited_agent_panes_to_shell();
+        if let Some(cwd) = self.active_pane_cwd() {
+            self.command_line.cwd = cwd;
+        }
+        self.start_usage_for_active_tab();
+        self.sync_pane_sizes_for_current_layout();
+        self.save_session_snapshot()?;
+
+        self.status = if termination_failures == 0 {
+            format!(
+                "closed grid {closing_title}; active grid {}",
+                self.tab_title
+            )
+        } else {
+            format!(
+                "closed grid {closing_title}; {termination_failures} pane cleanup operation(s) reported errors"
+            )
+        };
+        if recovered_agent && termination_failures == 0 {
+            self.status
+                .push_str("; restored exited agent panes to shells");
+        }
+        Ok(())
     }
 
     fn switch_to_tab(&mut self, index: usize) {
@@ -8918,6 +9025,14 @@ impl App {
         &self.status
     }
 
+    pub fn close_grid_confirmation_view(&self) -> Option<CloseGridConfirmationView> {
+        self.close_grid_confirmation_pending
+            .then(|| CloseGridConfirmationView {
+                title: self.tab_title.clone(),
+                pane_count: self.panes.len(),
+            })
+    }
+
     pub fn grid_resizer(&self) -> Option<&GridPicker> {
         self.grid_resizer.as_ref()
     }
@@ -11104,6 +11219,10 @@ fn swapped_index(index: usize, first: usize, second: usize) -> usize {
     }
 }
 
+fn tab_index_after_close(active: usize, tab_count: usize) -> Option<usize> {
+    (tab_count > 1).then(|| active.min(tab_count - 2))
+}
+
 fn wrapped_row_focus_target(
     focus: usize,
     pane_count: usize,
@@ -11246,6 +11365,22 @@ fn exited_recovery_action_for(key: KeyEvent) -> Option<ExitedRecoveryAction> {
             _ => None,
         },
         _ => None,
+    }
+}
+
+fn close_grid_confirmation_action(key: KeyEvent) -> CloseGridConfirmationAction {
+    if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) {
+        return CloseGridConfirmationAction::Continue;
+    }
+    match key.code {
+        KeyCode::Enter => CloseGridConfirmationAction::Confirm,
+        KeyCode::Esc => CloseGridConfirmationAction::Cancel,
+        KeyCode::Char(ch) => match ch.to_ascii_lowercase() {
+            'y' => CloseGridConfirmationAction::Confirm,
+            'n' => CloseGridConfirmationAction::Cancel,
+            _ => CloseGridConfirmationAction::Continue,
+        },
+        _ => CloseGridConfirmationAction::Continue,
     }
 }
 
@@ -12106,6 +12241,14 @@ mod tests {
     }
 
     #[test]
+    fn closing_a_grid_keeps_the_next_slot_or_falls_back_to_the_previous_one() {
+        assert_eq!(tab_index_after_close(0, 3), Some(0));
+        assert_eq!(tab_index_after_close(1, 3), Some(1));
+        assert_eq!(tab_index_after_close(2, 3), Some(1));
+        assert_eq!(tab_index_after_close(0, 1), None);
+    }
+
+    #[test]
     fn horizontal_focus_wraps_within_the_current_row() {
         let sleeping = selected(&[]);
 
@@ -12321,6 +12464,30 @@ mod tests {
         assert_eq!(
             exited_recovery_action_for(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT)),
             None
+        );
+    }
+
+    #[test]
+    fn close_grid_confirmation_requires_an_explicit_choice() {
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Confirm
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('Y'), KeyModifiers::SHIFT)),
+            CloseGridConfirmationAction::Confirm
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Cancel
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Cancel
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT)),
+            CloseGridConfirmationAction::Continue
         );
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -17,6 +17,7 @@ pub enum Action {
     RestartPanes,
     NextTab,
     NewTab,
+    CloseGrid,
     ResizeGrid,
     SwapPanes,
     ZoomPane,
@@ -49,6 +50,7 @@ const ACTIONS: &[Action] = &[
     Action::SelectAll,
     Action::NewTab,
     Action::NextTab,
+    Action::CloseGrid,
     Action::RenameTab,
     Action::CommandLine,
     Action::CommandPalette,
@@ -95,6 +97,7 @@ impl Action {
             Self::RestartPanes => "restart-panes",
             Self::NextTab => "next-tab",
             Self::NewTab => "new-tab",
+            Self::CloseGrid => "close-grid",
             Self::ResizeGrid => "resize-grid",
             Self::SwapPanes => "swap-panes",
             Self::ZoomPane => "zoom-pane",
@@ -133,6 +136,7 @@ impl Action {
             Self::RestartPanes => "restart exited panes",
             Self::NextTab => "switch to next tab",
             Self::NewTab => "open a new tab",
+            Self::CloseGrid => "close current grid",
             Self::ResizeGrid => "resize the grid",
             Self::SwapPanes => "swap selected panes",
             Self::ZoomPane => "zoom or restore focused pane",
@@ -175,6 +179,7 @@ impl Action {
             Self::RestartPanes => "alt+shift+t",
             Self::NextTab => "alt+t",
             Self::NewTab => "alt+n",
+            Self::CloseGrid => "alt+w",
             Self::ResizeGrid => "alt+l",
             Self::SwapPanes => "alt+x",
             Self::ZoomPane => "alt+f",
@@ -514,6 +519,15 @@ mod tests {
             .map(|action| action.name())
             .collect::<BTreeSet<_>>();
         assert_eq!(names.len(), ACTIONS.len());
+    }
+
+    #[test]
+    fn close_grid_has_a_modeless_default_shortcut() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT)),
+            Some(Action::CloseGrid)
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,17 +4,18 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
 };
 use vt100::Cell;
 
 use crate::{
     app::{
         App, AssistantMessageRole, BackgroundJobState, BackgroundJobView, BackgroundJobsView,
-        CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView, GridPalette,
-        PaneSelection, PaneSettingsTarget, PaneSettingsView, PortInspectorView, PreviousPaneView,
-        PreviousPanesView, RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab,
-        SettingsValueKind, TabLabel, WorkspaceAssistantView,
+        CloseGridConfirmationView, CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog,
+        GoalEditorView, GridPalette, PaneSelection, PaneSettingsTarget, PaneSettingsView,
+        PortInspectorView, PreviousPaneView, PreviousPanesView, RenamePaneView, RenameTabView,
+        SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind, TabLabel,
+        WorkspaceAssistantView,
     },
     auth::{AgentKind, AuthProfile},
     composer::GridPickerMode,
@@ -102,6 +103,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let assistant_view = app.workspace_assistant_view();
+    let close_grid_confirmation = app.close_grid_confirmation_view();
     let help_open = app.help_open();
     let copy_mode_open = app.copy_mode_open();
     let exited_recovery = if command_palette_view.is_some()
@@ -119,6 +121,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || goal_editor_view.is_some()
         || image_overlay.is_some()
         || assistant_view.is_some()
+        || close_grid_confirmation.is_some()
     {
         None
     } else {
@@ -139,6 +142,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || goal_editor_view.is_some()
         || image_overlay.is_some()
         || assistant_view.is_some()
+        || close_grid_confirmation.is_some()
         || exited_recovery.is_some();
     let mut pane_settings_rename_button = None;
     let mut pane_settings_reload_button = None;
@@ -348,6 +352,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
     if let Some(view) = command_palette_view.as_ref() {
         render_command_palette(frame, area, view, palette);
+    }
+    if let Some(confirmation) = close_grid_confirmation.as_ref() {
+        render_close_grid_confirmation(frame, area, confirmation, palette);
     }
 
     DrawState {
@@ -3595,6 +3602,71 @@ fn render_command_palette(
     frame.set_cursor_position((cursor_x, inner.y));
 }
 
+fn render_close_grid_confirmation(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    confirmation: &CloseGridConfirmationView,
+    palette: &GridPalette,
+) {
+    let modal = close_grid_confirmation_modal_rect(area);
+    let shadow = settings_shadow_rect(area, modal);
+
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+
+    frame.render_widget(Clear, modal);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.exited())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Close current grid? ")
+        .title_bottom(" Enter / Y closes | Esc / N cancels ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let pane_label = if confirmation.pane_count == 1 {
+        "pane"
+    } else {
+        "panes"
+    };
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!(
+                "Close \"{}\" and terminate {} {pane_label}?",
+                confirmation.title, confirmation.pane_count
+            ),
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Every visible process in this grid will stop.",
+            Style::default().fg(SETTINGS_TEXT),
+        )),
+        Line::from(Span::styled(
+            "Managed worktrees and branches will stay on disk.",
+            Style::default().fg(SETTINGS_MUTED),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .style(settings_panel_style()),
+        inner,
+    );
+}
+
 fn help_control(key: &str, action: &str, width: usize) -> String {
     truncate_text(&format!("{key:<13} {action}"), width)
 }
@@ -3654,6 +3726,22 @@ fn settings_modal_rect(area: Rect, row_count: usize) -> Rect {
 fn exited_recovery_modal_rect(area: Rect) -> Rect {
     let width = area.width.saturating_sub(4).min(62).max(area.width.min(1));
     let height = area.height.saturating_sub(2).min(9).max(area.height.min(1));
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn close_grid_confirmation_modal_rect(area: Rect) -> Rect {
+    let width = area.width.saturating_sub(4).min(66).max(area.width.min(1));
+    let height = area
+        .height
+        .saturating_sub(2)
+        .min(11)
+        .max(area.height.min(1));
 
     Rect {
         x: area.x + area.width.saturating_sub(width) / 2,
@@ -4171,6 +4259,29 @@ mod tests {
         let rendered = buffer_text(&terminal);
         assert!(rendered.contains("GridBash Commands"));
         assert!(rendered.contains("No matching"));
+    }
+
+    #[test]
+    fn close_grid_confirmation_names_the_grid_and_consequences() {
+        let backend = TestBackend::new(90, 18);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = CloseGridConfirmationView {
+            title: "Backend agents".into(),
+            pane_count: 3,
+        };
+
+        terminal
+            .draw(|frame| {
+                render_close_grid_confirmation(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render close-grid confirmation");
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("Close current grid?"));
+        assert!(rendered.contains("Backend agents"));
+        assert!(rendered.contains("terminate 3 panes"));
+        assert!(rendered.contains("worktrees and branches will stay on disk"));
+        assert!(rendered.contains("Enter / Y closes"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a configurable close-grid action with Alt+W as the default
- require explicit confirmation and protect the final remaining grid
- terminate closed-grid pane hosts, clean local state, activate an adjacent grid, and save the session
- document the workflow and add focused regression coverage

Closes #297