### PR TITLE
fix: stop a stale pane rect from crashing GridBash, and log the ones that get through

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,224 @@
+//! On-disk crash reporting.
+//!
+//! GridBash unwinds on panic, so a panic in the UI thread exits with status 101
+//! and prints to a terminal that is usually gone a moment later: no Windows
+//! Error Reporting entry, no minidump, no record of what happened. These
+//! reports are the only durable evidence after the process is gone.
+
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    panic::PanicHookInfo,
+    path::{Path, PathBuf},
+    thread,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use directories::ProjectDirs;
+
+/// Keep enough reports to cover a session's worth of restarts without letting
+/// the directory grow without bound.
+const MAX_REPORTS: usize = 50;
+
+pub fn logs_dir() -> Option<PathBuf> {
+    ProjectDirs::from("", "", "GridBash").map(|dirs| dirs.data_local_dir().join("logs"))
+}
+
+/// Record panics to disk before delegating to the previously installed hook.
+///
+/// The UI thread's terminal-restoring hook chains to whatever hook it replaced,
+/// so installing this first means both the plain CLI paths and the full TUI
+/// report panics without either needing to know about the other.
+pub fn install_panic_logger(role: &'static str) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        record_panic(info, role);
+        previous(info);
+    }));
+}
+
+/// Write a panic report. Called from inside a panic hook, so every failure is
+/// swallowed: a second panic here would abort the process and lose the report.
+pub fn record_panic(info: &PanicHookInfo<'_>, role: &str) {
+    let location = info
+        .location()
+        .map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    let thread = thread::current();
+    let report = format!(
+        "kind: panic\n\
+         {}\
+         thread: {}\n\
+         location: {location}\n\
+         message: {}\n\
+         backtrace:\n{}\n",
+        report_preamble(role),
+        thread.name().unwrap_or("unnamed"),
+        panic_message(info),
+        std::backtrace::Backtrace::force_capture(),
+    );
+    write_report("panic", role, &report);
+}
+
+/// Record a non-zero exit so a failed startup or teardown leaves a trail too.
+pub fn record_error_exit(role: &str, error: &anyhow::Error) {
+    let report = format!(
+        "kind: error-exit\n{}error: {error:#}\n",
+        report_preamble(role)
+    );
+    write_report("error", role, &report);
+}
+
+fn report_preamble(role: &str) -> String {
+    format!(
+        "role: {role}\nversion: {}\npid: {}\ntimestamp_ms: {}\n",
+        env!("CARGO_PKG_VERSION"),
+        std::process::id(),
+        now_millis(),
+    )
+}
+
+fn panic_message(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis())
+        .unwrap_or_default()
+}
+
+fn write_report(kind: &str, role: &str, report: &str) {
+    let Some(directory) = logs_dir() else {
+        return;
+    };
+    if fs::create_dir_all(&directory).is_err() {
+        return;
+    }
+    let path = directory.join(format!(
+        "{kind}-{role}-{}-{}.log",
+        now_millis(),
+        std::process::id()
+    ));
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(report.as_bytes());
+        let _ = file.flush();
+    }
+    prune_reports(&directory);
+}
+
+fn prune_reports(directory: &Path) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    let mut reports = entries
+        .flatten()
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    let Some(excess) = reports
+        .len()
+        .checked_sub(MAX_REPORTS)
+        .filter(|count| *count > 0)
+    else {
+        return;
+    };
+    reports.sort_by_key(|(modified, _)| *modified);
+    for (_, path) in reports.into_iter().take(excess) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_reports_name_the_role_and_location() {
+        let report = format!(
+            "kind: panic\n{}location: src/ui.rs:1:2\n",
+            report_preamble("tui")
+        );
+        assert!(report.contains("role: tui"));
+        assert!(report.contains(concat!("version: ", env!("CARGO_PKG_VERSION"))));
+        assert!(report.contains("location: src/ui.rs:1:2"));
+    }
+
+    /// End-to-end: a real panic must leave a readable report behind, because
+    /// this is the only evidence that survives the process.
+    #[test]
+    fn a_real_panic_writes_a_report_naming_the_message_and_location() {
+        let directory = logs_dir().expect("log directory");
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|info| record_panic(info, "smoketest")));
+        let result = std::panic::catch_unwind(|| panic!("gridbash crash log smoke test"));
+        std::panic::set_hook(previous);
+        assert!(result.is_err(), "the test panic must have unwound");
+
+        let reports = fs::read_dir(&directory)
+            .expect("read log directory")
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("panic-smoketest-"))
+            })
+            .collect::<Vec<_>>();
+        assert!(!reports.is_empty(), "panic must produce a report");
+
+        let body = fs::read_to_string(&reports[0]).expect("read report");
+        assert!(body.contains("kind: panic"), "report body: {body}");
+        assert!(body.contains("role: smoketest"), "report body: {body}");
+        assert!(
+            body.contains("gridbash crash log smoke test"),
+            "report body: {body}"
+        );
+        assert!(
+            body.contains("src\\diagnostics.rs") || body.contains("src/diagnostics.rs"),
+            "report must name the panicking file: {body}"
+        );
+
+        for report in reports {
+            let _ = fs::remove_file(report);
+        }
+    }
+
+    #[test]
+    fn pruning_keeps_the_newest_reports() {
+        let directory = std::env::temp_dir().join(format!("gridbash-logs-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&directory);
+        fs::create_dir_all(&directory).expect("create log directory");
+        for index in 0..MAX_REPORTS + 10 {
+            fs::write(directory.join(format!("panic-tui-{index:04}.log")), b"x")
+                .expect("write report");
+        }
+
+        prune_reports(&directory);
+
+        let remaining = fs::read_dir(&directory)
+            .expect("read log directory")
+            .flatten()
+            .count();
+        assert_eq!(remaining, MAX_REPORTS);
+        let _ = fs::remove_dir_all(&directory);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod config;
 mod control;
 mod control_discovery;
 mod copy_mode;
+mod diagnostics;
 mod image_preview;
 mod keybindings;
 mod layout;
@@ -42,6 +43,19 @@ use crate::{
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Installed before anything else can fail so the crash report survives the
+    // terminal. App::run chains its terminal-restoring hook onto this one.
+    let role = if cli.pane_host.is_some() {
+        "pane-host"
+    } else {
+        "tui"
+    };
+    diagnostics::install_panic_logger(role);
+
+    run(cli).inspect_err(|error| diagnostics::record_error_exit(role, error))
+}
+
+fn run(cli: Cli) -> Result<()> {
     if let Some(spec_path) = cli.pane_host.as_deref() {
         return pane_host::run_pane_host(spec_path);
     }

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -35,6 +35,10 @@ const HOST_START_TIMEOUT: Duration = Duration::from_secs(8);
 const HOST_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const HOST_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long a keep-running host waits for a replacement GridBash to reattach
+/// after the process that owned it disappeared. Long enough to survive a crash
+/// and relaunch, short enough that nothing lingers for hours.
+const ORPHAN_REATTACH_GRACE: Duration = Duration::from_secs(600);
 const BACKGROUND_OUTPUT_LIMIT: usize = 2 * 1024 * 1024;
 const PANE_HOST_PROTOCOL_VERSION: u16 = 1;
 
@@ -676,6 +680,9 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
     let mut active_client_id = None::<u64>;
     let mut next_client_id = 1_u64;
     let mut keep_running = spec.keep_running;
+    // Survives disconnection so an abruptly-dead owner can still be detected.
+    let mut last_owner_pid = None::<u32>;
+    let mut client_lost_at = None::<Instant>;
     let mut background_output = Vec::new();
     let mut last_exit_poll = Instant::now();
     let initial_client_deadline = Instant::now() + HOST_START_TIMEOUT;
@@ -709,6 +716,8 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                         accepted_client_once = true;
                         keep_running = connected.keep_running;
                         active_client_id = Some(connected.client.id);
+                        last_owner_pid = connected.client.owner_pid;
+                        client_lost_at = None;
                         client = Some(connected.client);
                         next_client_id = next_client_id.wrapping_add(1);
                     }
@@ -790,6 +799,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                         keep_running = value;
                         disconnect_client(&mut client);
                         active_client_id = None;
+                        client_lost_at = Some(Instant::now());
                         if !keep_running {
                             pane.terminate();
                             return Ok(());
@@ -804,6 +814,7 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
                 HostInputMessage::Closed => {
                     disconnect_client(&mut client);
                     active_client_id = None;
+                    client_lost_at = Some(Instant::now());
                     if !keep_running {
                         pane.terminate();
                         return Ok(());
@@ -850,14 +861,20 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
 
         if last_exit_poll.elapsed() >= HOST_EXIT_POLL_INTERVAL {
             if pane.poll_exit() {
+                pane.exited = true;
                 send_to_client(&mut client, &HostEvent::Exited);
             }
             last_exit_poll = Instant::now();
         }
 
         if client.is_none()
-            && !keep_running
             && (accepted_client_once || Instant::now() >= initial_client_deadline)
+            && should_shut_down_detached_host(
+                keep_running,
+                pane.exited,
+                client_process_is_gone(last_owner_pid),
+                client_lost_at.map(|at| at.elapsed()),
+            )
         {
             pane.terminate();
             return Ok(());
@@ -1104,6 +1121,25 @@ fn send_to_client(client: &mut Option<HostClient>, event: &HostEvent) {
     }
 }
 
+/// Decide whether a host with no attached client should exit.
+///
+/// A keep-running host deliberately outlives a clean disconnect so a later
+/// GridBash can reattach to it. It must still exit once nothing is left to
+/// reattach to: a dead PTY child has no session to resume, and an owner that
+/// vanished without a replacement would otherwise leave the host — and its
+/// pseudoconsole — running indefinitely.
+fn should_shut_down_detached_host(
+    keep_running: bool,
+    child_exited: bool,
+    owner_gone: bool,
+    detached_for: Option<Duration>,
+) -> bool {
+    if !keep_running || child_exited {
+        return true;
+    }
+    owner_gone && detached_for.is_some_and(|elapsed| elapsed >= ORPHAN_REATTACH_GRACE)
+}
+
 fn disconnect_client(client: &mut Option<HostClient>) {
     if let Some(client) = client.take() {
         let _ = client.stream.shutdown(Shutdown::Both);
@@ -1241,6 +1277,46 @@ mod tests {
     use super::*;
 
     static PANE_HOST_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn detached_hosts_without_keep_running_exit_immediately() {
+        assert!(should_shut_down_detached_host(false, false, false, None));
+    }
+
+    #[test]
+    fn keep_running_hosts_stay_for_a_live_owner() {
+        assert!(!should_shut_down_detached_host(true, false, false, None));
+        assert!(!should_shut_down_detached_host(
+            true,
+            false,
+            false,
+            Some(ORPHAN_REATTACH_GRACE * 2)
+        ));
+    }
+
+    #[test]
+    fn keep_running_hosts_exit_once_their_child_is_gone() {
+        // The leak that stranded pane hosts for hours: the child had exited and
+        // the owning GridBash was gone, but keep_running held the host open.
+        assert!(should_shut_down_detached_host(true, true, false, None));
+        assert!(should_shut_down_detached_host(true, true, true, None));
+    }
+
+    #[test]
+    fn keep_running_hosts_outlive_a_dead_owner_only_for_the_reattach_grace() {
+        assert!(!should_shut_down_detached_host(
+            true,
+            false,
+            true,
+            Some(ORPHAN_REATTACH_GRACE / 2)
+        ));
+        assert!(should_shut_down_detached_host(
+            true,
+            false,
+            true,
+            Some(ORPHAN_REATTACH_GRACE)
+        ));
+    }
 
     struct TestHostFiles {
         directory: PathBuf,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3976,17 +3976,39 @@ fn refresh_screen_cache(
     cache.buffer = buffer;
 }
 
+/// Copy a cached pane buffer into the frame at `area`.
+///
+/// Rendering must never take GridBash down. A pane rect can outlive the frame it
+/// was measured against — the terminal can shrink between layout and draw — and
+/// both `Buffer::index_of` and slice indexing panic outright on an out-of-range
+/// position. Because those checks were only `debug_assert!`s, a release build
+/// aborted the whole process. Clamping to what the two buffers actually cover
+/// makes a stale rect drop cells for one frame instead.
 fn blit_buffer(source: &Buffer, target: &mut Buffer, area: Rect) {
     debug_assert_eq!(source.area.width, area.width);
     debug_assert_eq!(source.area.height, area.height);
-    debug_assert_eq!(area.intersection(target.area), area);
 
-    let width = area.width as usize;
-    for row in 0..area.height {
-        let source_start = row as usize * width;
-        let target_start = target.index_of(area.x, area.y + row);
-        target.content[target_start..target_start + width]
-            .clone_from_slice(&source.content[source_start..source_start + width]);
+    let area = area.intersection(target.area);
+    let source_stride = source.area.width as usize;
+    let width = (area.width as usize).min(source_stride);
+    if width == 0 {
+        return;
+    }
+
+    // Index arithmetic mirrors Buffer::index_of without its out-of-range panic.
+    let target_stride = target.area.width as usize;
+    let target_column = area.x.saturating_sub(target.area.x) as usize;
+    for row in 0..area.height.min(source.area.height) {
+        let source_start = row as usize * source_stride;
+        let target_start =
+            (area.y.saturating_sub(target.area.y) + row) as usize * target_stride + target_column;
+        let Some(source_row) = source.content.get(source_start..source_start + width) else {
+            break;
+        };
+        let Some(target_row) = target.content.get_mut(target_start..target_start + width) else {
+            break;
+        };
+        target_row.clone_from_slice(source_row);
     }
 }
 
@@ -4824,6 +4846,36 @@ mod tests {
         assert_eq!(target[(3, 2)].symbol(), "C");
         assert_eq!(target[(4, 2)].symbol(), "D");
         assert_eq!(target[(2, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn blitting_a_pane_rect_wider_than_the_frame_clamps_instead_of_panicking() {
+        // A rect measured before the terminal shrank: the release build used to
+        // panic here in Buffer::index_of and take the whole process down.
+        let mut source = Buffer::empty(Rect::new(0, 0, 4, 3));
+        for x in 0..4 {
+            for y in 0..3 {
+                source[(x, y)].set_symbol("S");
+            }
+        }
+        let mut target = Buffer::empty(Rect::new(0, 0, 3, 2));
+
+        blit_buffer(&source, &mut target, Rect::new(2, 1, 4, 3));
+
+        assert_eq!(target[(2, 1)].symbol(), "S");
+        assert_eq!(target[(0, 0)].symbol(), " ");
+    }
+
+    #[test]
+    fn blitting_a_pane_rect_fully_outside_the_frame_is_a_no_op() {
+        let mut source = Buffer::empty(Rect::new(0, 0, 2, 2));
+        source[(0, 0)].set_symbol("S");
+        let mut target = Buffer::empty(Rect::new(0, 0, 4, 4));
+        let untouched = target.clone();
+
+        blit_buffer(&source, &mut target, Rect::new(9, 9, 2, 2));
+
+        assert_eq!(target, untouched);
     }
 
     #[test]


### PR DESCRIPTION
## Why

GridBash was dying outright — every pane at once, no error anywhere. Investigating a live crash turned up no Windows Error Reporting entry, no minidump, and no log: the process had simply vanished. That is the signature of an unwinding Rust panic, which exits with status 101 and prints to a terminal that is usually gone a moment later.

Three separate problems, found while chasing one crash.

## 1. The crash: `blit_buffer` had no release-mode guard

`blit_buffer` asserted all three of its preconditions with `debug_assert_eq!`, which are compiled out of release builds. The third — the pane rect being fully inside the frame buffer — is the one that can legitimately vary at runtime: a rect measured before the terminal shrinks lands outside the newly-resized frame, and `ratatui`'s `Buffer::index_of` panics outright on an out-of-range position.

Now clamps to the region both buffers actually cover, so a stale rect drops cells for one frame instead of aborting the process. The two asserts that are genuine invariants of `refresh_screen_cache` are kept.

## 2. Nothing was recorded when it happened

New `diagnostics` module writes a report to `<data-dir>/logs/` naming the role, version, pid, thread, panic message, **source file and line**, and a backtrace — keeping the newest 50. Installed before anything else can fail; `App::run` chains its terminal-restoring hook onto it, so the TUI and every pane-host process both report without either needing to know about the other.

This is what makes the next crash diagnosable instead of invisible.

## 3. Pane hosts leaked, holding a pseudoconsole

A pane host only exited when it had no client *and* `keep_running` was false. When the owning GridBash died abruptly, socket EOF cleared the client but `keep_running` stayed `true` — so the host looped forever even though its PTY child had already exited. Hosts were found alive for **4+ hours** with no child process and a dead parent.

Now exits once the child is gone (no session left to resume), and once the owner has vanished with no replacement reattaching within a grace period. The grace preserves session recovery across a crash and relaunch.

## Testing

- `cargo test`: **296 passed, 0 failed**, including the two existing pane-host lifecycle tests most at risk from change 3 (`pane_host_survives_disconnect_and_accepts_reattach`, `pane_host_replaces_a_client_owned_by_a_dead_process`)
- `cargo clippy --all-targets`: no issues
- `cargo fmt --check`: clean
- New coverage: oversized and fully-offscreen blits; four cases for the detached-host exit decision; an end-to-end test asserting a real panic writes a report naming its own file and line