### PR TITLE
feat: add agent pane prompting tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ printf "Report status, blockers, and next action" | gridbash agent prompt --othe
 `--others` excludes the calling pane and any sleeping or exited panes. Prompt
 text can be a positional argument or piped through stdin. Use
 `--no-agent-api` when launching GridBash to disable the pane-local tools.
+`GRIDBASH_AGENT_TOOLS` is a human-readable discovery hint, not a stable
+protocol; scripts should use `gridbash agent --help` for command discovery.
 
 Configure an agent MCP server to run `gridbash --mcp`. It can request a
 lightweight grid snapshot, read bounded recent output from specific stable pane

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ use that release's matching native artifact until npm publication catches up.
 | `gridbash 2x3 --profile codex --worktrees` | Isolate every pane in a git worktree |
 | `gridbash resume` | Choose a saved session to reopen |
 | `gridbash resume --latest` | Reopen the latest saved session |
-| `gridbash ctl list --json` | Discover opted-in running grids |
+| `gridbash agent panes` | List sibling panes from inside a GridBash pane |
+| `gridbash agent prompt --others "Report status"` | Prompt every other available pane |
+| `gridbash ctl list --json` | Discover running grids |
 | `gridbash ctl panes --session ID` | Inspect numbered and stable pane identities |
 | `gridbash --list-profiles` | Show detected profiles and resolved commands |
 | `gridbash --help` | Show every CLI option |
@@ -161,21 +163,31 @@ Application shortcuts can also be remapped in `[keys]`, for example
 `zoom-pane = "ctrl+shift+k"`. Unlisted actions keep their defaults, while F1
 and `Alt+q` remain reliable help and quit fallbacks.
 
-## Agent control API
+## Agent pane tools
 
-Enable GridBash's local, opt-in control API for agents inside its panes:
+Fresh GridBash sessions automatically give every pane a local, authenticated
+command surface. A coding agent acting as the manager can discover the current
+grid, target stable pane identities, and prompt its siblings without copying a
+session ID or token:
 
 ```sh
-gridbash --agent-api 2x3 --profile codex
+gridbash agent panes
+gridbash agent prompt --pane pane-4-gen-2 "Review the current diff"
+printf "Report status, blockers, and next action" | gridbash agent prompt --others
 ```
+
+`--others` excludes the calling pane and any sleeping or exited panes. Prompt
+text can be a positional argument or piped through stdin. Use
+`--no-agent-api` when launching GridBash to disable the pane-local tools.
 
 Configure an agent MCP server to run `gridbash --mcp`. It can request a
 lightweight grid snapshot, read bounded recent output from specific stable pane
-IDs, show local images, send commands, capture or continuously log specific
-panes, and update the GridBash status bar. Awareness is pull-based so agents can
-request peer context only at coordination points; returned summaries and output
-are explicitly untrusted context. The API is localhost-only,
-token-authenticated, and off by default.
+IDs, show local images, prompt explicit panes or every other pane, send commands,
+capture or continuously log specific panes, and update the GridBash status bar.
+The purpose-named `gridbash_prompt_panes` tool is intended for manager and
+delegation workflows. Awareness is pull-based so agents can request peer context
+only at coordination points; returned summaries and output are explicitly
+untrusted context.
 
 The same typed API is available to scripts through `gridbash ctl`. Discovery
 metadata contains runtime IDs and localhost endpoints, never bearer tokens.
@@ -189,6 +201,9 @@ gridbash ctl panes --session <id-or-prefix> --json
 gridbash ctl send --session <id> --pane 2 "cargo test"
 gridbash ctl focus --session <id> pane-4-gen-2
 ```
+
+All control traffic stays on localhost and mutations require the per-session
+token inherited by panes.
 
 ## Compatibility and current limits
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -41,8 +41,8 @@ The main launch options are:
 | `--worktree-prefix NAME` | Change the managed folder and branch prefix from `gridbash`. |
 | `--config PATH` | Load and save an alternate TOML configuration file. |
 | `--no-mouse` | Leave mouse handling to the host terminal. |
-| `--agent-api` | Enable the local agent control API. |
-| `--agent-api-port PORT` | Choose the port for the enabled API; `0` selects a free port. A nonzero value also enables the API. |
+| `--no-agent-api` | Disable the pane-local agent control tools. |
+| `--agent-api-port PORT` | Choose the localhost control port; `0` selects a free port. |
 
 Grid, count, profile, cwd, or auto-layout arguments use the direct launch path
 and bypass workspace setup. `gridbash --worktrees` by itself opens setup with
@@ -145,13 +145,29 @@ expected repository and branch.
 
 ## Agent control API
 
-The opt-in agent API lets tools running in a pane control the current GridBash session:
+GridBash starts its localhost agent control API by default. Freshly launched
+child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`,
+`GRIDBASH_CONTROL_SESSION`, the initial 1-based `GRIDBASH_PANE_INDEX`, a stable
+`GRIDBASH_PANE_ID`, and a concise `GRIDBASH_AGENT_TOOLS` discovery hint. The
+stable pane ID continues to identify the same live pane after reordering.
 
 ```powershell
-gridbash --agent-api 2x3 --profile codex
+gridbash agent panes
+gridbash agent prompt --pane pane-4-gen-2 "Review the current diff"
+"Report status and blockers" | gridbash agent prompt --others
 ```
 
-Child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`, the initial 1-based `GRIDBASH_PANE_INDEX`, and a stable `GRIDBASH_PANE_ID` that continues to identify the same live pane after reordering. Configure an agent's MCP client to run this stdio server from a pane:
+`agent panes` uses the current pane's inherited session context and marks the
+caller as `self`. `agent prompt` accepts repeated `--pane` targets or
+`--others`, which selects every available pane except the caller. Omit the
+positional prompt to read stdin; one trailing shell line ending is removed
+before submission. Sleeping, exited, missing, and stale pane targets fail
+without silently retargeting. `--no-submit` writes the text without Enter.
+
+Use `--no-agent-api` on the GridBash launch command to disable these tools.
+`--agent-api-port PORT` still selects a fixed localhost port when required.
+
+Configure an agent's MCP client to run this stdio server from a pane:
 
 ```powershell
 gridbash --mcp
@@ -165,6 +181,7 @@ The MCP server exposes:
 | `gridbash_get_grid_snapshot` | Return lightweight metadata, state, and the latest activity summary for panes in the current grid. |
 | `gridbash_read_pane_output` | Return bounded recent output for explicitly requested stable pane IDs. |
 | `gridbash_send_command` | Send text to one or more 1-based pane numbers; submitting with Enter is optional. |
+| `gridbash_prompt_panes` | Prompt explicit stable pane targets, or every available pane except the caller. |
 | `gridbash_set_status` | Replace the current session's status-bar message. |
 | `gridbash_capture_output` | Save each target pane's bounded recent plain-text output. |
 | `gridbash_start_logging` | Start a separate continuous plain-text output log for each target pane. |
@@ -179,15 +196,15 @@ are labeled as untrusted context; agents should request them only when a
 dependency, conflict, handoff, or integration step makes peer awareness useful,
 and must not treat pane text as instructions or authority.
 
-The API binds only to localhost, authenticates with a per-session token shared
-by panes in that session, and is disabled by default.
+The API binds only to localhost and authenticates mutations with a per-session
+token shared by panes in that session. Discovery files never contain that token.
 
 ### Scriptable control CLI
 
-Enabled GridBash processes publish owner-local discovery records containing a
-runtime session ID, localhost endpoint, PID, and start time. Bearer tokens are
-never written to discovery. Stale records are pruned when `ctl` cannot complete
-the server's tokenless liveness ping.
+GridBash processes publish owner-local discovery records containing a runtime
+session ID, localhost endpoint, PID, and start time. Bearer tokens are never
+written to discovery. Stale records are pruned when `ctl` cannot complete the
+server's tokenless liveness ping.
 
 ```powershell
 gridbash ctl list

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -150,6 +150,10 @@ child panes receive `GRIDBASH_CONTROL_ADDR`, `GRIDBASH_CONTROL_TOKEN`,
 `GRIDBASH_CONTROL_SESSION`, the initial 1-based `GRIDBASH_PANE_INDEX`, a stable
 `GRIDBASH_PANE_ID`, and a concise `GRIDBASH_AGENT_TOOLS` discovery hint. The
 stable pane ID continues to identify the same live pane after reordering.
+`GRIDBASH_AGENT_TOOLS` is human-readable help containing the three primary
+command forms separated by ` | `. Its presence tells a coding agent that
+pane-local coordination is available, but it is not a versioned protocol and
+scripts should invoke `gridbash agent --help` instead of parsing its value.
 
 ```powershell
 gridbash agent panes

--- a/docs/devlogs/2026-07-27-make-pane-to-pane-prompting-discoverable-to-agents.md
+++ b/docs/devlogs/2026-07-27-make-pane-to-pane-prompting-discoverable-to-agents.md
@@ -1,0 +1,39 @@
+# Make pane-to-pane prompting discoverable to agents
+
+Date: 2026-07-27
+Release target: unreleased
+
+## Summary
+
+- Added an agent-oriented pane discovery and prompting interface for manager
+  panes and delegation workflows.
+
+## What Changed
+
+- Added `gridbash agent panes` with caller-aware output and stable pane targets.
+- Added `gridbash agent prompt` with positional or piped stdin input, repeated
+  explicit targets, `--others`, and optional no-submit behavior.
+- Added the `gridbash_prompt_panes` MCP tool with stable targets and a
+  caller-excluding other-panes mode.
+- Enabled local authenticated pane tools for fresh sessions by default, with
+  `--no-agent-api` as an explicit opt-out.
+- Exposed a concise `GRIDBASH_AGENT_TOOLS` discovery hint inside child panes.
+
+## Why It Matters
+
+- A coding agent can now recognize the purpose-built GridBash commands from CLI
+  help or its pane environment, then coordinate siblings without manually
+  copying session IDs or bearer tokens.
+- One pane can act as the manager and safely prompt every other available pane
+  without accidentally prompting itself.
+
+## Validation
+
+- Pending focused Rust tests, formatting, and the repository validation batch.
+
+## Release Notes
+
+- From any GridBash pane, run `gridbash agent panes`, then prompt a target with
+  `gridbash agent prompt --pane <stable-target> "..."`.
+- Pipe a generated instruction to every other available pane with
+  `... | gridbash agent prompt --others`.

--- a/docs/devlogs/2026-07-27-make-pane-to-pane-prompting-discoverable-to-agents.md
+++ b/docs/devlogs/2026-07-27-make-pane-to-pane-prompting-discoverable-to-agents.md
@@ -29,7 +29,14 @@ Release target: unreleased
 
 ## Validation
 
-- Pending focused Rust tests, formatting, and the repository validation batch.
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test` (287 passed, 3 ignored)
+- Repository Node test files (48 passed)
+- `cargo build --release --bin gridbash`
+- Release-binary `--help`, `agent --help`, and `agent prompt --help` smoke checks
+- `node npm/scripts/prepare.js`
+- Root and Windows native `npm pack --dry-run --ignore-scripts`
 
 ## Release Notes
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2517,7 +2517,7 @@ impl App {
                 columns: 3,
             });
         let (control_handle, control_rx) =
-            start_agent_control(!cli.no_agent_api, cli.agent_api_port)?;
+            start_agent_control(cli.agent_control_enabled(), cli.agent_api_port)?;
         let base_status = if config.keys.is_empty() {
             default_status(mouse_enabled)
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2479,6 +2479,23 @@ fn default_status(mouse_enabled: bool) -> String {
     }
 }
 
+fn start_agent_control(
+    enabled: bool,
+    port: u16,
+) -> Result<(
+    Option<ControlHandle>,
+    Option<std_mpsc::Receiver<ControlEnvelope>>,
+)> {
+    if !enabled {
+        return Ok((None, None));
+    }
+    let (control_tx, control_rx) = std_mpsc::channel();
+    Ok((
+        Some(control::start_control_server(port, control_tx)?),
+        Some(control_rx),
+    ))
+}
+
 impl App {
     pub fn new(cli: Cli, config: Config) -> Result<Self> {
         let startup_cwd = resolved_current_dir()?;
@@ -2499,19 +2516,8 @@ impl App {
                 rows: 2,
                 columns: 3,
             });
-        let agent_api_enabled = cli.agent_api || cli.agent_api_port != 0;
-        let (control_handle, control_rx) = if agent_api_enabled {
-            let (control_tx, control_rx) = std_mpsc::channel();
-            (
-                Some(control::start_control_server(
-                    cli.agent_api_port,
-                    control_tx,
-                )?),
-                Some(control_rx),
-            )
-        } else {
-            (None, None)
-        };
+        let (control_handle, control_rx) =
+            start_agent_control(!cli.no_agent_api, cli.agent_api_port)?;
         let base_status = if config.keys.is_empty() {
             default_status(mouse_enabled)
         } else {
@@ -2519,7 +2525,7 @@ impl App {
         };
         let status = control_handle
             .as_ref()
-            .map(|control| format!("agent API {} | {base_status}", control.endpoint()))
+            .map(|_| format!("agent pane tools ready | {base_status}"))
             .unwrap_or(base_status);
         let settings = SettingsState::from_config(&config);
 
@@ -2544,7 +2550,13 @@ impl App {
         })
     }
 
-    pub fn resume(config: Config, record: SessionRecord, mouse_enabled: bool) -> Result<Self> {
+    pub fn resume(
+        config: Config,
+        record: SessionRecord,
+        mouse_enabled: bool,
+        agent_control_enabled: bool,
+        agent_control_port: u16,
+    ) -> Result<Self> {
         let mut launch_plan = record.session.launch_plan()?;
         apply_auth_defaults(&mut launch_plan, &config)?;
         let grid = launch_plan.grid;
@@ -2565,6 +2577,13 @@ impl App {
             .first()
             .map(|pane| pane.cwd.clone())
             .unwrap_or(resolved_current_dir()?);
+        let (control_handle, control_rx) =
+            start_agent_control(agent_control_enabled, agent_control_port)?;
+        let status = if control_handle.is_some() {
+            format!("resumed session {session_id} | agent pane tools ready")
+        } else {
+            format!("resumed session {session_id}")
+        };
 
         Self::from_parts(AppInit {
             config,
@@ -2574,8 +2593,8 @@ impl App {
             grid,
             mouse_enabled,
             command_cwd,
-            control_handle: None,
-            control_rx: None,
+            control_handle,
+            control_rx,
             settings,
             tab_title,
             restored_histories,
@@ -2583,7 +2602,7 @@ impl App {
             restored_hosts,
             restored_tabs,
             session_recorder: Some(recorder),
-            status: format!("resumed session {session_id}"),
+            status,
         })
     }
 
@@ -2591,6 +2610,8 @@ impl App {
         config: Config,
         recovery: InterruptedRecovery,
         mouse_enabled: bool,
+        agent_control_enabled: bool,
+        agent_control_port: u16,
     ) -> Result<Self> {
         let InterruptedRecovery {
             mut tabs,
@@ -2614,6 +2635,13 @@ impl App {
             .map(|pane| pane.cwd.clone())
             .unwrap_or(resolved_current_dir()?);
         let tab_count = tabs.len() + 1;
+        let (control_handle, control_rx) =
+            start_agent_control(agent_control_enabled, agent_control_port)?;
+        let agent_control_status = if control_handle.is_some() {
+            " | agent pane tools ready"
+        } else {
+            ""
+        };
 
         Self::from_parts(AppInit {
             config,
@@ -2623,8 +2651,8 @@ impl App {
             grid,
             mouse_enabled,
             command_cwd,
-            control_handle: None,
-            control_rx: None,
+            control_handle,
+            control_rx,
             settings,
             tab_title: active.title,
             restored_histories,
@@ -2633,7 +2661,7 @@ impl App {
             restored_tabs: tabs,
             session_recorder: None,
             status: format!(
-                "recovered {pane_count} pane{} from {session_count} interrupted session{} into {tab_count} tab{} | Alt+t switches tabs",
+                "recovered {pane_count} pane{} from {session_count} interrupted session{} into {tab_count} tab{} | Alt+t switches tabs{agent_control_status}",
                 if pane_count == 1 { "" } else { "s" },
                 if session_count == 1 { "" } else { "s" },
                 if tab_count == 1 { "" } else { "s" },
@@ -3201,6 +3229,11 @@ impl App {
                 (
                     "GRIDBASH_PANE_ID".into(),
                     pane_id.0.saturating_add(1).to_string().into(),
+                ),
+                (
+                    "GRIDBASH_AGENT_TOOLS".into(),
+                    "gridbash agent panes | gridbash agent prompt --pane TARGET | gridbash agent prompt --others"
+                        .into(),
                 ),
             ]);
         }
@@ -4760,7 +4793,7 @@ impl App {
     ) -> ControlResponse {
         match command {
             ControlCommand::Ping => ControlResponse::ok("GridBash control session is live"),
-            ControlCommand::Describe => self.describe_control_session(),
+            ControlCommand::Describe => self.describe_control_session(caller_pane_id),
             ControlCommand::GetGridSnapshot => self.control_grid_snapshot(caller_pane_id),
             ControlCommand::ReadPaneOutput {
                 pane_ids,
@@ -4772,6 +4805,12 @@ impl App {
                 command,
                 submit,
             } => self.send_control_command(&panes, &command, submit),
+            ControlCommand::PromptPanes {
+                panes,
+                prompt,
+                submit,
+                others,
+            } => self.prompt_control_panes(&panes, &prompt, submit, others, caller_pane_id),
             ControlCommand::ShowImage { path, title } => self.show_control_image(path, title),
             ControlCommand::CaptureOutput { panes, directory } => {
                 self.capture_control_output(&panes, directory.as_deref())
@@ -4801,6 +4840,7 @@ impl App {
                 serde_json::json!({
                     "pane_id": pane_id,
                     "pane_number": index + 1,
+                    "target": PaneTarget::stable_label(pane.id(), pane.generation()),
                     "is_self": caller_pane_id == Some(pane_id),
                     "label": self.pane_label(index),
                     "name": self.pane_names.get(index).and_then(|name| name.as_deref()),
@@ -4847,7 +4887,7 @@ impl App {
         )
     }
 
-    fn describe_control_session(&self) -> ControlResponse {
+    fn describe_control_session(&self, caller_pane_id: Option<usize>) -> ControlResponse {
         let Some(control) = self.control_handle.as_ref() else {
             return ControlResponse::error("GridBash control API is not enabled");
         };
@@ -4861,6 +4901,7 @@ impl App {
                     "id": PaneTarget::stable_label(pane.id(), pane.generation()),
                     "pane_id": pane.id().0,
                     "generation": pane.generation(),
+                    "is_self": caller_pane_id == Some(stable_control_pane_id(pane.id())),
                     "label": self.pane_label(index),
                     "cwd": pane.cwd().display().to_string(),
                     "focused": self.focus == index && !self.command_line.focused,
@@ -5001,38 +5042,16 @@ impl App {
 
     fn send_control_command(
         &mut self,
-        pane_numbers: &[PaneTarget],
+        pane_targets: &[PaneTarget],
         command: &str,
         submit: bool,
     ) -> ControlResponse {
-        let targets = match self.control_pane_indices(pane_numbers) {
+        let targets = match self.control_pane_indices(pane_targets) {
             Ok(targets) => targets,
             Err(error) => return ControlResponse::error(format!("{error:#}")),
         };
-        let command_bytes = command.as_bytes();
-
-        for index in &targets {
-            let Some(pane) = self.panes.get_mut(*index) else {
-                return ControlResponse::error(format!("pane {} is unavailable", index + 1));
-            };
-            if !command_bytes.is_empty() {
-                if let Err(error) = pane.write(command_bytes) {
-                    return ControlResponse::error(format!(
-                        "failed to send command to pane {}: {error:#}",
-                        index + 1
-                    ));
-                }
-                pane.record_input(command_bytes);
-            }
-            if submit {
-                if let Err(error) = pane.write(b"\r") {
-                    return ControlResponse::error(format!(
-                        "failed to submit command in pane {}: {error:#}",
-                        index + 1
-                    ));
-                }
-                pane.record_input(b"\r");
-            }
+        if let Err(error) = self.write_control_input(&targets, command, submit) {
+            return ControlResponse::error(format!("{error:#}"));
         }
 
         let panes = pane_number_list(&targets);
@@ -5042,6 +5061,83 @@ impl App {
             format!("agent wrote text to pane(s) {panes}")
         };
         ControlResponse::ok(self.status.clone())
+    }
+
+    fn prompt_control_panes(
+        &mut self,
+        pane_targets: &[PaneTarget],
+        prompt: &str,
+        submit: bool,
+        others: bool,
+        caller_pane_id: Option<usize>,
+    ) -> ControlResponse {
+        if prompt.trim().is_empty() {
+            return ControlResponse::error("pane prompt cannot be empty");
+        }
+        if others && !pane_targets.is_empty() {
+            return ControlResponse::error(
+                "choose explicit pane targets or every other pane, not both",
+            );
+        }
+
+        let targets = if others {
+            let Some(caller_pane_id) = caller_pane_id else {
+                return ControlResponse::error(
+                    "--others is only available inside a GridBash pane; use --pane outside the grid",
+                );
+            };
+            match other_available_pane_indices(&self.control_pane_states(), caller_pane_id) {
+                Ok(targets) => targets,
+                Err(error) => return ControlResponse::error(format!("{error:#}")),
+            }
+        } else {
+            let targets = match self.control_pane_indices(pane_targets) {
+                Ok(targets) => targets,
+                Err(error) => return ControlResponse::error(format!("{error:#}")),
+            };
+            for index in &targets {
+                if self.panes.get(*index).is_some_and(|pane| pane.exited) {
+                    return ControlResponse::error(format!("pane {} has exited", index + 1));
+                }
+                if self.sleeping.contains(index) {
+                    return ControlResponse::error(format!("pane {} is asleep", index + 1));
+                }
+            }
+            targets
+        };
+
+        if let Err(error) = self.write_control_input(&targets, prompt, submit) {
+            return ControlResponse::error(format!("{error:#}"));
+        }
+
+        let panes = pane_number_list(&targets);
+        self.status = if submit {
+            format!("agent prompted pane(s) {panes}")
+        } else {
+            format!("agent wrote a prompt to pane(s) {panes}")
+        };
+        ControlResponse::ok(self.status.clone())
+    }
+
+    fn write_control_input(&mut self, targets: &[usize], input: &str, submit: bool) -> Result<()> {
+        let input_bytes = input.as_bytes();
+        for index in targets {
+            let pane = self
+                .panes
+                .get_mut(*index)
+                .ok_or_else(|| anyhow!("pane {} is unavailable", index + 1))?;
+            if !input_bytes.is_empty() {
+                pane.write(input_bytes)
+                    .with_context(|| format!("failed to send input to pane {}", index + 1))?;
+                pane.record_input(input_bytes);
+            }
+            if submit {
+                pane.write(b"\r")
+                    .with_context(|| format!("failed to submit input in pane {}", index + 1))?;
+                pane.record_input(b"\r");
+            }
+        }
+        Ok(())
     }
 
     fn show_control_image(
@@ -10406,6 +10502,28 @@ fn control_pane_indices_by_id(
     Ok(targets)
 }
 
+fn other_available_pane_indices(
+    states: &[ControlPaneState],
+    caller_pane_id: usize,
+) -> Result<Vec<usize>> {
+    if !states.iter().any(|state| state.pane_id == caller_pane_id) {
+        return Err(anyhow!(
+            "the calling pane is not in the current grid; use explicit --pane targets"
+        ));
+    }
+    let targets = states
+        .iter()
+        .enumerate()
+        .filter_map(|(index, state)| {
+            (state.pane_id != caller_pane_id && state.unavailable_reason.is_none()).then_some(index)
+        })
+        .collect::<Vec<_>>();
+    if targets.is_empty() {
+        return Err(anyhow!("no other available panes to prompt"));
+    }
+    Ok(targets)
+}
+
 fn capture_goal_text(
     manager_goal: &mut Option<ManagerGoal>,
     sleeping: &BTreeSet<usize>,
@@ -13723,6 +13841,38 @@ mod selection_tests {
                 .unwrap_err()
                 .to_string()
                 .contains("current grid")
+        );
+    }
+
+    #[test]
+    fn other_pane_prompt_targets_exclude_the_caller_and_unavailable_panes() {
+        let states = [
+            ControlPaneState {
+                pane_id: 2,
+                unavailable_reason: None,
+            },
+            ControlPaneState {
+                pane_id: 4,
+                unavailable_reason: Some("is asleep"),
+            },
+            ControlPaneState {
+                pane_id: 7,
+                unavailable_reason: None,
+            },
+        ];
+
+        assert_eq!(other_available_pane_indices(&states, 2).unwrap(), vec![2]);
+        assert!(
+            other_available_pane_indices(&states, 9)
+                .unwrap_err()
+                .to_string()
+                .contains("calling pane")
+        );
+        assert!(
+            other_available_pane_indices(&states[..1], 2)
+                .unwrap_err()
+                .to_string()
+                .contains("no other available")
         );
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,13 +49,17 @@ pub struct Cli {
     #[arg(long)]
     pub no_mouse: bool,
 
-    /// Enable the local agent control API for child agent tools.
-    #[arg(long)]
+    /// Compatibility flag; agent tools are enabled by default.
+    #[arg(long, hide = true)]
     pub agent_api: bool,
 
     /// Localhost port for the agent control API. Use 0 to pick an available port.
     #[arg(long, default_value_t = 0)]
     pub agent_api_port: u16,
+
+    /// Disable pane-local agent discovery and prompting tools.
+    #[arg(long, conflicts_with_all = ["agent_api", "agent_api_port"])]
+    pub no_agent_api: bool,
 
     /// Run the GridBash MCP server over stdio.
     #[arg(long)]
@@ -85,6 +89,7 @@ impl Cli {
             && self.layout == GridMode::Grid
             && !self.agent_api
             && self.agent_api_port == 0
+            && !self.no_agent_api
             && self.set_default_profile.is_none()
             && !self.list_profiles
             && !self.mcp
@@ -100,10 +105,56 @@ pub enum GridMode {
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {
+    /// Discover panes and prompt sibling coding agents.
+    Agent(AgentArgs),
     /// Find and reopen a saved GridBash session.
     Resume(ResumeArgs),
-    /// Inspect or control an opted-in running GridBash session.
+    /// Inspect or control a running GridBash session.
     Ctl(CtlArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct AgentArgs {
+    /// Runtime session id or unique id prefix. Defaults to the current pane's session.
+    #[arg(long, global = true)]
+    pub session: Option<String>,
+
+    /// Session bearer token. Defaults to the current pane's GRIDBASH_CONTROL_TOKEN.
+    #[arg(long, global = true)]
+    pub token: Option<String>,
+
+    /// Print machine-readable JSON.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub action: AgentAction,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AgentAction {
+    /// List the current grid's panes, including stable prompt targets and the caller.
+    Panes,
+    /// Send a prompt to selected panes or every other available pane.
+    #[command(visible_alias = "send")]
+    Prompt {
+        /// Pane number or stable pane-<id>-gen-<generation> target. Repeat for multiple panes.
+        #[arg(
+            short = 'p',
+            long = "pane",
+            required_unless_present = "others",
+            conflicts_with = "others"
+        )]
+        panes: Vec<String>,
+        /// Prompt every other available pane in the current grid.
+        #[arg(long)]
+        others: bool,
+        /// Prompt text. Omit this argument to read the prompt from stdin.
+        prompt: Option<String>,
+        /// Write the prompt without pressing Enter.
+        #[arg(long)]
+        no_submit: bool,
+    },
 }
 
 #[derive(Debug, Clone, Args)]
@@ -211,6 +262,9 @@ mod tests {
 
         let agent_api = Cli::parse_from(["gridbash", "--agent-api"]);
         assert!(!agent_api.allows_automatic_recovery());
+
+        let no_agent_api = Cli::parse_from(["gridbash", "--no-agent-api"]);
+        assert!(!no_agent_api.allows_automatic_recovery());
     }
 
     #[test]
@@ -235,6 +289,50 @@ mod tests {
             args.action,
             CtlAction::Send { panes, command, no_submit: true }
                 if panes == vec!["pane-4-gen-2"] && command == "echo ready"
+        ));
+    }
+
+    #[test]
+    fn parses_agent_prompt_from_stdin_for_other_panes() {
+        let cli = Cli::parse_from(["gridbash", "agent", "prompt", "--others"]);
+        let Some(Command::Agent(args)) = cli.command else {
+            panic!("expected agent command");
+        };
+
+        assert!(matches!(
+            args.action,
+            AgentAction::Prompt {
+                panes,
+                others: true,
+                prompt: None,
+                no_submit: false
+            } if panes.is_empty()
+        ));
+    }
+
+    #[test]
+    fn parses_agent_prompt_with_stable_targets() {
+        let cli = Cli::parse_from([
+            "gridbash",
+            "agent",
+            "prompt",
+            "--pane",
+            "pane-4-gen-2",
+            "--no-submit",
+            "Review the current diff",
+        ]);
+        let Some(Command::Agent(args)) = cli.command else {
+            panic!("expected agent command");
+        };
+
+        assert!(matches!(
+            args.action,
+            AgentAction::Prompt {
+                panes,
+                others: false,
+                prompt: Some(prompt),
+                no_submit: true
+            } if panes == vec!["pane-4-gen-2"] && prompt == "Review the current diff"
         ));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,10 @@ pub struct Cli {
 }
 
 impl Cli {
+    pub fn agent_control_enabled(&self) -> bool {
+        !self.no_agent_api
+    }
+
     pub fn allows_automatic_recovery(&self) -> bool {
         self.command.is_none()
             && self.grid.is_none()
@@ -255,6 +259,7 @@ mod tests {
     #[test]
     fn automatic_recovery_only_applies_to_plain_launches() {
         let plain = Cli::parse_from(["gridbash"]);
+        assert!(plain.agent_control_enabled());
         assert!(plain.allows_automatic_recovery());
 
         let worktrees = Cli::parse_from(["gridbash", "--worktrees"]);
@@ -264,7 +269,13 @@ mod tests {
         assert!(!agent_api.allows_automatic_recovery());
 
         let no_agent_api = Cli::parse_from(["gridbash", "--no-agent-api"]);
+        assert!(!no_agent_api.agent_control_enabled());
         assert!(!no_agent_api.allows_automatic_recovery());
+
+        assert!(
+            Cli::try_parse_from(["gridbash", "--no-agent-api", "--agent-api-port", "4321"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeSet,
     env,
-    io::{self, BufRead, Read, Write},
+    io::{self, BufRead, IsTerminal, Read, Write},
     net::{Shutdown, SocketAddr, TcpListener, TcpStream},
     path::PathBuf,
     sync::mpsc::{self, Sender},
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::{
-    cli::{CtlAction, CtlArgs},
+    cli::{AgentAction, AgentArgs, CtlAction, CtlArgs},
     control_discovery::{self, DiscoveryLease, DiscoveryRecord},
     layout::PaneId,
 };
@@ -153,6 +153,12 @@ pub enum ControlCommand {
         panes: Vec<PaneTarget>,
         command: String,
         submit: bool,
+    },
+    PromptPanes {
+        panes: Vec<PaneTarget>,
+        prompt: String,
+        submit: bool,
+        others: bool,
     },
     ShowImage {
         path: PathBuf,
@@ -365,6 +371,49 @@ pub fn run_mcp_server() -> Result<()> {
     Ok(())
 }
 
+pub fn run_agent(args: &AgentArgs) -> Result<()> {
+    let sessions = control_discovery::discover_sessions(probe_discovered_session)?;
+    let requested_session = args
+        .session
+        .clone()
+        .or_else(|| env::var("GRIDBASH_CONTROL_SESSION").ok());
+    let session = select_discovered_session(&sessions, requested_session.as_deref())?;
+    let (command, token) = match &args.action {
+        AgentAction::Panes => (ControlCommand::Describe, None),
+        AgentAction::Prompt {
+            panes,
+            others,
+            prompt,
+            no_submit,
+        } => (
+            ControlCommand::PromptPanes {
+                panes: parse_pane_targets(panes)?,
+                prompt: read_agent_prompt(prompt.as_deref())?,
+                submit: !no_submit,
+                others: *others,
+            },
+            Some(agent_token(args)?),
+        ),
+    };
+
+    let response = call_control(&session.endpoint, token.as_deref(), command)?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&response)
+                .context("failed to serialize control response")?
+        );
+    } else if matches!(&args.action, AgentAction::Panes) && response.ok {
+        print_panes(response.data.as_ref());
+    } else {
+        println!("{}", response.message);
+    }
+    if !response.ok {
+        bail!(response.message);
+    }
+    Ok(())
+}
+
 pub fn run_ctl(args: &CtlArgs) -> Result<()> {
     let sessions = control_discovery::discover_sessions(probe_discovered_session)?;
     if matches!(&args.action, CtlAction::List) {
@@ -374,7 +423,7 @@ pub fn run_ctl(args: &CtlArgs) -> Result<()> {
                 serde_json::to_string_pretty(&sessions).context("failed to serialize sessions")?
             );
         } else if sessions.is_empty() {
-            println!("gridbash: no opted-in running sessions found");
+            println!("gridbash: no running sessions with agent control found");
         } else {
             println!("ID\tPID\tENDPOINT\tSTARTED");
             for session in &sessions {
@@ -480,7 +529,9 @@ fn select_discovered_session<'a>(
     }
 
     match sessions {
-        [] => Err(anyhow!("no opted-in running GridBash sessions found")),
+        [] => Err(anyhow!(
+            "no running GridBash sessions with agent control found"
+        )),
         [session] => Ok(session),
         _ => Err(anyhow!(
             "multiple GridBash sessions are running; pass --session <id-or-prefix>"
@@ -499,11 +550,51 @@ fn ctl_token(args: &CtlArgs) -> Result<String> {
         })
 }
 
+fn agent_token(args: &AgentArgs) -> Result<String> {
+    args.token
+        .clone()
+        .or_else(|| env::var("GRIDBASH_CONTROL_TOKEN").ok())
+        .ok_or_else(|| {
+            anyhow!("prompting panes requires the current pane's GRIDBASH_CONTROL_TOKEN or --token")
+        })
+}
+
 fn parse_pane_targets(values: &[String]) -> Result<Vec<PaneTarget>> {
     values
         .iter()
         .map(|value| PaneTarget::parse(value))
         .collect()
+}
+
+fn read_agent_prompt(argument: Option<&str>) -> Result<String> {
+    let prompt = if let Some(argument) = argument {
+        argument.to_string()
+    } else {
+        let mut stdin = io::stdin();
+        if stdin.is_terminal() {
+            bail!("provide prompt text as an argument or pipe it through stdin");
+        }
+        let mut prompt = String::new();
+        stdin
+            .read_to_string(&mut prompt)
+            .context("failed to read the pane prompt from stdin")?;
+        trim_one_trailing_line_ending(&mut prompt);
+        prompt
+    };
+
+    if prompt.trim().is_empty() {
+        bail!("pane prompt cannot be empty");
+    }
+    Ok(prompt)
+}
+
+fn trim_one_trailing_line_ending(value: &mut String) {
+    if value.ends_with('\n') {
+        value.pop();
+        if value.ends_with('\r') {
+            value.pop();
+        }
+    }
 }
 
 fn print_panes(data: Option<&Value>) {
@@ -514,6 +605,7 @@ fn print_panes(data: Option<&Value>) {
     for pane in panes.into_iter().flatten() {
         let mut states = Vec::new();
         for (field, label) in [
+            ("is_self", "self"),
             ("focused", "focused"),
             ("selected", "selected"),
             ("sleeping", "sleeping"),
@@ -683,6 +775,42 @@ fn tools_list_result() -> Value {
                 }
             },
             {
+                "name": "gridbash_prompt_panes",
+                "title": "Prompt Agent Panes",
+                "description": "Send a prompt to explicit stable pane targets, or set other_panes to prompt every available pane except the caller. Use this for manager and delegation workflows.",
+                "inputSchema": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "targets": {
+                            "type": "array",
+                            "description": "Stable pane target strings from the latest grid snapshot, such as pane-4-gen-2. Omit when other_panes is true.",
+                            "items": {
+                                "type": "string",
+                                "pattern": "^pane-[0-9]+-gen-[0-9]+$"
+                            },
+                            "minItems": 1
+                        },
+                        "other_panes": {
+                            "type": "boolean",
+                            "description": "When true, prompt every available pane in the current grid except this calling pane.",
+                            "default": false
+                        },
+                        "prompt": {
+                            "type": "string",
+                            "description": "Prompt text to write into each target agent pane.",
+                            "minLength": 1
+                        },
+                        "submit": {
+                            "type": "boolean",
+                            "description": "When true, append Enter after the prompt.",
+                            "default": true
+                        }
+                    },
+                    "required": ["prompt"]
+                }
+            },
+            {
                 "name": "gridbash_set_status",
                 "title": "Set Status",
                 "description": "Set the GridBash status bar text for the current session.",
@@ -835,6 +963,34 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
                 submit: args.submit.unwrap_or(true),
             })
         }
+        "gridbash_prompt_panes" => {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Args {
+                #[serde(default)]
+                targets: Vec<String>,
+                #[serde(default)]
+                other_panes: bool,
+                prompt: String,
+                submit: Option<bool>,
+            }
+
+            let args: Args = serde_json::from_value(arguments).context("invalid prompt args")?;
+            if args.prompt.trim().is_empty() {
+                return Err(anyhow!("pane prompt cannot be empty"));
+            }
+            if args.other_panes == !args.targets.is_empty() {
+                return Err(anyhow!(
+                    "provide stable pane targets or set other_panes to true"
+                ));
+            }
+            Ok(ControlCommand::PromptPanes {
+                panes: parse_pane_targets(&args.targets)?,
+                prompt: args.prompt,
+                submit: args.submit.unwrap_or(true),
+                others: args.other_panes,
+            })
+        }
         "gridbash_set_status" => {
             #[derive(Deserialize)]
             struct Args {
@@ -922,9 +1078,9 @@ fn absolute_tool_path(path: PathBuf) -> Result<PathBuf> {
 
 fn call_gridbash_control(command: ControlCommand) -> Result<ControlResponse> {
     let endpoint = env::var("GRIDBASH_CONTROL_ADDR")
-        .context("GRIDBASH_CONTROL_ADDR is not set; start GridBash with --agent-api")?;
+        .context("GRIDBASH_CONTROL_ADDR is not set; run this tool inside a GridBash pane")?;
     let token = env::var("GRIDBASH_CONTROL_TOKEN")
-        .context("GRIDBASH_CONTROL_TOKEN is not set; start GridBash with --agent-api")?;
+        .context("GRIDBASH_CONTROL_TOKEN is not set; run this tool inside a GridBash pane")?;
     call_control(&endpoint, Some(&token), command)
 }
 
@@ -1040,6 +1196,7 @@ mod tests {
                 "gridbash_get_grid_snapshot",
                 "gridbash_read_pane_output",
                 "gridbash_send_command",
+                "gridbash_prompt_panes",
                 "gridbash_set_status",
                 "gridbash_capture_output",
                 "gridbash_start_logging",
@@ -1121,6 +1278,77 @@ mod tests {
                 submit: true
             } if panes == vec![PaneTarget::Number(2)] && command == "cargo test"
         ));
+    }
+
+    #[test]
+    fn pane_prompt_accepts_stable_targets_or_every_other_pane() {
+        let targeted = tool_arguments_to_command(
+            "gridbash_prompt_panes",
+            json!({
+                "targets": ["pane-4-gen-2"],
+                "prompt": "Review the current diff"
+            }),
+        )
+        .expect("targeted prompt");
+        assert!(matches!(
+            targeted,
+            ControlCommand::PromptPanes {
+                panes,
+                prompt,
+                submit: true,
+                others: false
+            } if panes == vec![PaneTarget::Stable { pane_id: 4, generation: 2 }]
+                && prompt == "Review the current diff"
+        ));
+
+        let others = tool_arguments_to_command(
+            "gridbash_prompt_panes",
+            json!({
+                "other_panes": true,
+                "prompt": "Report your status",
+                "submit": false
+            }),
+        )
+        .expect("other pane prompt");
+        assert!(matches!(
+            others,
+            ControlCommand::PromptPanes {
+                panes,
+                prompt,
+                submit: false,
+                others: true
+            } if panes.is_empty() && prompt == "Report your status"
+        ));
+    }
+
+    #[test]
+    fn pane_prompt_requires_exactly_one_target_mode() {
+        for arguments in [
+            json!({ "prompt": "status" }),
+            json!({
+                "targets": ["pane-4-gen-2"],
+                "other_panes": true,
+                "prompt": "status"
+            }),
+        ] {
+            assert!(
+                tool_arguments_to_command("gridbash_prompt_panes", arguments)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("stable pane targets")
+            );
+        }
+    }
+
+    #[test]
+    fn piped_prompts_drop_one_shell_line_ending() {
+        let mut windows = "first\r\nsecond\r\n".to_string();
+        trim_one_trailing_line_ending(&mut windows);
+        assert_eq!(windows, "first\r\nsecond");
+
+        let mut unix = "review this\n".to_string();
+        trim_one_trailing_line_ending(&mut unix);
+        assert_eq!(unix, "review this");
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -979,7 +979,7 @@ fn tool_arguments_to_command(tool_name: &str, arguments: Value) -> Result<Contro
             if args.prompt.trim().is_empty() {
                 return Err(anyhow!("pane prompt cannot be empty"));
             }
-            if args.other_panes == !args.targets.is_empty() {
+            if args.other_panes != args.targets.is_empty() {
                 return Err(anyhow!(
                     "provide stable pane targets or set other_panes to true"
                 ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,10 @@ fn main() -> Result<()> {
         return control::run_mcp_server();
     }
 
+    if let Some(Command::Agent(args)) = &cli.command {
+        return control::run_agent(args);
+    }
+
     if let Some(Command::Ctl(args)) = &cli.command {
         return control::run_ctl(args);
     }
@@ -87,14 +91,26 @@ fn main() -> Result<()> {
             return Ok(());
         };
 
-        let mut app = App::resume(config, record, !cli.no_mouse)?;
+        let mut app = App::resume(
+            config,
+            record,
+            !cli.no_mouse,
+            !cli.no_agent_api,
+            cli.agent_api_port,
+        )?;
         return app.run();
     }
 
     if cli.allows_automatic_recovery()
         && let Some(recovery) = claim_interrupted_recovery()?
     {
-        let mut app = App::recover_interrupted(config, recovery, !cli.no_mouse)?;
+        let mut app = App::recover_interrupted(
+            config,
+            recovery,
+            !cli.no_mouse,
+            !cli.no_agent_api,
+            cli.agent_api_port,
+        )?;
         return app.run();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> Result<()> {
             config,
             record,
             !cli.no_mouse,
-            !cli.no_agent_api,
+            cli.agent_control_enabled(),
             cli.agent_api_port,
         )?;
         return app.run();
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
             config,
             recovery,
             !cli.no_mouse,
-            !cli.no_agent_api,
+            cli.agent_control_enabled(),
             cli.agent_api_port,
         )?;
         return app.run();


### PR DESCRIPTION
## Summary

- add `gridbash agent panes` and stdin-capable `gridbash agent prompt`
- let a manager pane prompt all other available panes without targeting itself
- expose the purpose-named `gridbash_prompt_panes` MCP tool with stable targets
- enable authenticated localhost pane tools by default with `--no-agent-api` opt-out
- document the agent-facing commands and inherited discovery context

Closes #301

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (287 passed, 3 ignored)
- [x] Repository Node tests (48 passed)
- [x] `cargo build --release --bin gridbash`
- [x] Release-binary CLI help smoke checks
- [x] `node npm/scripts/prepare.js`
- [x] Root and Windows native `npm pack --dry-run --ignore-scripts`

## Contributor Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I signed off my commits with `git commit -s`.
- [x] I updated docs, examples, or tests when behavior changed.
- [x] This is not a public report of a security vulnerability.

## Notes For Reviewers

`gridbash_send_command` remains unchanged for compatibility. The new prompt path rejects empty input, stale or unavailable explicit targets, and ambiguous target modes. `--others` requires a caller pane identity and filters the caller, sleeping panes, and exited panes inside GridBash.