### PR TITLE
feat: rework the main TUI chrome and pane renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,15 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,23 +151,8 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -292,7 +268,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -337,7 +313,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -487,7 +463,6 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -516,16 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csscolorparser"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
-dependencies = [
- "lab",
- "phf",
-]
-
-[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +510,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -556,7 +521,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -564,12 +529,6 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
-
-[[package]]
-name = "deltae"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
@@ -596,7 +555,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -648,7 +607,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -689,23 +648,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "euclid"
-version = "0.22.14"
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
-]
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "fancy-regex"
-version = "0.11.0"
+name = "fallible-streaming-iterator"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fast-srgb8"
@@ -740,18 +692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "finl_unicode"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,10 +702,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -892,7 +832,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -929,6 +869,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -942,13 +883,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -959,7 +909,16 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -967,12 +926,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1238,7 +1191,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1304,7 +1257,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1332,7 +1285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1356,12 +1309,6 @@ dependencies = [
  "portable-atomic",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "lab"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1398,6 +1345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1458,16 +1416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac_address"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
-dependencies = [
- "nix 0.29.0",
- "winapi",
-]
-
-[[package]]
 name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,21 +1426,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memmem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1574,19 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,7 +1530,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1641,7 +1561,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1762,15 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,7 +1702,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1822,100 +1733,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
-dependencies = [
- "pest",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1961,7 +1778,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.28.0",
+ "nix",
  "serial2",
  "shared_library",
  "shell-words",
@@ -1991,7 +1808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2053,7 +1870,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand 0.10.2",
+ "rand",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2103,29 +1920,14 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2139,7 +1941,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2151,9 +1953,6 @@ dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
- "ratatui-macros",
- "ratatui-termina",
- "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
 ]
@@ -2190,37 +1989,6 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
-]
-
-[[package]]
-name = "ratatui-macros"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
-dependencies = [
- "ratatui-core",
- "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-termina"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
-dependencies = [
- "instability",
- "ratatui-core",
- "termina",
-]
-
-[[package]]
-name = "ratatui-termwiz"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
-dependencies = [
- "ratatui-core",
- "termwiz",
 ]
 
 [[package]]
@@ -2347,6 +2115,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,7 +2251,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2610,12 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2449,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2681,17 +2457,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -2721,83 +2486,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "termina"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
-dependencies = [
- "bitflags 2.13.0",
- "parking_lot",
- "rustix",
- "signal-hook",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "terminfo"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
-dependencies = [
- "fnv",
- "nom",
- "phf",
- "phf_codegen",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "termwiz"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
-dependencies = [
- "anyhow",
- "base64",
- "bitflags 2.13.0",
- "fancy-regex",
- "filedescriptor",
- "finl_unicode",
- "fixedbitset",
- "hex",
- "lazy_static",
- "libc",
- "log",
- "memmem",
- "nix 0.29.0",
- "num-derive",
- "num-traits",
- "ordered-float",
- "pest",
- "pest_derive",
- "phf",
- "sha2",
- "signal-hook",
- "siphasher",
- "terminfo",
- "termios",
- "thiserror 1.0.69",
- "ucd-trie",
- "unicode-segmentation",
- "vtparse",
- "wezterm-bidi",
- "wezterm-blob-leases",
- "wezterm-color-types",
- "wezterm-dynamic",
- "wezterm-input-types",
- "winapi",
+ "syn",
 ]
 
 [[package]]
@@ -2826,7 +2515,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2837,7 +2526,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -2897,19 +2586,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -3059,12 +2736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,16 +2795,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.23.4"
+name = "vcpkg"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
-dependencies = [
- "atomic",
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3160,15 +2825,6 @@ checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
  "memchr",
-]
-
-[[package]]
-name = "vtparse"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
-dependencies = [
- "utf8parse",
 ]
 
 [[package]]
@@ -3247,7 +2903,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3294,78 +2950,6 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "wezterm-bidi"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
-dependencies = [
- "log",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-blob-leases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
-dependencies = [
- "getrandom 0.3.4",
- "mac_address",
- "sha2",
- "thiserror 1.0.69",
- "uuid",
-]
-
-[[package]]
-name = "wezterm-color-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
-dependencies = [
- "csscolorparser",
- "deltae",
- "lazy_static",
- "wezterm-dynamic",
-]
-
-[[package]]
-name = "wezterm-dynamic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
-dependencies = [
- "log",
- "ordered-float",
- "strsim",
- "thiserror 1.0.69",
- "wezterm-dynamic-derive",
-]
-
-[[package]]
-name = "wezterm-dynamic-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "wezterm-input-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
-dependencies = [
- "bitflags 1.3.2",
- "euclid",
- "lazy_static",
- "serde",
- "wezterm-dynamic",
-]
 
 [[package]]
 name = "whisper-rs"
@@ -3473,7 +3057,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3484,7 +3068,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -3667,7 +3251,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -3688,7 +3272,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "synstructure",
 ]
 
@@ -3728,7 +3312,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,19 @@ categories = ["command-line-utilities", "development-tools"]
 anyhow = "1.0"
 base64 = "0.22"
 clap = { version = "4.5", features = ["derive"] }
-crossterm = { version = "0.29", features = ["event-stream"] }
+crossterm = "0.29"
 directories = "6.0"
 fs4 = "1.1"
 getrandom = "0.3"
 image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 portable-pty = "0.9"
-ratatui = "0.30"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm", "layout-cache"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shell-words = "1.1"
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.48", features = ["sync"] }
 toml = "0.9"
 vt100 = "0.16"
 
@@ -37,4 +38,11 @@ whisper-rs = "0.16"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
+
+[profile.release]
+codegen-units = 1
+lto = "thin"
+# Crash reports capture a backtrace. Keep the symbol table so its frames are
+# named instead of bare addresses; the heavier debug info is still stripped.
+strip = "debuginfo"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ use that release's matching native artifact until npm publication catches up.
 
 - **Precise input routing.** Type into the focused pane, a selected set, or the
   entire grid.
-- **Managed agent launch.** Choose the agent, auth profile, project, layout, and
-  worktree policy before GridBash starts any panes.
+- **Four-field launch.** Rows, columns, a grid name, and a project folder with
+  Tab completion. Worktrees and the shell profile are assumed for you.
 - **Real terminals underneath.** Run up to 100 PTY-backed panes across tabbed
   grids, with raw shell grids still available as a secondary path.
 - **Safer parallel work.** Give every pane an isolated repo-local git worktree.
@@ -67,6 +67,7 @@ use that release's matching native artifact until npm publication catches up.
 | `gridbash 2x3 --profile codex --worktrees` | Isolate every pane in a git worktree |
 | `gridbash resume` | Choose a saved session to reopen |
 | `gridbash resume --latest` | Reopen the latest saved session |
+| `gridbash resume <id> --delete` | Permanently delete a saved session |
 | `gridbash ctl list --json` | Discover opted-in running grids |
 | `gridbash ctl panes --session ID` | Inspect numbered and stable pane identities |
 | `gridbash --list-profiles` | Show detected profiles and resolved commands |
@@ -85,15 +86,20 @@ agents and shells.
 | --- | --- |
 | Drag mouse | Select and copy text inside one pane |
 | Right-click pane | Add or remove the pane from the selected set |
+| Left-click grid tab | Switch directly to that grid |
+| Right-click grid tab | Add or remove the grid from the selected set |
 | `Alt+k` | Search and run GridBash commands |
 | `Alt` + arrow keys | Move focus between panes |
 | `Alt+s` / `Alt+a` | Toggle the focused pane / select or clear all panes |
+| `Alt+Shift+s` / `Alt+x` | Select the current grid / swap two selected grids |
 | `Alt+c` | Open or close the command line |
 | `Alt+Shift+C` | Save bounded recent output from the target panes |
 | `Alt+Shift+L` | Start or stop continuous target-pane logging |
 | `Alt+d` | Chat with BashBot across all open grids and panes |
 | `Alt+n` / `Alt+t` | Open a new tab / switch tabs |
+| `Alt+w` | Open the current-grid close confirmation |
 | `Alt+p` | Open focused-pane activity |
+| `Ctrl+Alt+p` | Inspect and stop localhost ports launched by agents |
 | `Alt+Shift+A` | Manage auth profiles and assign one to the focused pane |
 | `Alt+f` | Zoom or restore the focused pane |
 | `Alt+b` | Search, select, and copy focused-pane scrollback |
@@ -102,7 +108,7 @@ agents and shells.
 | `Alt+Shift+V` | Dictate one prompt without submitting it |
 | `Alt+o` | Open settings |
 | `Alt+h` or `F1` | Open the full in-app shortcut guide |
-| `Alt+q` | Quit |
+| `Alt+q` | Show the quit confirmation and exact resume command |
 
 See the [full controls reference](docs/REFERENCE.md#controls) for resizing,
 renaming, sleeping, restarting, scrolling, settings, and recovery actions.
@@ -111,6 +117,16 @@ To keep live terminals running after GridBash closes, open Settings with
 `Alt+o` and enable **Keep terminals running**. GridBash returns control to the
 launching shell when you quit; reconnect later with `gridbash resume --latest`
 or select the session with `gridbash resume`.
+
+Running Codex panes are also saved by conversation ID. If their live terminal
+cannot survive a restart or laptop shutdown, `gridbash resume` relaunches them
+with `codex resume <conversation-id>` instead of opening an empty Codex pane.
+
+`Alt+q` snapshots the current workspace and opens a confirmation with the full
+`gridbash resume <session-id>` command for that exact setup. Press `Alt+q` again
+to close GridBash, or any other key to cancel. The same command is printed after
+GridBash returns to the launching shell. Quit confirmation is enabled by default
+and can be disabled in Settings.
 
 If the terminal or GridBash process closes unexpectedly, the next plain
 `gridbash` launch automatically recovers unfinished agent sessions. Saved panes
@@ -121,11 +137,12 @@ start the workspace you requested, and older snapshots remain available through
 
 ## Profiles and configuration
 
-A bare `gridbash` opens the agent-workspace setup. Detected agent profiles are
-listed first; choose a compatible managed auth profile, project folder, grid
-dimensions, and optional worktree isolation, then launch. Built-in shell
-profiles remain available in the same screen as clearly labeled raw-terminal
-options.
+A bare `gridbash`, or `Alt+n` in a running workspace, opens the new-grid screen.
+It asks for rows, columns, a grid name, and a project folder with Tab
+completion, then launches. Managed worktrees are on whenever the repository can
+host them, and panes start in the platform shell (Git Bash on Windows). Choose
+agents per pane afterwards, or launch them straight from the CLI with
+`--profile`.
 
 Managed auth applies to Claude or Codex processes GridBash launches. GridBash
 does not install global shims, replace the normal `codex` or `claude` commands,

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,7 @@ pane_workload = "adaptive"
 [ui]
 compact_titles = false
 activity_badges = true
-confirm_quit = false
+confirm_quit = true
 # Leave live pane processes in local background hosts when the UI closes.
 keep_terminals_running = false
 scrollback_rows = 10000

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -326,7 +326,7 @@ Output capture writes the same bounded, ANSI-stripped pane tail used for session
 context. Continuous logging appends only new PTY output; submitted input,
 environment variables, and sibling panes are never added separately. With
 multiple selected panes, capture and logging create one file per selected pane;
-otherwise they target the focused pane. Active logs show a `logging` pane badge.
+otherwise they target the focused pane. Active logs show a `rec` pane badge.
 Default collision-safe files live under GridBash's platform-local data `output`
 directory, and every operation reports its resolved path. Agent API capture and
 start-log calls may provide an explicit output directory. A write failure stops
@@ -390,7 +390,9 @@ customize `command-line` instead.
 
 The resize picker starts from the current dimensions and shows each existing pane's latest activity summary when one is available. Shrinking a grid deactivates live panes outside the retained upper-left rectangle; changing `3x3` to `3x2`, for example, removes the rightmost column.
 
-A pane's top border shows a stable activity state by default. Opt-in AI activity summaries replace that state with a concise work headline after output settles; GridBash never uses raw typing or terminal UI fragments as the displayed summary. A configured manager goal replaces pane summaries across the grid until removed. A quiet marker appears after roughly three seconds without output; it indicates output followed by inactivity, not completion or process exit. Saving a blank pane name restores its default number.
+A pane's top border carries its number and name on the left and its state on the right. Opt-in AI activity summaries add a concise work headline after the name once output settles; GridBash never uses raw typing or terminal UI fragments as the displayed summary. A configured manager goal replaces pane summaries across the grid until removed. Saving a blank pane name restores its default number.
+
+The state on the right is whichever one matters most: `exited`, `asleep`, `needs you`, or `idle`. `needs you` marks an agent pane that has stopped producing output for roughly three seconds, which is how an agent asks for input — it indicates output followed by inactivity, not completion or process exit. A non-agent pane that goes quiet reads `idle` instead. As a pane narrows, its header drops its usage figure first, then its activity summary; the number, name, and state are kept. Focused and selected panes are marked by a filled number chip and a coloured border, which outrank a pane's own state.
 
 ## Voice mode
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -4,13 +4,31 @@ This guide covers launch options, sessions, managed worktrees, controls, profile
 configuration, and platform-specific behavior. See the [project
 README](../README.md) for installation and a shorter introduction.
 
-## Create an agent workspace
+## Create a grid
 
-Run `gridbash` with no arguments to open the agent-workspace setup. It detects
-installed agent and terminal profiles and lets you choose the launch profile,
-compatible Claude/Codex auth, project folder, layout, and worktree isolation.
-Agent profiles appear first. Shell profiles remain available as explicitly
-unmanaged raw-terminal grids.
+Run `gridbash` with no arguments, or press `Alt+n` inside a running workspace,
+to open the new-grid screen. It asks for four things and decides the rest:
+
+| Field | Meaning |
+| --- | --- |
+| Rows | 1-10 rows of panes. |
+| Columns | 1-10 columns of panes. |
+| Name | Tab title for this grid. Blank falls back to `Grid N`. |
+| Project | Folder the panes start in, with Tab completion. |
+
+Everything else is assumed so there is nothing else to answer:
+
+- **Worktrees are on** whenever the project is a git repository with a commit
+  and no tracked modifications. The screen names the exact branches it will
+  create and falls back to the shared project folder — saying why — when the
+  repository cannot host them. `Alt+w` overrides the choice.
+- **Panes run the platform shell**: Git Bash on Windows, otherwise the first
+  available of zsh, bash, fish, sh, or PowerShell. `GRIDBASH_PROFILE`, a
+  non-agent `--set-default` profile, and `--profile` still win. Pick agents per
+  pane once the grid is up, or launch them directly with `--profile`.
+
+A live preview shows the grid that is about to exist, one cell per pane, each
+labelled with the managed branch it will check out.
 
 Common direct launches:
 
@@ -45,29 +63,33 @@ The main launch options are:
 | `--agent-api-port PORT` | Choose the port for the enabled API; `0` selects a free port. A nonzero value also enables the API. |
 
 Grid, count, profile, cwd, or auto-layout arguments use the direct launch path
-and bypass workspace setup. `gridbash --worktrees` by itself opens setup with
-worktree isolation enabled.
+and bypass the new-grid screen. `gridbash --worktrees` by itself opens it with
+the managed worktree prefix from `--worktree-prefix`.
 
-Set the initial agent selection or direct-launch default with:
+Set the direct-launch default profile with:
 
 ```powershell
 gridbash --set-default codex
 ```
 
-An older configured shell default remains valid for direct launches, but bare
-interactive startup leads with the first detected agent. Select a raw terminal
-in workspace setup when that is the intended workflow.
-
-### Workspace setup controls
+### New-grid controls
 
 | Input | Action |
 | --- | --- |
-| Up / Down | Move between profile, auth, layout, worktrees, and project fields. |
-| Left / Right | Change the selected field. |
-| `w` | Toggle managed worktrees. |
-| `e` | Edit the project folder while the Project field is selected. |
-| Enter | Confirm a project edit or launch the workspace. |
-| Esc / `q` | Quit. |
+| Up / Down | Move between the four fields. |
+| Left / Right | Resize on Rows and Columns; move the cursor in Name and Project. |
+| `0`-`9` | Set the focused dimension directly; `0` means 10. |
+| Tab | Complete the project path, or move to the next field. |
+| Tab again | Cycle the remaining folder matches. |
+| Ctrl+w / Ctrl+u | Delete the previous path segment / clear the field. |
+| Alt+w | Override managed worktrees for this grid. |
+| Enter | Launch, from any field. |
+| Esc / Ctrl+c | Cancel. |
+
+Project completion works like a shell: the first Tab extends to the prefix every
+candidate shares, and later presses walk the candidates. The panel below lists
+the folders next to the current path so nearby projects are one keystroke away.
+`~` expands to the home directory.
 
 Managed auth is a launch boundary, not a global shell hook. GridBash sets
 `CLAUDE_CONFIG_DIR` or `CODEX_HOME` for compatible agent panes it launches. It
@@ -77,27 +99,42 @@ terminal panes retain their normal shell environment.
 ## Sessions and resume
 
 GridBash writes bounded session snapshots to local app data when grids launch,
-while they run, and when they exit. Resume interactively, resume the latest
-snapshot, list snapshots, or select a session by its full ID or unique prefix:
+when persisted state changes while they run, and when they exit. Resume
+interactively, resume the latest snapshot, list snapshots, or select a session
+by its full ID or unique prefix:
 
 ```powershell
 gridbash resume
 gridbash resume --latest
 gridbash resume --list
 gridbash resume <session-id>
+gridbash resume <session-id> --delete
 ```
+
+`Alt+q` saves a fresh snapshot and shows a quit confirmation containing the
+full command for that specific session. Press `Alt+q` again to quit or any other
+key to cancel. After a confirmed quit, GridBash prints the command again in the
+launching shell so it remains easy to copy. Confirmation is enabled by default;
+set `ui.confirm_quit = false` or turn it off in Settings to skip the dialog.
 
 A snapshot restores grid dimensions, pane profiles, working directories,
 worktree names, auth assignments, and a pane-local view of recent submitted
 commands and output. By default, resume starts new child terminals and does not
 replay old commands into a shell.
 
+For a pane that is actively running Codex, the snapshot also stores the Codex
+conversation ID. If its live pane host is unavailable after a restart or laptop
+shutdown, GridBash relaunches that pane with `codex resume <conversation-id>`.
+This applies both to Codex profiles and to Codex launched inside a GridBash
+shell; unrelated shell commands remain view-only and are never replayed.
+
 Enable **Keep terminals running** in Settings to detach live pane hosts when the
 GridBash UI closes. `gridbash resume` then reconnects to the same PTYs; output
 produced while detached is added to the restored view. If a host is no longer
 available, GridBash starts a replacement terminal and retains the saved context.
 The background hosts are local, authenticated, and accept one GridBash client at
-a time.
+a time. Resuming a saved session atomically claims it before terminals launch,
+so a second client cannot duplicate or overwrite the same workspace.
 
 Session snapshots record whether their GridBash owner is still running and
 whether it exited cleanly. On a plain `gridbash` launch, snapshots left by a
@@ -106,6 +143,12 @@ visible, tabbed, and background panes by working directory, names each recovered
 tab after the directory, and preserves the bounded command/output context. It
 does not claim sessions owned by another live GridBash process. Use `Alt+t` to
 cycle through the recovered tabs.
+
+In the interactive resume picker, press Delete twice to permanently remove the
+selected snapshot. Deleting a detached session first stops its saved terminal
+hosts; a session owned by a live GridBash process cannot be deleted. The
+`--delete` form provides the same behavior for scripts and requires a full
+session ID or unique prefix.
 
 Automatic recovery only applies to a plain launch. Grid, profile, count, cwd,
 worktree, layout, and agent-API launch options take precedence, while every
@@ -212,15 +255,19 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | --- | --- |
 | Drag mouse | Select terminal text inside the pane where the drag began and copy it on release. |
 | Right-click pane | Add or remove that pane from the selected set. |
+| Left-click grid tab | Switch directly to that grid. |
+| Right-click grid tab | Add or remove that grid from the selected set. Ctrl-click and Shift-click work too. |
 | Mouse wheel | Scroll only the pane under the pointer; selected panes use GridBash scrollback. |
 | Alt+k | Open the searchable command palette. Type to filter, use Up/Down to select, and press Enter to run an action. |
 | Alt+Left / Alt+Right | Focus the previous or next pane in the row, wrapping at the edge. |
 | Alt+Up / Alt+Down | Focus the pane above or below, wrapping at the edge. |
 | Alt+l | Resize the current grid. |
-| Alt+x | Swap the two selected panes. |
-| Alt+n | Open the startup picker and launch a new tab. |
+| Alt+x | Swap two selected grids when any grids are selected; otherwise swap the two selected panes. |
+| Alt+n | Open the new-grid screen and launch another tab. |
 | Alt+t | Switch to the next tab. |
+| Alt+w | Open the current-grid close confirmation. |
 | Alt+s | Toggle selection of the focused pane. |
+| Alt+Shift+s | Toggle selection of the current grid. |
 | Alt+a | Select all panes, or clear the set when all are selected. |
 | Alt+c | Open or close the expanded command line. |
 | Alt+Shift+C | Save bounded recent plain-text output from the focused or selected panes. |
@@ -231,6 +278,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+Shift+V | Dictate one utterance, or cancel active listening. |
 | Alt+h / F1 | Open or close help. |
 | Alt+p | Open the focused-pane activity summary. |
+| Ctrl+Alt+p | Open the agent port inspector. |
 | Alt+Shift+P | Open the previous-panes list. |
 | Alt+Shift+A | Open Auth Profiles to manage accounts or assign one to the focused pane. |
 | Alt+Shift+B | Move selected panes, or the focused pane, into the background and launch fresh replacements. |
@@ -243,7 +291,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+g | Create or edit the current grid's manager goal. |
 | Alt+u | Stop the current grid's manager goal. |
 | Alt+o | Open settings. |
-| Alt+q | Quit. |
+| Alt+q | Save the workspace and open quit confirmation with its exact resume command. |
 
 Drag selection is contained to its source pane and copies through the standard OSC 52 clipboard sequence. Use `--no-mouse` if the host terminal, serial link, or multiplexer cannot forward mouse reporting.
 
@@ -272,7 +320,16 @@ Alt+D opens BashBot in a compact dock at the bottom-right. BashBot uses bounded,
 
 The command palette lists the available pane, tab, grid, manager, settings, help, and quit actions together with their configured shortcuts. Its query supports tolerant subsequence matching, pasted Unicode text, and cursor editing. Palette input is never sent to a child terminal; press Esc or the configured command-palette shortcut to close it without running anything.
 
+The close-grid confirmation names the grid, reports its pane count, and requires
+Enter or Y before GridBash terminates all of its visible panes, even when **Keep
+terminals running** is enabled. Escape or N cancels. After confirmation,
+GridBash removes the tab and activates the next grid or the previous grid when
+the closed one was last. GridBash never closes the only remaining grid; use
+Alt+q to quit the workspace. Managed worktrees and their branches are preserved.
+
 Pane Activity provides auth, rename, refresh, sleep/wake, deactivate, and manager-goal controls. Navigate with Up/Down and activate with Enter or Space. Direct keys inside the view are `n` to rename, `r` to refresh, `z` to sleep or wake, `d` to deactivate, `g` to edit the grid goal, and `u` to stop it. Close it with Esc, `q`, or Alt+p; Alt+Shift+A opens Auth Profiles and Alt+o switches to overall settings.
+
+The bottom-right **Ports** control shows the most recent count of TCP listeners launched inside GridBash agent process trees. Click it or press Ctrl+Alt+p to scan and see each port, process name, PID, and owning pane or tab. Use Up/Down to select a listener, `R` to refresh, and Enter or Delete followed by Enter to terminate its process. Scanning is paused while the inspector is closed. GridBash excludes unrelated system listeners and its own pane-host control sockets from this view.
 
 Deactivating a pane ends its terminal process, compacts the remaining panes, and shrinks the grid whenever a smaller dimension can still hold them. Columns are removed before rows, so deactivating two panes from a `2x3` grid compacts it to `2x2`. The final pane cannot be deactivated.
 
@@ -295,9 +352,9 @@ settings = "f8"
 ```
 
 Supported actions are `quit`, `help`, `focus-left`, `focus-right`, `focus-up`,
-`focus-down`, `toggle-selection`, `select-all`, `sleep-panes`, `restart-panes`,
-`next-tab`, `new-tab`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
-`command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`,
+`focus-down`, `toggle-selection`, `toggle-grid-selection`, `select-all`, `sleep-panes`, `restart-panes`,
+`next-tab`, `new-tab`, `close-grid`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
+`command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`, `ports`,
 `pane-activity`, `copy-mode`, `auth-profiles`, `capture-output`,
 `toggle-output-logging`, `rename-tab`, and `rename-pane`. Unlisted actions retain their
 defaults. Duplicate chords and unmodified terminal keys are rejected. F1 and
@@ -405,7 +462,7 @@ pane_workload = "adaptive"     # or "unrestricted"
 [ui]
 compact_titles = false
 activity_badges = true
-confirm_quit = false
+confirm_quit = true
 keep_terminals_running = false
 scrollback_rows = 10000
 refresh_ms = 16

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -16,11 +16,14 @@ fn search_keywords(action: Action) -> &'static str {
         Action::ZoomPane => "maximize fullscreen restore",
         Action::RestartPanes => "exited dead",
         Action::PreviousPanes => "history list switch",
+        Action::CloseGrid => "remove delete tab workspace terminate",
+        Action::Ports => "localhost server listener process pid terminate",
         Action::VoiceInput => "microphone speech",
         Action::AuthProfiles => "accounts credentials profiles",
         Action::CaptureOutput | Action::ToggleOutputLogging => "save terminal logs",
         Action::CopyMode => "scrollback clipboard search",
         Action::BackgroundPanes | Action::BackgroundJobs => "agents pool stash restore swap",
+        Action::SwapPanes => "reorder grids tabs rearrange",
         Action::BashBot => "assistant brief delegate coordinate",
         _ => "",
     }
@@ -66,6 +69,8 @@ mod tests {
         assert!(fuzzy_match_score("rn pane", Action::RenamePane).is_some());
         assert!(fuzzy_match_score("orchestrate", Action::EditGoal).is_some());
         assert!(fuzzy_match_score("tab next", Action::NextTab).is_some());
+        assert!(fuzzy_match_score("delete grid", Action::CloseGrid).is_some());
+        assert!(fuzzy_match_score("reorder grids", Action::SwapPanes).is_some());
         assert!(fuzzy_match_score("unrelated", Action::NextTab).is_none());
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -9873,6 +9873,23 @@ impl App {
         self.sleeping.contains(&index)
     }
 
+    /// True when an agent pane has gone quiet, which is how an agent signals it
+    /// is waiting on the user.
+    pub fn pane_needs_input(&self, index: usize) -> bool {
+        let Some(pane) = self.panes.get(index) else {
+            return false;
+        };
+        pane_needs_user_input(
+            self.launch_plan
+                .as_ref()
+                .and_then(|plan| plan.panes.get(index))
+                .is_some_and(PaneLaunchSpec::is_agent),
+            self.sleeping.contains(&index),
+            pane.exited,
+            pane.output_quiet(),
+        )
+    }
+
     pub fn pane_logging(&self, index: usize) -> bool {
         self.panes.get(index).is_some_and(|pane| {
             self.output_logs

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use std::process::Stdio;
 
 use anyhow::{Context, Result, anyhow};
 use crossterm::{
+    cursor::Show,
     event::{
         self, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
         EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
@@ -33,6 +34,7 @@ use crate::{
     actions::{fuzzy_match_score, palette_actions, palette_label},
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
+    diagnostics,
     composer::{Composer, GridPicker, GridPickerAction},
     config::{Config, PaletteColor, PaneWorkloadPolicy, UiConfig, UiPalette},
     control::{
@@ -46,12 +48,13 @@ use crate::{
     manager::{self, ActivitySummary, AssistantReply, ManagerCommand, ManagerDecision},
     output_capture::{self, OutputLogs, PaneLogKey},
     pane_host::{PaneHostBusy, PaneHostIncompatible, PaneHostRejected, PtyHostRef, PtyPane},
+    ports::{self, AgentPort, AgentProcessRoot},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile, is_terminal_profile, startup_profiles},
     pty::{PtyEvent, PtyWriteToken},
     session::{
-        InterruptedRecovery, SavedBackgroundPane, SavedPane, SavedPaneHistory, SavedTab,
-        SessionRecord, SessionRecorder,
+        InterruptedRecovery, InterruptedRecoveryClaim, SavedBackgroundPane, SavedPane,
+        SavedPaneHistory, SavedTab, SessionRecord, SessionRecorder, complete_interrupted_recovery,
     },
     setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
     ui,
@@ -63,12 +66,23 @@ use crate::{
 pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 
 const INPUT_POLL_INTERVAL: Duration = Duration::from_millis(16);
+/// How many panics and errors one minute of the event loop may recover from
+/// before the session exits instead. Panics get the smaller allowance: an error
+/// is often a transient failure to reach the disk or a subprocess, while a panic
+/// means state the code did not expect.
+const MAX_RECOVERED_PANICS: u32 = 8;
+const MAX_RECOVERED_LOOP_ERRORS: u32 = 32;
+/// Windows consoles deliver a paste as synthetic keystrokes instead of a
+/// bracketed paste, so a burst has to be stitched back together by hand.
+const PASTE_BURST_GAP: Duration = Duration::from_millis(4);
+const PASTE_BURST_MAX_BYTES: usize = 256 * 1024;
 const LARGE_GRID_FRAME_INTERVAL: Duration = Duration::from_millis(33);
 const PTY_EVENT_CHANNEL_CAPACITY: usize = 256;
 const PTY_DRAIN_MAX_EVENTS: usize = 64;
 const PTY_DRAIN_MAX_BYTES: usize = 512 * 1024;
 const PTY_DRAIN_MAX_TIME: Duration = Duration::from_millis(4);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const PORT_SCAN_INTERVAL: Duration = Duration::from_secs(2);
 const SESSION_AUTOSAVE_INTERVAL: Duration = Duration::from_secs(5);
 const PANE_GOAL_OUTPUT_MAX_BYTES: usize = 12_000;
 const PANE_GOAL_REVIEW_IDLE: Duration = Duration::from_secs(2);
@@ -103,6 +117,7 @@ pub struct App {
     worktrees: Option<ManagedWorktreeOptions>,
     tabs: Vec<Option<GridTabSnapshot>>,
     active_tab: usize,
+    selected_grids: BTreeSet<usize>,
     tab_title: String,
     launch_plan: Option<LaunchPlan>,
     layout: GridLayout,
@@ -145,12 +160,16 @@ pub struct App {
     grid_resizer: Option<GridPicker>,
     help_open: bool,
     quit_confirmation_pending: bool,
+    close_grid_confirmation_pending: bool,
     settings: SettingsState,
     rename: RenamePaneState,
     tab_rename: RenameTabState,
     previous_panes: PreviousPanesState,
     background_jobs: Vec<BackgroundJob>,
     background_picker: BackgroundPickerState,
+    port_inspector: PortInspectorState,
+    port_scan_tx: std_mpsc::Sender<Result<Vec<AgentPort>, String>>,
+    port_scan_rx: std_mpsc::Receiver<Result<Vec<AgentPort>, String>>,
     follow_up: Option<FollowUpPromptState>,
     auth_profiles: Vec<AuthProfile>,
     auth_refresh_rx: Option<std_mpsc::Receiver<Result<Vec<AuthProfile>, String>>>,
@@ -160,10 +179,12 @@ pub struct App {
     restored_hosts: Vec<Option<PtyHostRef>>,
     restored_tabs: Vec<SavedTab>,
     session_recorder: Option<SessionRecorder>,
+    interrupted_recovery_claim: Option<InterruptedRecoveryClaim>,
     output_logs: OutputLogs,
     next_pane_id: usize,
     next_background_job_id: u64,
     next_tab_number: usize,
+    tab_rects: Vec<(usize, Rect)>,
     previous_panes_button: Option<Rect>,
     previous_pane_rows: Vec<(usize, Rect)>,
     pane_settings_button: Option<Rect>,
@@ -175,8 +196,11 @@ pub struct App {
     pane_settings_stop_goal_button: Option<Rect>,
     background_jobs_button: Option<Rect>,
     background_job_rows: Vec<(usize, Rect)>,
+    ports_button: Option<Rect>,
+    port_rows: Vec<(usize, Rect)>,
     event_tx: mpsc::Sender<PtyEvent>,
     event_rx: mpsc::Receiver<PtyEvent>,
+    pane_routes_scratch: HashMap<(PaneId, u64), PaneRoute>,
     pane_render_cache: RefCell<HashMap<PaneId, ui::PaneRenderCache>>,
     applied_workloads: HashMap<PaneId, (PaneWorkloadPolicy, PaneWorkloadClass)>,
     terminal_focused: bool,
@@ -207,6 +231,7 @@ struct AppInit {
     restored_hosts: Vec<Option<PtyHostRef>>,
     restored_tabs: Vec<SavedTab>,
     session_recorder: Option<SessionRecorder>,
+    interrupted_recovery_claim: Option<InterruptedRecoveryClaim>,
     status: String,
 }
 
@@ -235,6 +260,28 @@ struct BackgroundJob {
     host: Option<PtyHostRef>,
     history: SavedPaneHistory,
     idle: PaneIdleState,
+}
+
+fn retire_pane(pane: &mut PtyPane) -> Result<()> {
+    let policy_result = pane.set_keep_running(false);
+    let termination_result = pane.terminate();
+    match (policy_result, termination_result) {
+        (_, Ok(())) => Ok(()),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(policy_error), Err(termination_error)) => Err(termination_error.context(format!(
+            "failed to disable pane-host persistence first: {policy_error:#}"
+        ))),
+    }
+}
+
+fn retire_panes<'a>(panes: impl IntoIterator<Item = &'a mut PtyPane>) -> Result<()> {
+    let mut first_error = None;
+    for pane in panes {
+        if let Err(error) = retire_pane(pane) {
+            first_error.get_or_insert(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
 }
 
 impl BackgroundJob {
@@ -282,6 +329,8 @@ impl BackgroundJob {
 pub struct TabLabel {
     pub title: String,
     pub active: bool,
+    pub selected: bool,
+    pub waiting: bool,
     pub activity: bool,
     pub exited: bool,
 }
@@ -292,6 +341,13 @@ enum KeyOutcome {
     Render,
     AuthLogin(AuthProfile),
     Quit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloseGridConfirmationAction {
+    Confirm,
+    Cancel,
+    Continue,
 }
 
 #[derive(Debug, Clone)]
@@ -908,6 +964,18 @@ pub struct FollowUpDialog {
     pub todo_position: usize,
     pub todo_count: usize,
     pub quiet_seconds: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct QuitConfirmationView {
+    pub resume_command: String,
+    pub keeps_terminals_running: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloseGridConfirmationView {
+    pub title: String,
+    pub pane_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1723,7 +1791,7 @@ impl Default for SettingsState {
             create_auth: None,
             compact_titles: false,
             activity_badges: true,
-            confirm_quit: false,
+            confirm_quit: UiConfig::default_confirm_quit(),
             keep_terminals_running: false,
             idle_followups: true,
             idle_seconds: crate::config::TodoSettings::default_idle_seconds(),
@@ -2060,13 +2128,19 @@ impl SettingsState {
                     .filter(|edit| edit.target == target)
                     .map(|edit| edit.buffer.as_str())
                     .unwrap_or_else(|| match target {
-                        ManagerSettingTarget::ActivitySummaries => unreachable!(),
+                        // Handled by the early return above; an empty value keeps
+                        // the row renderable instead of panicking mid-frame.
+                        ManagerSettingTarget::ActivitySummaries => "",
                         ManagerSettingTarget::Endpoint => config.endpoint.as_str(),
                         ManagerSettingTarget::Model => config.model.as_str(),
                         ManagerSettingTarget::ApiKey => config.api_key.as_str(),
                     });
                 let (label, value, hint) = match target {
-                    ManagerSettingTarget::ActivitySummaries => unreachable!(),
+                    ManagerSettingTarget::ActivitySummaries => (
+                        "AI activity summaries",
+                        switch_value(config.activity_summaries),
+                        "sends bounded active-tab output after quiet periods",
+                    ),
                     ManagerSettingTarget::Endpoint => (
                         "API endpoint",
                         format!("{}{}", raw, if editing { "_" } else { "" }),
@@ -2376,10 +2450,10 @@ fn switch_value(enabled: bool) -> String {
 
 fn default_status(mouse_enabled: bool) -> String {
     if mouse_enabled {
-        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Drag copies within pane | Wheel scrolls selected panes locally | Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+w close grid | Alt+Shift+t restart | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     } else {
-        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
+        "Alt+k commands | Alt+Shift+b background | Alt+Ctrl+b jobs | Ctrl+Alt+p ports | Alt+arrows move | Alt+f zoom | Alt+l resize | Alt+Shift+A auth | Alt+n new tab | Alt+t tab | Alt+w close grid | Alt+Shift+t restart | Alt+s select | Alt+c command line | Alt+d BashBot | Alt+Shift+V voice | Alt+p pane summary | Alt+r rename | Alt+x swap | Alt+z sleep | Alt+g grid goal | Alt+u stop goal | Alt+o settings | Alt+h help"
             .into()
     }
 }
@@ -2445,6 +2519,7 @@ impl App {
             restored_hosts: Vec::new(),
             restored_tabs: Vec::new(),
             session_recorder: None,
+            interrupted_recovery_claim: None,
             status,
         })
     }
@@ -2488,6 +2563,7 @@ impl App {
             restored_hosts,
             restored_tabs,
             session_recorder: Some(recorder),
+            interrupted_recovery_claim: None,
             status: format!("resumed session {session_id}"),
         })
     }
@@ -2501,6 +2577,7 @@ impl App {
             mut tabs,
             session_count,
             pane_count,
+            claim,
         } = recovery;
         let active = if tabs.is_empty() {
             return Err(anyhow!("interrupted recovery has no tabs"));
@@ -2537,6 +2614,7 @@ impl App {
             restored_hosts,
             restored_tabs: tabs,
             session_recorder: None,
+            interrupted_recovery_claim: Some(claim),
             status: format!(
                 "recovered {pane_count} pane{} from {session_count} interrupted session{} into {tab_count} tab{} | Alt+t switches tabs",
                 if pane_count == 1 { "" } else { "s" },
@@ -2563,6 +2641,7 @@ impl App {
             .unwrap_or(0)
             .saturating_add(1);
         let (activity_summary_tx, activity_summary_rx) = std_mpsc::channel();
+        let (port_scan_tx, port_scan_rx) = std_mpsc::channel();
         let keybindings = KeyBindings::from_overrides(&init.config.keys)?;
         let (assistant_tx, assistant_rx) = std_mpsc::channel();
 
@@ -2573,6 +2652,7 @@ impl App {
             worktrees: init.worktrees,
             tabs: vec![None],
             active_tab: 0,
+            selected_grids: BTreeSet::new(),
             tab_title: init.tab_title,
             launch_plan: init.launch_plan,
             layout: GridLayout::new(init.grid),
@@ -2615,12 +2695,16 @@ impl App {
             grid_resizer: None,
             help_open: false,
             quit_confirmation_pending: false,
+            close_grid_confirmation_pending: false,
             settings: init.settings,
             rename: RenamePaneState::default(),
             tab_rename: RenameTabState::default(),
             previous_panes: PreviousPanesState::default(),
             background_jobs,
             background_picker: BackgroundPickerState::default(),
+            port_inspector: PortInspectorState::default(),
+            port_scan_tx,
+            port_scan_rx,
             follow_up: None,
             auth_profiles: Vec::new(),
             auth_refresh_rx: None,
@@ -2630,10 +2714,12 @@ impl App {
             restored_hosts: init.restored_hosts,
             restored_tabs: init.restored_tabs,
             session_recorder: init.session_recorder,
+            interrupted_recovery_claim: init.interrupted_recovery_claim,
             output_logs: OutputLogs::default(),
             next_pane_id: 0,
             next_background_job_id,
             next_tab_number: 2,
+            tab_rects: Vec::new(),
             previous_panes_button: None,
             previous_pane_rows: Vec::new(),
             pane_settings_button: None,
@@ -2645,8 +2731,11 @@ impl App {
             pane_settings_stop_goal_button: None,
             background_jobs_button: None,
             background_job_rows: Vec::new(),
+            ports_button: None,
+            port_rows: Vec::new(),
             event_tx,
             event_rx,
+            pane_routes_scratch: HashMap::new(),
             pane_render_cache: RefCell::new(HashMap::new()),
             applied_workloads: HashMap::new(),
             terminal_focused: true,
@@ -2662,21 +2751,39 @@ impl App {
     }
 
     pub fn run(&mut self) -> Result<()> {
+        let _panic_hook = TerminalPanicHookGuard::install(self.mouse_enabled);
+        let mut restore_guard = TerminalRestoreGuard::new(self.mouse_enabled);
         let mut terminal = setup_terminal(self.mouse_enabled)?;
         let result = self.run_in_terminal(&mut terminal);
-        teardown_terminal(&mut terminal, self.mouse_enabled)?;
+        let teardown_result = teardown_terminal(&mut terminal, self.mouse_enabled);
+        if teardown_result.is_ok() {
+            restore_guard.disarm();
+        }
+        if let Err(cleanup_error) = teardown_result {
+            return match result {
+                Ok(()) => Err(cleanup_error),
+                Err(run_error) => {
+                    Err(run_error
+                        .context(format!("terminal cleanup also failed: {cleanup_error:#}")))
+                }
+            };
+        }
         if result.is_ok()
-            && self.settings.keep_terminals_running
-            && (self.panes.iter().any(|pane| !pane.exited)
-                || self
-                    .tabs
-                    .iter()
-                    .filter_map(Option::as_ref)
-                    .any(|tab| tab.panes.iter().any(|pane| !pane.exited)))
+            && let Some(command) = self.resume_command()
         {
-            println!(
-                "gridbash: terminals are still running; reconnect with `gridbash resume --latest`"
-            );
+            let terminals_still_running = self.settings.keep_terminals_running
+                && (self.panes.iter().any(|pane| !pane.exited)
+                    || self
+                        .tabs
+                        .iter()
+                        .filter_map(Option::as_ref)
+                        .any(|tab| tab.panes.iter().any(|pane| !pane.exited)));
+            if terminals_still_running {
+                println!("gridbash: terminals are still running; reconnect to this exact session:");
+            } else {
+                println!("gridbash: session saved; resume this exact setup:");
+            }
+            println!("{command}");
         }
         result
     }
@@ -2684,14 +2791,24 @@ impl App {
     fn run_in_terminal(&mut self, terminal: &mut Tui) -> Result<()> {
         if self.launch_plan.is_none() {
             let current_dir = resolved_current_dir()?;
-            let mut composer = Composer::new(current_dir, self.worktrees.clone(), &self.config)?;
-            let Some(plan) = composer.run(terminal, &self.config)? else {
+            let default_name = self.tab_title.clone();
+            let mut composer = Composer::new(
+                current_dir,
+                self.worktrees.clone(),
+                &self.config,
+                &default_name,
+            )?;
+            let Some(outcome) = composer.run(terminal, &self.config)? else {
                 return Ok(());
             };
-            self.set_launch_plan(plan)?;
+            self.tab_title = outcome.title;
+            self.set_launch_plan(outcome.plan)?;
         }
 
         self.spawn_initial_panes()?;
+        if let Some(claim) = self.interrupted_recovery_claim.take() {
+            complete_interrupted_recovery(&claim)?;
+        }
         self.sync_initial_pane_sizes(terminal)?;
 
         let run_result = self.run_loop(terminal);
@@ -2744,19 +2861,55 @@ impl App {
         self.start_session_recorder(&plan)?;
 
         for (index, spec) in plan.panes.iter().enumerate() {
-            self.spawn_pane_spec(index, spec)?;
+            if let Err(error) = self.spawn_pane_spec(index, spec) {
+                let cleanup_error = self.retire_owned_panes().err();
+                self.panes.clear();
+                return Err(match cleanup_error {
+                    Some(cleanup_error) => error.context(format!(
+                        "initial pane cleanup also failed: {cleanup_error:#}"
+                    )),
+                    None => error,
+                });
+            }
         }
         self.restored_histories.clear();
         self.restored_hosts.clear();
         for saved_tab in mem::take(&mut self.restored_tabs) {
-            let snapshot = self.restore_saved_tab(saved_tab)?;
-            self.tabs.push(Some(snapshot));
+            match self.restore_saved_tab(saved_tab) {
+                Ok(snapshot) => self.tabs.push(Some(snapshot)),
+                Err(error) => {
+                    let cleanup_error = self.retire_owned_panes().err();
+                    return Err(match cleanup_error {
+                        Some(cleanup_error) => error.context(format!(
+                            "initial workspace cleanup also failed: {cleanup_error:#}"
+                        )),
+                        None => error,
+                    });
+                }
+            }
         }
         self.restore_background_panes();
         self.next_tab_number = self.tabs.len() + 1;
         self.start_usage_monitor(&plan);
 
         self.save_session_snapshot()
+    }
+
+    fn retire_owned_panes(&mut self) -> Result<()> {
+        let mut first_error = retire_panes(self.panes.iter_mut()).err();
+        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
+            if let Err(error) = retire_panes(tab.panes.iter_mut()) {
+                first_error.get_or_insert(error);
+            }
+        }
+        for job in &mut self.background_jobs {
+            if let Some(pane) = job.pane.as_mut()
+                && let Err(error) = retire_pane(pane)
+            {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
     }
 
     fn restore_background_panes(&mut self) {
@@ -2793,8 +2946,14 @@ impl App {
         self.background_jobs = jobs;
     }
 
+    /// Name the next tab would take, without consuming the number. The composer
+    /// shows this as the pre-filled grid name.
+    fn peek_tab_title(&self) -> String {
+        format!("Grid {}", self.next_tab_number)
+    }
+
     fn next_tab_title(&mut self) -> String {
-        let title = format!("Grid {}", self.next_tab_number);
+        let title = self.peek_tab_title();
         self.next_tab_number += 1;
         title
     }
@@ -2808,7 +2967,18 @@ impl App {
         for (index, spec) in plan.panes.iter().enumerate() {
             let history = histories.get(index).cloned().unwrap_or_default();
             let host = hosts.get(index).cloned().flatten();
-            panes.push(self.create_pane(spec, index, &history, host)?);
+            match self.create_pane(spec, index, &history, host) {
+                Ok(pane) => panes.push(pane),
+                Err(error) => {
+                    let cleanup_error = retire_panes(panes.iter_mut()).err();
+                    return Err(match cleanup_error {
+                        Some(cleanup_error) => error.context(format!(
+                            "restored-tab cleanup also failed: {cleanup_error:#}"
+                        )),
+                        None => error,
+                    });
+                }
+            }
         }
         let pane_count = panes.len();
         let grid = plan.grid;
@@ -2875,11 +3045,13 @@ impl App {
     }
 
     fn close_tab_modals(&mut self) {
+        self.close_grid_confirmation_pending = false;
         self.command_palette.close();
         self.rename.close();
         self.tab_rename.close();
         self.previous_panes.close();
         self.background_picker.close();
+        self.port_inspector.close();
         self.pane_settings.close();
         self.follow_up = None;
         self.goal_editor = None;
@@ -2921,11 +3093,16 @@ impl App {
         Ok(())
     }
 
-    fn add_tab_from_plan(&mut self, plan: LaunchPlan) -> Result<()> {
+    fn add_tab_from_plan(&mut self, title: Option<String>, plan: LaunchPlan) -> Result<()> {
         self.save_current_tab();
         self.tabs.push(None);
         self.active_tab = self.tabs.len() - 1;
-        let title = self.next_tab_title();
+        // The number is consumed either way so later tabs never reuse it.
+        let fallback = self.next_tab_title();
+        let title = title
+            .as_deref()
+            .and_then(normalized_tab_title)
+            .unwrap_or(fallback);
         self.close_tab_modals();
         self.activate_plan_as_tab(title, plan)
     }
@@ -3075,84 +3252,232 @@ impl App {
         env
     }
 
+    /// Drives the interface until the user quits.
+    ///
+    /// Every iteration runs behind a panic firewall. A panic or error inside one
+    /// iteration is recorded, surfaced in the status bar, and dropped; the
+    /// session keeps its panes and its terminal state. Only a session that
+    /// cannot stop failing gives up, and it does so through the normal teardown
+    /// path so the terminal is always restored.
     fn run_loop(&mut self, terminal: &mut Tui) -> Result<()> {
-        let mut immediate_render = true;
-        let mut output_render = false;
-        let mut last_render = Instant::now();
-        let mut mouse_capture_enabled = self.mouse_enabled;
+        let mut state = LoopState {
+            immediate_render: true,
+            output_render: false,
+            last_render: Instant::now(),
+            mouse_capture_enabled: self.mouse_enabled,
+        };
+        let mut panic_budget = FailureBudget::new(MAX_RECOVERED_PANICS);
+        let mut error_budget = FailureBudget::new(MAX_RECOVERED_LOOP_ERRORS);
 
         loop {
-            let frame_interval = self.output_frame_interval();
-            let until_frame = frame_interval.saturating_sub(last_render.elapsed());
-            let wait = if immediate_render || !self.event_rx.is_empty() {
-                Duration::ZERO
-            } else if output_render {
-                until_frame.min(INPUT_POLL_INTERVAL)
-            } else {
-                INPUT_POLL_INTERVAL
-            };
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _shield = diagnostics::PanicShield::new();
+                self.run_loop_iteration(terminal, &mut state)
+            }));
 
-            if event::poll(wait)? {
-                let event = event::read()?;
-                if self.handle_terminal_event(
-                    terminal,
-                    event,
-                    &mut immediate_render,
-                    &mut mouse_capture_enabled,
-                )? {
-                    break;
+            match outcome {
+                Ok(Ok(LoopStep::Quit)) => break,
+                Ok(Ok(LoopStep::Continue)) => {}
+                Ok(Err(error)) => {
+                    let detail = format!("{error:#}");
+                    diagnostics::record_recovered("tui", "event loop iteration", &detail);
+                    if error_budget.record() {
+                        return Err(error.context(format!(
+                            "the event loop failed {} times without recovering",
+                            error_budget.count()
+                        )));
+                    }
+                    self.status = format!("recovered from an internal error: {detail}");
+                    state.immediate_render = true;
+                }
+                Err(payload) => {
+                    let detail = diagnostics::panic_payload_message(payload.as_ref());
+                    diagnostics::record_recovered("tui", "event loop panic", &detail);
+                    if panic_budget.record() {
+                        return Err(anyhow!(
+                            "the interface panicked {} times without recovering; last panic: {detail}",
+                            panic_budget.count()
+                        ));
+                    }
+                    // A panic inside `draw` leaves the frame half-written and
+                    // never swaps the buffers, so the backend's diff no longer
+                    // describes the screen. Drop the partial frame, then force a
+                    // full repaint.
+                    terminal.current_buffer_mut().reset();
+                    let _ = terminal.clear();
+                    state.immediate_render = true;
+                    self.status = format!(
+                        "recovered from an internal error ({}); a report was saved to the GridBash log directory",
+                        panic_budget.count()
+                    );
                 }
             }
-
-            output_render |= self.drain_pty_events();
-            immediate_render |= self.drain_usage_events();
-            immediate_render |= self.drain_auth_refresh();
-            immediate_render |= self.drain_command_events();
-            immediate_render |= self.drain_goal_reviews();
-            immediate_render |= self.drain_activity_summary_events();
-            immediate_render |= self.drain_assistant_events();
-            immediate_render |= self.drain_voice_events()?;
-            immediate_render |= self.drain_control_events();
-            immediate_render |= self.decay_activity();
-            immediate_render |= self.update_follow_up_prompt();
-            immediate_render |= self.schedule_goal_reviews();
-            immediate_render |= self.schedule_activity_summaries();
-            immediate_render |= self.autosave_session_if_due();
-            if immediate_render {
-                immediate_render |= self.refresh_workload_classes();
-            }
-
-            if immediate_render || (output_render && last_render.elapsed() >= frame_interval) {
-                terminal.draw(|frame| {
-                    let draw_state = ui::draw(frame, self);
-                    self.grid_area = draw_state.grid_area;
-                    self.rects = draw_state.pane_rects;
-                    self.previous_panes_button = draw_state.previous_panes_button;
-                    self.previous_pane_rows = draw_state.previous_pane_rows;
-                    self.pane_settings_button = draw_state.pane_settings_button;
-                    self.pane_settings_rename_button = draw_state.pane_settings_rename_button;
-                    self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
-                    self.pane_settings_sleep_button = draw_state.pane_settings_sleep_button;
-                    self.pane_settings_deactivate_button =
-                        draw_state.pane_settings_deactivate_button;
-                    self.pane_settings_goal_button = draw_state.pane_settings_goal_button;
-                    self.pane_settings_stop_goal_button = draw_state.pane_settings_stop_goal_button;
-                    self.background_jobs_button = draw_state.background_jobs_button;
-                    self.background_job_rows = draw_state.background_job_rows;
-                })?;
-                self.sync_pane_sizes();
-                immediate_render = false;
-                output_render = false;
-                last_render = Instant::now();
-            }
-            self.sync_mouse_capture(terminal, &mut mouse_capture_enabled)?;
         }
 
-        if mouse_capture_enabled {
+        if state.mouse_capture_enabled {
             execute!(terminal.backend_mut(), DisableMouseCapture)?;
         }
 
         Ok(())
+    }
+
+    fn run_loop_iteration(&mut self, terminal: &mut Tui, state: &mut LoopState) -> Result<LoopStep> {
+        let frame_interval = self.output_frame_interval();
+        let until_frame = frame_interval.saturating_sub(state.last_render.elapsed());
+        let wait = if state.immediate_render || !self.event_rx.is_empty() {
+            Duration::ZERO
+        } else if state.output_render {
+            until_frame.min(INPUT_POLL_INTERVAL)
+        } else {
+            INPUT_POLL_INTERVAL
+        };
+
+        if event::poll(wait)? {
+            for event in self.read_input_events()? {
+                if self.handle_terminal_event(
+                    terminal,
+                    event,
+                    &mut state.immediate_render,
+                    &mut state.mouse_capture_enabled,
+                )? {
+                    return Ok(LoopStep::Quit);
+                }
+            }
+        }
+
+        state.output_render |= self.drain_pty_events();
+        state.immediate_render |= self.flush_output_logs_if_due();
+        state.immediate_render |= self.drain_usage_events();
+        state.immediate_render |= self.drain_auth_refresh();
+        state.immediate_render |= self.drain_command_events();
+        state.immediate_render |= self.drain_port_scan();
+        state.immediate_render |= self.drain_goal_reviews();
+        state.immediate_render |= self.drain_activity_summary_events();
+        state.immediate_render |= self.drain_assistant_events();
+        state.immediate_render |= self.drain_voice_events()?;
+        state.immediate_render |= self.drain_control_events();
+        state.immediate_render |= self.decay_activity();
+        state.immediate_render |= self.update_follow_up_prompt();
+        state.immediate_render |= self.schedule_goal_reviews();
+        state.immediate_render |= self.schedule_activity_summaries();
+        state.immediate_render |= self.autosave_session_if_due();
+        state.immediate_render |= self.schedule_port_scan();
+        if state.immediate_render {
+            state.immediate_render |= self.refresh_workload_classes();
+        }
+
+        if state.immediate_render
+            || (state.output_render && state.last_render.elapsed() >= frame_interval)
+        {
+            terminal.draw(|frame| {
+                let draw_state = ui::draw(frame, self);
+                self.grid_area = draw_state.grid_area;
+                self.rects = draw_state.pane_rects;
+                self.tab_rects = draw_state.tab_rects;
+                self.previous_panes_button = draw_state.previous_panes_button;
+                self.previous_pane_rows = draw_state.previous_pane_rows;
+                self.pane_settings_button = draw_state.pane_settings_button;
+                self.pane_settings_rename_button = draw_state.pane_settings_rename_button;
+                self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
+                self.pane_settings_sleep_button = draw_state.pane_settings_sleep_button;
+                self.pane_settings_deactivate_button = draw_state.pane_settings_deactivate_button;
+                self.pane_settings_goal_button = draw_state.pane_settings_goal_button;
+                self.pane_settings_stop_goal_button = draw_state.pane_settings_stop_goal_button;
+                self.background_jobs_button = draw_state.background_jobs_button;
+                self.background_job_rows = draw_state.background_job_rows;
+                self.ports_button = draw_state.ports_button;
+                self.port_rows = draw_state.port_rows;
+            })?;
+            self.sync_pane_sizes();
+            state.immediate_render = false;
+            state.output_render = false;
+            state.last_render = Instant::now();
+        }
+        self.sync_mouse_capture(terminal, &mut state.mouse_capture_enabled)?;
+
+        Ok(LoopStep::Continue)
+    }
+
+    /// Reads the events crossterm has ready, folding a synthetic keystroke
+    /// burst back into a single `Event::Paste`.
+    ///
+    /// Windows consoles hand a paste to the application as one key event per
+    /// character, so crossterm never reports `Event::Paste` there and every
+    /// pasted line break arrives as Enter. Without this, pasting a multi-line
+    /// prompt submits the first line and runs the rest as separate commands.
+    /// Only bursts that span a line break are folded, so ordinary typing and
+    /// key repeat keep their existing per-key behaviour.
+    fn read_input_events(&self) -> Result<Vec<Event>> {
+        let first = event::read()?;
+        if !cfg!(windows) || !self.input_reaches_pane() {
+            return Ok(vec![first]);
+        }
+        let Some(first_char) = paste_burst_char(&first) else {
+            return Ok(vec![first]);
+        };
+
+        let mut keys = vec![first];
+        let mut text = String::from(first_char);
+        let mut trailing = None;
+        while text.len() < PASTE_BURST_MAX_BYTES {
+            // The console buffer can run dry mid-paste, so allow a short gap
+            // once a burst is under way rather than cutting it in half.
+            let gap = if keys.len() > 1 {
+                PASTE_BURST_GAP
+            } else {
+                Duration::ZERO
+            };
+            if !event::poll(gap)? {
+                break;
+            }
+            let event = event::read()?;
+            // Key releases are dropped by `handle_terminal_event` anyway, and
+            // Windows interleaves one after every synthesized character.
+            if matches!(&event, Event::Key(key) if key.kind != KeyEventKind::Press) {
+                continue;
+            }
+            match paste_burst_char(&event) {
+                Some(ch) => {
+                    text.push(ch);
+                    keys.push(event);
+                }
+                None => {
+                    trailing = Some(event);
+                    break;
+                }
+            }
+        }
+
+        if text.contains('\n') && text.chars().any(|ch| ch != '\n') {
+            keys.clear();
+            keys.push(Event::Paste(text));
+        }
+        keys.extend(trailing);
+        Ok(keys)
+    }
+
+    /// True when plain keystrokes are forwarded to a pane rather than consumed
+    /// by an overlay, modal, or the command line.
+    fn input_reaches_pane(&self) -> bool {
+        !self.quit_confirmation_pending
+            && !self.close_grid_confirmation_pending
+            && self.copy_mode.is_none()
+            && !self.command_palette.open
+            && !self.assistant.open
+            && !self.help_open
+            && self.grid_resizer.is_none()
+            && self.image_overlay.is_none()
+            && !self.tab_rename.open
+            && !self.rename.open
+            && !self.background_picker.open
+            && !self.previous_panes.open
+            && !self.pane_settings.open
+            && !self.port_inspector.open
+            && self.follow_up.is_none()
+            && self.goal_editor.is_none()
+            && !self.settings.open
+            && !self.command_line.focused
+            && self.exited_recovery_view().is_none()
     }
 
     fn handle_terminal_event(
@@ -3215,11 +3540,14 @@ impl App {
             }
             Event::Paste(text)
                 if !self.command_palette.open
+                    && !self.quit_confirmation_pending
+                    && !self.close_grid_confirmation_pending
                     && !self.settings.open
                     && self.grid_resizer.is_none()
                     && !self.rename.open
                     && !self.background_picker.open
                     && !self.previous_panes.open
+                    && !self.port_inspector.open
                     && !self.pane_settings.open
                     && self.image_overlay.is_none()
                     && self.follow_up.is_none()
@@ -3230,11 +3558,13 @@ impl App {
                     self.command_line.insert_text(&text);
                     *needs_render = true;
                 } else {
-                    self.route_input(text.as_bytes())?;
+                    *needs_render |= self.route_paste(&text)?;
                 }
             }
             Event::Mouse(mouse)
                 if (self.mouse_enabled || !self.sleeping.is_empty())
+                    && !self.quit_confirmation_pending
+                    && !self.close_grid_confirmation_pending
                     && !self.command_palette.open
                     && !self.settings.open
                     && self.grid_resizer.is_none()
@@ -3317,9 +3647,14 @@ impl App {
         }
 
         self.applied_workloads.retain(|id, _| seen.contains(id));
+        // Only the panes in the active grid are ever blitted, but `seen` also
+        // covers inactive tabs and background jobs. Each stale entry is a full
+        // pane-sized `Buffer`, so keep the cache to what is on screen; it
+        // rebuilds on the first draw after a tab switch.
+        let visible = self.panes.iter().map(PtyPane::id).collect::<BTreeSet<_>>();
         self.pane_render_cache
             .borrow_mut()
-            .retain(|id, _| seen.contains(id));
+            .retain(|id, _| visible.contains(id));
         self.activity_summary_states
             .retain(|id, _| seen.contains(id));
         if let Some(error) = failure
@@ -3354,7 +3689,8 @@ impl App {
         };
 
         let mut changed = false;
-        let routes = self.pane_routes();
+        let mut routes = mem::take(&mut self.pane_routes_scratch);
+        self.populate_pane_routes(&mut routes);
         let mut pending_output = HashMap::<(PaneId, u64), Vec<u8>>::new();
         let mut pending_output_order = Vec::new();
         let mut exited = Vec::new();
@@ -3422,14 +3758,19 @@ impl App {
         }
 
         for (pane, generation) in pending_output_order {
-            let bytes = pending_output
-                .remove(&(pane, generation))
-                .expect("pending output order and batches stay in sync");
+            // The order list and the batch map are filled together, so a missing
+            // batch means nothing to write; skipping it costs one frame of pane
+            // output where indexing would cost the session.
+            let Some(bytes) = pending_output.remove(&(pane, generation)) else {
+                continue;
+            };
             let log_key = PaneLogKey::new(pane, generation);
             let activity = match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
+                    let Some(target) = self.panes.get_mut(index) else {
+                        continue;
+                    };
                     let (pane_id, pane_generation, plain) = {
-                        let target = &mut self.panes[index];
                         let plain = target.process_output(&bytes);
                         (target.id(), target.generation(), plain)
                     };
@@ -3440,18 +3781,19 @@ impl App {
                     Some((pane_id, pane_generation))
                 }
                 Some(PaneRoute::Inactive { tab, pane }) => {
-                    let activity_and_plain =
-                        if let Some(tab) = self.tabs.get_mut(tab).and_then(Option::as_mut) {
-                            let target = &mut tab.panes[pane];
+                    let activity_and_plain = self
+                        .tabs
+                        .get_mut(tab)
+                        .and_then(Option::as_mut)
+                        .and_then(|tab| {
+                            let target = tab.panes.get_mut(pane)?;
                             let was_active = target.active;
                             let plain = target.process_output(&bytes);
                             let activity = (target.id(), target.generation());
                             capture_goal_text(&mut tab.manager_goal, &tab.sleeping, pane, &plain);
                             changed |= !was_active;
                             Some((activity, plain))
-                        } else {
-                            None
-                        };
+                        });
                     if let Some((activity, plain)) = activity_and_plain {
                         changed |= self.append_output_log(log_key, pane + 1, &plain);
                         Some(activity)
@@ -3483,6 +3825,7 @@ impl App {
             }
         }
 
+        let had_exit_events = !exited.is_empty();
         for (pane, generation) in exited {
             let log_key = PaneLogKey::new(pane, generation);
             match self.output_logs.stop(log_key) {
@@ -3498,7 +3841,7 @@ impl App {
             }
             match routes.get(&(pane, generation)).copied() {
                 Some(PaneRoute::Visible(index)) => {
-                    changed |= self.handle_visible_pane_exit(index, pane, generation);
+                    changed |= self.mark_visible_pane_exited(index, pane, generation);
                 }
                 Some(PaneRoute::Inactive { tab, pane }) => {
                     if let Some(target) = self
@@ -3526,11 +3869,15 @@ impl App {
                 None => {}
             }
         }
+        if had_exit_events {
+            changed |= self.recover_exited_agent_panes_to_shell();
+        }
 
         if should_poll_exits {
             changed |= self.poll_exited_panes();
         }
 
+        self.pane_routes_scratch = routes;
         changed
     }
 
@@ -3546,7 +3893,18 @@ impl App {
         }
     }
 
-    fn handle_visible_pane_exit(&mut self, index: usize, pane_id: PaneId, generation: u64) -> bool {
+    fn flush_output_logs_if_due(&mut self) -> bool {
+        match self.output_logs.flush_due() {
+            Ok(()) => false,
+            Err(error) => {
+                self.status =
+                    format!("pane output logging stopped after a flush failure: {error:#}");
+                true
+            }
+        }
+    }
+
+    fn mark_visible_pane_exited(&mut self, index: usize, pane_id: PaneId, generation: u64) -> bool {
         let changed = {
             let Some(pane) = self.panes.get_mut(index) else {
                 return false;
@@ -3565,17 +3923,7 @@ impl App {
         {
             self.follow_up = None;
         }
-
-        match self.recover_exited_agent_pane_to_shell(index) {
-            Ok(recovered) => changed || recovered,
-            Err(error) => {
-                self.status = format!(
-                    "pane {} agent exited; failed to open an interactive shell: {error:#}",
-                    index + 1
-                );
-                true
-            }
-        }
+        changed
     }
 
     fn recover_exited_agent_pane_to_shell(&mut self, index: usize) -> Result<bool> {
@@ -3602,7 +3950,7 @@ impl App {
             let _ = pane.terminate();
         }
         let mut replacement = self.spawn_pane_instance(&shell_spec, index)?;
-        replacement.restore_history_display(&history.output_tail, &history.input_history);
+        replacement.restore_history_state(&history.output_tail, &history.input_history);
         self.panes[index] = replacement;
         if let Some(plan) = self.launch_plan.as_mut()
             && let Some(spec) = plan.panes.get_mut(index)
@@ -3624,11 +3972,14 @@ impl App {
         let exited = self
             .panes
             .iter()
-            .enumerate()
-            .filter_map(|(index, pane)| pane.exited.then_some(index))
+            .map(|pane| pane.exited)
             .collect::<Vec<_>>();
+        let Some(specs) = self.launch_plan.as_ref().map(|plan| plan.panes.as_slice()) else {
+            return false;
+        };
+        let targets = agent_recovery_targets(&exited, specs);
         let mut changed = false;
-        for index in exited {
+        for index in targets {
             match self.recover_exited_agent_pane_to_shell(index) {
                 Ok(recovered) => changed |= recovered,
                 Err(error) => {
@@ -3683,8 +4034,18 @@ impl App {
         changed
     }
 
-    fn pane_routes(&self) -> HashMap<(PaneId, u64), PaneRoute> {
-        let mut routes = HashMap::new();
+    fn populate_pane_routes(&self, routes: &mut HashMap<(PaneId, u64), PaneRoute>) {
+        routes.clear();
+        routes.reserve(
+            self.panes.len()
+                + self
+                    .tabs
+                    .iter()
+                    .filter_map(Option::as_ref)
+                    .map(|tab| tab.panes.len())
+                    .sum::<usize>()
+                + self.background_jobs.len(),
+        );
         for (index, pane) in self.panes.iter().enumerate() {
             routes.insert((pane.id(), pane.generation()), PaneRoute::Visible(index));
         }
@@ -3707,7 +4068,6 @@ impl App {
                 routes.insert((pane.id(), pane.generation()), PaneRoute::Background(index));
             }
         }
-        routes
     }
 
     fn apply_manager_write_result(
@@ -3787,8 +4147,10 @@ impl App {
         let config = self.config.manager.clone();
         let tx = self.assistant_tx.clone();
         thread::spawn(move || {
-            let result = manager::assist(&config, &conversation, &workspace_context)
-                .map_err(|error| format!("{error:#}"));
+            let result = diagnostics::recovering("the BashBot request", || {
+                manager::assist(&config, &conversation, &workspace_context)
+                    .map_err(|error| format!("{error:#}"))
+            });
             let _ = tx.send(AssistantEvent {
                 request_id,
                 targets,
@@ -3904,7 +4266,8 @@ impl App {
         targets: &[AssistantTarget],
         commands: &[ManagerCommand],
     ) -> (usize, Vec<String>) {
-        let routes = self.pane_routes();
+        let mut routes = mem::take(&mut self.pane_routes_scratch);
+        self.populate_pane_routes(&mut routes);
         let mut sent = 0;
         let mut failures = Vec::new();
 
@@ -3999,6 +4362,7 @@ impl App {
             }
         }
 
+        self.pane_routes_scratch = routes;
         (sent, failures)
     }
 
@@ -4057,8 +4421,9 @@ impl App {
         let config = self.config.manager.clone();
         let tx = self.goal_tx.clone();
         thread::spawn(move || {
-            let result = manager::review(&config, &objective, &context)
-                .map_err(|error| format!("{error:#}"));
+            let result = diagnostics::recovering("the grid goal review", || {
+                manager::review(&config, &objective, &context).map_err(|error| format!("{error:#}"))
+            });
             let _ = tx.send(GoalReviewEvent {
                 goal_id,
                 targets,
@@ -4181,8 +4546,10 @@ impl App {
         let config = self.config.manager.clone();
         let tx = self.activity_summary_tx.clone();
         thread::spawn(move || {
-            let result = manager::summarize_activity(&config, &context, &expected_panes)
-                .map_err(|error| format!("{error:#}"));
+            let result = diagnostics::recovering("the activity summary", || {
+                manager::summarize_activity(&config, &context, &expected_panes)
+                    .map_err(|error| format!("{error:#}"))
+            });
             let _ = tx.send(ActivitySummaryEvent {
                 request_id,
                 targets,
@@ -4360,6 +4727,99 @@ impl App {
         }
 
         changed
+    }
+
+    fn schedule_port_scan(&mut self) -> bool {
+        if !self.port_inspector.open {
+            return false;
+        }
+        if self.port_inspector.refreshing
+            || self
+                .port_inspector
+                .last_scan
+                .is_some_and(|last| last.elapsed() < PORT_SCAN_INTERVAL)
+        {
+            return false;
+        }
+
+        let roots = self.agent_process_roots();
+        if roots.is_empty() {
+            let changed = !self.port_inspector.ports.is_empty()
+                || self.port_inspector.error.is_some()
+                || self.port_inspector.refreshing;
+            self.port_inspector.ports.clear();
+            self.port_inspector.error = None;
+            self.port_inspector.refreshing = false;
+            self.port_inspector.last_scan = Some(Instant::now());
+            self.port_inspector.clamp_cursor();
+            return changed;
+        }
+
+        self.port_inspector.refreshing = true;
+        let sender = self.port_scan_tx.clone();
+        thread::spawn(move || {
+            let result = diagnostics::recovering("the port scan", || {
+                ports::discover_agent_ports(&roots).map_err(|error| error.to_string())
+            });
+            let _ = sender.send(result);
+        });
+        self.port_inspector.open
+    }
+
+    fn drain_port_scan(&mut self) -> bool {
+        let mut changed = false;
+        while let Ok(result) = self.port_scan_rx.try_recv() {
+            self.port_inspector.refreshing = false;
+            self.port_inspector.last_scan = Some(Instant::now());
+            match result {
+                Ok(ports) => {
+                    changed |= self.port_inspector.ports != ports;
+                    self.port_inspector.ports = ports;
+                    self.port_inspector.error = None;
+                }
+                Err(error) => {
+                    let error = bounded_prefix(&error, 240);
+                    changed |= self.port_inspector.error.as_deref() != Some(error.as_str());
+                    self.port_inspector.error = Some(error);
+                }
+            }
+            self.port_inspector.clamp_cursor();
+            changed |= self.port_inspector.open;
+        }
+        changed
+    }
+
+    fn agent_process_roots(&self) -> Vec<AgentProcessRoot> {
+        let mut roots = Vec::new();
+        roots.extend(self.panes.iter().enumerate().filter_map(|(index, pane)| {
+            pane.host_process_id().map(|pid| AgentProcessRoot {
+                pid,
+                label: port_owner_label(&self.tab_title, &self.pane_names, index),
+            })
+        }));
+        for tab in self.tabs.iter().filter_map(Option::as_ref) {
+            roots.extend(tab.panes.iter().enumerate().filter_map(|(index, pane)| {
+                pane.host_process_id().map(|pid| AgentProcessRoot {
+                    pid,
+                    label: port_owner_label(&tab.title, &tab.pane_names, index),
+                })
+            }));
+        }
+        roots.extend(self.background_jobs.iter().filter_map(|job| {
+            job.pane
+                .as_ref()?
+                .host_process_id()
+                .map(|pid| AgentProcessRoot {
+                    pid,
+                    label: format!(
+                        "Background / {}",
+                        job.name
+                            .clone()
+                            .unwrap_or_else(|| format!("job {}", job.id))
+                    ),
+                })
+        }));
+        roots
     }
 
     fn drain_voice_events(&mut self) -> Result<bool> {
@@ -4989,6 +5449,9 @@ impl App {
 
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
         let action = self.keybindings.action_for(&key);
+        if self.close_grid_confirmation_pending {
+            return self.handle_close_grid_confirmation_key(key);
+        }
         if is_quit_recovery(&key) || action == Some(Action::Quit) {
             return Ok(self.request_quit());
         }
@@ -4996,6 +5459,7 @@ impl App {
         if self.quit_confirmation_pending {
             self.quit_confirmation_pending = false;
             self.status = "quit canceled".into();
+            return Ok(KeyOutcome::Render);
         }
 
         if self.copy_mode.is_some() {
@@ -5036,6 +5500,10 @@ impl App {
         if self.pane_settings.open && action == Some(Action::PaneActivity) {
             self.pane_settings.close();
             self.status = "pane activity closed".into();
+            return Ok(KeyOutcome::Render);
+        }
+        if self.port_inspector.open && action == Some(Action::Ports) {
+            self.close_port_inspector();
             return Ok(KeyOutcome::Render);
         }
         if self.settings.open && action == Some(Action::Settings) {
@@ -5079,6 +5547,11 @@ impl App {
 
         if self.pane_settings.open {
             let outcome = self.handle_pane_settings_key(key)?;
+            return Ok(render_if_selection_cleared(outcome, selection_cleared));
+        }
+
+        if self.port_inspector.open {
+            let outcome = self.handle_port_inspector_key(key);
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
@@ -5137,8 +5610,17 @@ impl App {
             return KeyOutcome::Quit;
         }
 
+        if let Err(error) = self.save_session_snapshot() {
+            self.status = format!("quit canceled: failed to save resumable session: {error:#}");
+            return KeyOutcome::Render;
+        }
+        if self.resume_command().is_none() {
+            self.status = "quit canceled: no resumable session is available yet".into();
+            return KeyOutcome::Render;
+        }
+
         self.quit_confirmation_pending = true;
-        self.status = "press Alt+q again to quit; any other key cancels".into();
+        self.status = "quit confirmation open | Alt+q confirms | any other key cancels".into();
         KeyOutcome::Render
     }
 
@@ -5279,8 +5761,7 @@ impl App {
         let (width, height) = self.copy_mode_dimensions(pane_index);
         let searching = self.copy_mode.as_ref().is_some_and(CopyMode::searching);
 
-        if searching {
-            let mode = self.copy_mode.as_mut().expect("copy mode checked above");
+        if let Some(mode) = self.copy_mode.as_mut().filter(|_| searching) {
             match key.code {
                 KeyCode::Enter => mode.finish_search(),
                 KeyCode::Backspace => mode.backspace_search(width, height),
@@ -5316,11 +5797,14 @@ impl App {
                 .modifiers
                 .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
         {
-            let (pane, text) = self
+            let Some((pane, text)) = self
                 .copy_mode
                 .as_ref()
                 .map(|mode| (mode.pane(), mode.copy_text()))
-                .expect("copy mode checked above");
+            else {
+                self.close_copy_mode();
+                return Ok(KeyOutcome::Render);
+            };
             if text.is_empty() {
                 self.status = "copy selection is empty".into();
                 return Ok(KeyOutcome::Render);
@@ -5548,6 +6032,9 @@ impl App {
                     self.toggle_pane_selection(self.focus);
                 }
             }
+            Action::ToggleGridSelection => {
+                self.toggle_grid_selection(self.active_tab);
+            }
             Action::SelectAll => {
                 if self.selected.len() == self.panes.len() {
                     self.selected.clear();
@@ -5568,6 +6055,9 @@ impl App {
             Action::NewTab => {
                 self.open_new_tab(terminal)?;
             }
+            Action::CloseGrid => {
+                self.request_close_current_grid()?;
+            }
             Action::ToggleOutputLogging => {
                 self.toggle_target_output_logging();
             }
@@ -5575,7 +6065,11 @@ impl App {
                 self.open_grid_resizer();
             }
             Action::SwapPanes => {
-                self.swap_selected_tiles();
+                if self.selected_grids.is_empty() {
+                    self.swap_selected_tiles();
+                } else {
+                    self.swap_selected_grids();
+                }
             }
             Action::ZoomPane => {
                 self.toggle_zoom();
@@ -5608,6 +6102,9 @@ impl App {
             }
             Action::PaneActivity => {
                 self.toggle_pane_settings();
+            }
+            Action::Ports => {
+                self.open_port_inspector();
             }
             Action::CopyMode => {
                 self.open_copy_mode();
@@ -5716,10 +6213,16 @@ impl App {
 
     fn open_new_tab(&mut self, terminal: &mut Tui) -> Result<()> {
         let current_dir = self.active_pane_cwd().unwrap_or(resolved_current_dir()?);
-        let mut composer = Composer::new(current_dir, self.worktrees.clone(), &self.config)?;
+        let default_name = self.peek_tab_title();
+        let mut composer = Composer::new(
+            current_dir,
+            self.worktrees.clone(),
+            &self.config,
+            &default_name,
+        )?;
         match composer.run(terminal, &self.config)? {
-            Some(plan) => {
-                self.add_tab_from_plan(plan)?;
+            Some(outcome) => {
+                self.add_tab_from_plan(Some(outcome.title), outcome.plan)?;
                 self.sync_initial_pane_sizes(terminal)?;
             }
             None => {
@@ -5737,6 +6240,125 @@ impl App {
 
         let next = (self.active_tab + 1) % self.tabs.len();
         self.switch_to_tab(next);
+    }
+
+    fn request_close_current_grid(&mut self) -> Result<()> {
+        if self.tabs.len() <= 1 {
+            self.close_grid_confirmation_pending = false;
+            self.status = "the only grid cannot be closed; use Alt+q to quit GridBash".into();
+            return Ok(());
+        }
+
+        self.close_tab_modals();
+        self.close_grid_confirmation_pending = true;
+        self.status = format!("close grid confirmation open for {}", self.tab_title);
+        Ok(())
+    }
+
+    fn handle_close_grid_confirmation_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
+        match close_grid_confirmation_action(key) {
+            CloseGridConfirmationAction::Confirm => {
+                self.close_grid_confirmation_pending = false;
+                self.close_current_grid()?;
+            }
+            CloseGridConfirmationAction::Cancel => {
+                self.close_grid_confirmation_pending = false;
+                self.status = "close grid canceled".into();
+            }
+            CloseGridConfirmationAction::Continue => return Ok(KeyOutcome::Continue),
+        }
+        Ok(KeyOutcome::Render)
+    }
+
+    fn close_current_grid(&mut self) -> Result<()> {
+        let closing_title = self.tab_title.clone();
+        let closing_index = self.active_tab;
+        let Some(next_index) = tab_index_after_close(closing_index, self.tabs.len()) else {
+            self.status = "the only grid cannot be closed; use Alt+q to quit GridBash".into();
+            return Ok(());
+        };
+
+        self.close_tab_modals();
+        let mut termination_failures = 0usize;
+        for mut pane in mem::take(&mut self.panes) {
+            let pane_id = pane.id();
+            let log_key = PaneLogKey::new(pane_id, pane.generation());
+            if self.output_logs.stop(log_key).is_err() {
+                termination_failures += 1;
+            }
+            self.pane_render_cache.borrow_mut().remove(&pane_id);
+            self.applied_workloads.remove(&pane_id);
+            self.activity_summary_states.remove(&pane_id);
+            if retire_pane(&mut pane).is_err() {
+                termination_failures += 1;
+            }
+        }
+        self.voice.cancel();
+        self.voice_destination = None;
+
+        self.tabs.remove(closing_index);
+        self.selected_grids = self
+            .selected_grids
+            .iter()
+            .filter_map(|index| {
+                if *index == closing_index {
+                    None
+                } else {
+                    Some(if *index > closing_index {
+                        *index - 1
+                    } else {
+                        *index
+                    })
+                }
+            })
+            .collect();
+        let snapshot = self.tabs[next_index]
+            .take()
+            .ok_or_else(|| anyhow!("surviving grid {} is unavailable", next_index + 1))?;
+        self.active_tab = next_index;
+        self.restore_tab_snapshot(snapshot);
+        let recovered_agent = self.recover_exited_agent_panes_to_shell();
+        if let Some(cwd) = self.active_pane_cwd() {
+            self.command_line.cwd = cwd;
+        }
+        self.start_usage_for_active_tab();
+        self.sync_pane_sizes_for_current_layout();
+        self.save_session_snapshot()?;
+
+        self.status = if termination_failures == 0 {
+            format!(
+                "closed grid {closing_title}; active grid {}",
+                self.tab_title
+            )
+        } else {
+            format!(
+                "closed grid {closing_title}; {termination_failures} pane cleanup operation(s) reported errors"
+            )
+        };
+        if recovered_agent && termination_failures == 0 {
+            self.status
+                .push_str("; restored exited agent panes to shells");
+        }
+        Ok(())
+    }
+
+    fn toggle_grid_selection(&mut self, index: usize) {
+        if index >= self.tabs.len() {
+            return;
+        }
+
+        let selected = toggle_selection(&mut self.selected_grids, index);
+        self.status = format!(
+            "{} grid {} ({} grid{} selected)",
+            if selected { "selected" } else { "deselected" },
+            index + 1,
+            self.selected_grids.len(),
+            if self.selected_grids.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
     }
 
     fn switch_to_tab(&mut self, index: usize) {
@@ -5757,6 +6379,7 @@ impl App {
         if !recovered_agent {
             self.status = format!("active tab {}", self.tab_title);
         }
+        self.sync_pane_sizes_for_current_layout();
     }
 
     fn begin_tab_rename(&mut self) {
@@ -5940,6 +6563,142 @@ impl App {
         self.status = "background agents closed".into();
     }
 
+    fn open_port_inspector(&mut self) {
+        self.close_tab_modals();
+        self.settings.open = false;
+        self.image_overlay = None;
+        self.help_open = false;
+        self.port_inspector.open = true;
+        self.port_inspector.pending_terminate = None;
+        self.port_inspector.last_scan = None;
+        self.status = if self.port_inspector.ports.is_empty() {
+            "looking for agent-owned localhost ports".into()
+        } else {
+            format!(
+                "{} agent-owned localhost port(s)",
+                self.port_inspector.ports.len()
+            )
+        };
+    }
+
+    fn close_port_inspector(&mut self) {
+        self.port_inspector.close();
+        self.status = "agent ports closed".into();
+    }
+
+    fn handle_port_inspector_key(&mut self, key: KeyEvent) -> KeyOutcome {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return KeyOutcome::Quit;
+        }
+
+        let changed = match key.code {
+            KeyCode::Esc if self.port_inspector.pending_terminate.is_some() => {
+                self.port_inspector.pending_terminate = None;
+                self.status = "port termination canceled".into();
+                true
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.close_port_inspector();
+                true
+            }
+            KeyCode::Up => {
+                self.port_inspector.move_cursor(-1);
+                true
+            }
+            KeyCode::Down => {
+                self.port_inspector.move_cursor(1);
+                true
+            }
+            KeyCode::Home => {
+                self.port_inspector.cursor = 0;
+                self.port_inspector.pending_terminate = None;
+                true
+            }
+            KeyCode::End => {
+                self.port_inspector.cursor = self.port_inspector.ports.len().saturating_sub(1);
+                self.port_inspector.pending_terminate = None;
+                true
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.port_inspector.last_scan = None;
+                self.port_inspector.error = None;
+                self.status = "refreshing agent-owned localhost ports".into();
+                true
+            }
+            KeyCode::Delete | KeyCode::Enter => {
+                self.confirm_or_terminate_selected_port();
+                true
+            }
+            _ => false,
+        };
+
+        if changed {
+            KeyOutcome::Render
+        } else {
+            KeyOutcome::Continue
+        }
+    }
+
+    fn confirm_or_terminate_selected_port(&mut self) {
+        let Some(port) = self
+            .port_inspector
+            .ports
+            .get(self.port_inspector.cursor)
+            .cloned()
+        else {
+            self.status = "no agent-owned port selected".into();
+            return;
+        };
+
+        if self.port_inspector.pending_terminate != Some(port.pid) {
+            self.port_inspector.pending_terminate = Some(port.pid);
+            self.status = format!(
+                "press Enter to terminate {} (PID {}) on port {}",
+                port.process, port.pid, port.port
+            );
+            return;
+        }
+
+        let roots = self.agent_process_roots();
+        let verified = match ports::discover_agent_ports(&roots) {
+            Ok(current) => current
+                .iter()
+                .any(|listener| listener.pid == port.pid && listener.port == port.port),
+            Err(error) => {
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.status = format!("could not verify port before termination: {error}");
+                return;
+            }
+        };
+        if !verified {
+            self.port_inspector.pending_terminate = None;
+            self.port_inspector.last_scan = None;
+            self.status = format!("port {} is no longer owned by PID {}", port.port, port.pid);
+            return;
+        }
+
+        match ports::terminate_process(port.pid) {
+            Ok(()) => {
+                self.port_inspector
+                    .ports
+                    .retain(|listener| listener.pid != port.pid);
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.port_inspector.clamp_cursor();
+                self.status = format!(
+                    "terminated {} (PID {}) from port {}",
+                    port.process, port.pid, port.port
+                );
+            }
+            Err(error) => {
+                self.port_inspector.pending_terminate = None;
+                self.port_inspector.last_scan = None;
+                self.status = format!("failed to terminate PID {}: {error}", port.pid);
+            }
+        }
+    }
+
     fn handle_background_jobs_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
         if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
             return Ok(KeyOutcome::Quit);
@@ -6082,6 +6841,13 @@ impl App {
         Ok(())
     }
 
+    /// Puts a job back where it was after an insertion could not be completed.
+    fn restore_background_job(&mut self, index: usize, job: BackgroundJob) {
+        self.background_jobs
+            .insert(index.min(self.background_jobs.len()), job);
+        self.status = "background agent could not be inserted into the focused pane".into();
+    }
+
     fn insert_background_job(&mut self, index: usize) -> Result<()> {
         let Some(job) = self.background_jobs.get(index) else {
             self.status = "no background agent selected".into();
@@ -6097,11 +6863,12 @@ impl App {
             return Ok(());
         }
 
-        let target = self.focus.min(self.panes.len() - 1);
-        if self
-            .launch_plan
-            .as_ref()
-            .is_none_or(|plan| target >= plan.panes.len())
+        let target = self.focus.min(self.panes.len().saturating_sub(1));
+        if target >= self.panes.len()
+            || self
+                .launch_plan
+                .as_ref()
+                .is_none_or(|plan| target >= plan.panes.len())
         {
             self.status = "focused pane configuration is unavailable".into();
             return Ok(());
@@ -6113,8 +6880,33 @@ impl App {
             .clone()
             .or_else(|| job.spec.agent_label())
             .unwrap_or_else(|| "terminal".into());
-        let restored_pane = job.pane.take().expect("checked live background pane");
-        let displaced_pane = mem::replace(&mut self.panes[target], restored_pane);
+        // The checks above establish every slot this swap touches. Each bail-out
+        // below hands the live pane straight back to the background list, so a
+        // stale focus index costs the insertion rather than the pane or the
+        // session.
+        let Some((restored_pane, displaced_spec)) = job
+            .pane
+            .take()
+            .zip(self.launch_plan.as_mut().and_then(|plan| {
+                plan.panes
+                    .get_mut(target)
+                    .map(|slot| mem::replace(slot, job.spec.clone()))
+            }))
+        else {
+            self.restore_background_job(index, job);
+            return Ok(());
+        };
+        let Some(visible_slot) = self.panes.get_mut(target) else {
+            if let Some(plan) = self.launch_plan.as_mut()
+                && let Some(slot) = plan.panes.get_mut(target)
+            {
+                *slot = displaced_spec;
+            }
+            job.pane = Some(restored_pane);
+            self.restore_background_job(index, job);
+            return Ok(());
+        };
+        let displaced_pane = mem::replace(visible_slot, restored_pane);
         let displaced_name = self
             .pane_names
             .get_mut(target)
@@ -6125,10 +6917,6 @@ impl App {
             .get_mut(target)
             .map(|idle| mem::replace(idle, job.idle))
             .unwrap_or_else(|| PaneIdleState::new(Instant::now()));
-        let displaced_spec = {
-            let plan = self.launch_plan.as_mut().expect("checked launch plan");
-            mem::replace(&mut plan.panes[target], job.spec)
-        };
         let displaced_history = SavedPaneHistory::from_pane(&displaced_pane);
         let displaced_id = self.next_background_job_id;
         self.next_background_job_id = self.next_background_job_id.saturating_add(1);
@@ -6211,12 +6999,16 @@ impl App {
             return Ok(());
         }
 
-        let mut job = self.background_jobs.remove(index);
-        if let Some(pane) = job.pane.as_mut()
+        if let Some(pane) = self.background_jobs[index].pane.as_mut()
             && !pane.exited
         {
-            pane.terminate()?;
+            if let Err(error) = retire_pane(pane) {
+                self.background_picker.pending_delete = None;
+                self.status = format!("failed to stop background agent {label}: {error:#}");
+                return Ok(());
+            }
         }
+        let _job = self.background_jobs.remove(index);
         self.background_picker.pending_delete = None;
         self.background_picker
             .clamp_cursor(self.background_jobs.len());
@@ -6545,7 +7337,17 @@ impl App {
             .cloned()
             .ok_or_else(|| anyhow!("pane {} has no launch settings", pane_index + 1))?;
         set_spec_auth(&mut spec, auth_env);
-        let pane = self.spawn_pane_instance(&spec, pane_index)?;
+        let mut pane = self.spawn_pane_instance(&spec, pane_index)?;
+
+        if let Err(error) = retire_pane(&mut self.panes[pane_index]) {
+            let cleanup_error = retire_pane(&mut pane).err();
+            return Err(match cleanup_error {
+                Some(cleanup_error) => error.context(format!(
+                    "replacement pane cleanup also failed: {cleanup_error:#}"
+                )),
+                None => error,
+            });
+        }
 
         self.panes[pane_index] = pane;
         if let Some(plan) = &mut self.launch_plan {
@@ -6751,6 +7553,51 @@ impl App {
         swap_set_indices(&mut self.sleeping, first, second);
         self.focus = swapped_index(self.focus, first, second);
         self.status = format!("swapped panes {} and {}", first + 1, second + 1);
+    }
+
+    fn swap_selected_grids(&mut self) {
+        let (first, second) = match selected_swap_pair(&self.selected_grids) {
+            SwapSelection::NeedsMore => {
+                self.status = "select two grids to swap".into();
+                return;
+            }
+            SwapSelection::TooMany => {
+                self.status = "deselect grids until only two are selected".into();
+                return;
+            }
+            SwapSelection::Pair(first, second) => (first, second),
+        };
+
+        if first >= self.tabs.len() || second >= self.tabs.len() {
+            self.status = "select two available grids to swap".into();
+            return;
+        }
+
+        self.save_current_tab();
+        swap_grid_slots(&mut self.tabs, &mut self.active_tab, first, second);
+        if let Some(VoiceDestination::Panes { tab, .. }) = self.voice_destination.as_mut() {
+            *tab = swapped_index(*tab, first, second);
+        }
+
+        // `save_current_tab` just stored the active snapshot and `swap_grid_slots`
+        // moved `active_tab` with it, so this is present. Leaving the swap
+        // applied without a reload beats taking the session down.
+        let Some(snapshot) = self.tabs.get_mut(self.active_tab).and_then(Option::take) else {
+            self.status = "swapped grids; the active grid could not be reloaded".into();
+            return;
+        };
+        self.restore_tab_snapshot(snapshot);
+        self.sync_pane_sizes_for_current_layout();
+        self.status = format!("swapped grids {} and {}", first + 1, second + 1);
+    }
+
+    #[allow(dead_code)]
+    fn delete_selected_grids(&mut self) {
+        self.status = if self.selected_grids.is_empty() {
+            "select one or more grids to delete".into()
+        } else {
+            "selected-grid deletion is not wired yet".into()
+        };
     }
 
     fn handle_settings_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -7052,7 +7899,9 @@ impl App {
                 };
                 let value = edit.buffer.trim().to_string();
                 match edit.target {
-                    ManagerSettingTarget::ActivitySummaries => unreachable!(),
+                    // A switch has no text buffer to commit, so there is nothing
+                    // to save and nothing worth panicking over.
+                    ManagerSettingTarget::ActivitySummaries => return Ok(KeyOutcome::Render),
                     ManagerSettingTarget::Endpoint => self.config.manager.endpoint = value,
                     ManagerSettingTarget::Model => self.config.manager.model = value,
                     ManagerSettingTarget::ApiKey => self.config.manager.api_key = value,
@@ -7139,6 +7988,39 @@ impl App {
         }
 
         if self.mouse_enabled
+            && matches!(
+                mouse.kind,
+                MouseEventKind::Down(MouseButton::Left | MouseButton::Right)
+            )
+            && let Some(index) = self.tab_at(mouse.column, mouse.row)
+        {
+            let selecting = matches!(mouse.kind, MouseEventKind::Down(MouseButton::Right))
+                || mouse
+                    .modifiers
+                    .intersects(KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+            if selecting {
+                self.toggle_grid_selection(index);
+                return Ok(true);
+            }
+
+            let changed = index != self.active_tab;
+            self.switch_to_tab(index);
+            return Ok(changed);
+        }
+
+        if self.mouse_enabled
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && self.ports_button_at(mouse.column, mouse.row)
+        {
+            if self.port_inspector.open {
+                self.close_port_inspector();
+            } else {
+                self.open_port_inspector();
+            }
+            return Ok(true);
+        }
+
+        if self.mouse_enabled
             && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
             && self.background_jobs_button_at(mouse.column, mouse.row)
         {
@@ -7176,6 +8058,14 @@ impl App {
             } else {
                 Ok(false)
             };
+        }
+
+        if self.port_inspector.open {
+            return Ok(if self.mouse_enabled {
+                self.handle_port_inspector_mouse(mouse)
+            } else {
+                false
+            });
         }
 
         if self.previous_panes.open {
@@ -7335,6 +8225,25 @@ impl App {
         Ok(true)
     }
 
+    fn handle_port_inspector_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+
+        let Some(index) = self.port_row_at(mouse.column, mouse.row) else {
+            return false;
+        };
+        self.port_inspector.cursor = index;
+        self.port_inspector.pending_terminate = None;
+        if let Some(port) = self.port_inspector.ports.get(index) {
+            self.status = format!(
+                "port {} | {} | PID {} | {}",
+                port.port, port.process, port.pid, port.owner
+            );
+        }
+        true
+    }
+
     fn handle_pane_settings_mouse(&mut self, mouse: MouseEvent) -> bool {
         if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
             return false;
@@ -7382,6 +8291,12 @@ impl App {
     fn previous_panes_button_at(&self, x: u16, y: u16) -> bool {
         self.previous_panes_button
             .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn tab_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.tab_rects
+            .iter()
+            .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
     }
 
     fn previous_pane_row_at(&self, x: u16, y: u16) -> Option<usize> {
@@ -7560,6 +8475,18 @@ impl App {
 
         let before = self.panes.len();
         let slots = grid_resize_slots(current, next, before);
+        // Rebuilding the pane vectors below moves panes out by index and cannot
+        // be undone partway through, so reject an impossible slot map while the
+        // live grid is still whole.
+        let mut claimed = BTreeSet::new();
+        for old_index in slots.iter().flatten().copied() {
+            if old_index >= before || !claimed.insert(old_index) {
+                return Err(anyhow!(
+                    "grid resize mapped pane {} more than once or out of range",
+                    old_index + 1
+                ));
+            }
+        }
         let old_to_new = slots
             .iter()
             .enumerate()
@@ -7623,32 +8550,31 @@ impl App {
         self.pane_idle = Vec::with_capacity(next.count());
         self.pane_names = Vec::with_capacity(next.count());
         for (new_index, old_index) in slots.iter().copied().enumerate() {
-            if let Some(old_index) = old_index {
-                self.panes.push(
-                    old_panes
-                        .get_mut(old_index)
-                        .and_then(Option::take)
-                        .expect("retained pane index"),
-                );
-                self.pane_idle.push(
-                    old_idle
-                        .get_mut(old_index)
-                        .and_then(Option::take)
-                        .unwrap_or_else(|| PaneIdleState::new(Instant::now())),
-                );
-                self.pane_names.push(
-                    old_names
-                        .get_mut(old_index)
-                        .and_then(Option::take)
-                        .unwrap_or(None),
-                );
-            } else {
-                self.panes
-                    .push(spawned.remove(&new_index).expect("spawned resize pane"));
-                self.pane_idle.push(PaneIdleState::new(Instant::now()));
-                self.pane_names.push(None);
-            }
+            // The slot check above and the spawn loop together guarantee a pane
+            // for every slot. Dropping an unexpectedly empty slot keeps the grid
+            // usable where indexing would have taken the session down.
+            let pane = match old_index {
+                Some(old_index) => old_panes.get_mut(old_index).and_then(Option::take),
+                None => spawned.remove(&new_index),
+            };
+            let Some(pane) = pane else {
+                continue;
+            };
+            self.panes.push(pane);
+            self.pane_idle.push(match old_index {
+                Some(old_index) => old_idle
+                    .get_mut(old_index)
+                    .and_then(Option::take)
+                    .unwrap_or_else(|| PaneIdleState::new(Instant::now())),
+                None => PaneIdleState::new(Instant::now()),
+            });
+            self.pane_names.push(match old_index {
+                Some(old_index) => old_names.get_mut(old_index).and_then(Option::take).flatten(),
+                None => None,
+            });
         }
+        let removed_cleanup_error =
+            retire_panes(old_panes.iter_mut().filter_map(Option::as_mut)).err();
 
         let old_focus = self.focus;
         self.focus = resized_focus_index(old_focus, current, next, &old_to_new);
@@ -7691,6 +8617,10 @@ impl App {
         } else {
             format!("grid resized to {}x{}", next.rows, next.columns)
         };
+        if let Some(error) = removed_cleanup_error {
+            self.status
+                .push_str(&format!("; pane cleanup reported: {error:#}"));
+        }
 
         Ok(())
     }
@@ -7704,6 +8634,11 @@ impl App {
         if pane_index >= before {
             self.pane_settings.close();
             self.status = format!("pane {} is no longer available", pane_index + 1);
+            return;
+        }
+
+        if let Err(error) = retire_pane(&mut self.panes[pane_index]) {
+            self.status = format!("failed to deactivate pane {}: {error:#}", pane_index + 1);
             return;
         }
 
@@ -7748,6 +8683,7 @@ impl App {
 
         self.pane_render_cache.borrow_mut().remove(&removed_id);
         self.applied_workloads.remove(&removed_id);
+        self.activity_summary_states.remove(&removed_id);
 
         let next_plan = self.launch_plan.as_mut().map(|plan| {
             if pane_index < plan.panes.len() {
@@ -8023,6 +8959,13 @@ impl App {
                 }
             }
         }
+        for job in &mut self.background_jobs {
+            if let Some(pane) = job.pane.as_mut()
+                && let Err(error) = pane.set_keep_running(keep_running)
+            {
+                first_error.get_or_insert(error);
+            }
+        }
         if let Some(error) = first_error {
             self.status = format!("saved setting; failed to update a pane host: {error:#}");
         }
@@ -8234,6 +9177,46 @@ impl App {
     fn route_input(&mut self, bytes: &[u8]) -> Result<bool> {
         let targets = self.input_targets();
         self.route_input_to_targets(bytes, targets)
+    }
+
+    /// Delivers pasted text as a paste rather than as keystrokes, so a
+    /// multi-line paste lands in the pane program's editor instead of
+    /// submitting each line. The wrapping is decided per pane because only the
+    /// program running there knows whether it asked for bracketed paste.
+    fn route_paste(&mut self, text: &str) -> Result<bool> {
+        let mut skipped_exited = 0;
+        let mut changed = false;
+
+        for index in self.input_targets() {
+            let pane = self
+                .panes
+                .get_mut(index)
+                .ok_or_else(|| anyhow!("invalid pane index {index}"))?;
+            if pane.exited {
+                skipped_exited += 1;
+                continue;
+            }
+            let bytes = paste_bytes(text, pane.screen().bracketed_paste());
+            changed |= pane.reset_view();
+            pane.write(&bytes)
+                .with_context(|| format!("failed to paste into pane {}", index + 1))?;
+            pane.record_input(&bytes);
+            self.mark_pane_touched(index);
+        }
+
+        if skipped_exited > 0 {
+            self.status = if skipped_exited == 1 {
+                "pane exited; press R or Enter to restart, Z to sleep".into()
+            } else {
+                format!(
+                    "skipped {skipped_exited} exited {}; press Alt+t to restart them",
+                    pane_word(skipped_exited)
+                )
+            };
+            return Ok(true);
+        }
+
+        Ok(changed)
     }
 
     fn route_input_to_targets(&mut self, bytes: &[u8], targets: Vec<usize>) -> Result<bool> {
@@ -8550,6 +9533,10 @@ impl App {
         &self.selected
     }
 
+    pub fn selected_grid_count(&self) -> usize {
+        self.selected_grids.len()
+    }
+
     pub fn selection_for_pane(&self, index: usize) -> Option<PaneSelection> {
         self.text_selection
             .filter(|selection| selection.pane == index)
@@ -8569,6 +9556,22 @@ impl App {
 
     pub fn status(&self) -> &str {
         &self.status
+    }
+
+    pub fn quit_confirmation_view(&self) -> Option<QuitConfirmationView> {
+        self.quit_confirmation_pending.then_some(())?;
+        Some(QuitConfirmationView {
+            resume_command: self.resume_command()?,
+            keeps_terminals_running: self.settings.keep_terminals_running,
+        })
+    }
+
+    pub fn close_grid_confirmation_view(&self) -> Option<CloseGridConfirmationView> {
+        self.close_grid_confirmation_pending
+            .then(|| CloseGridConfirmationView {
+                title: self.tab_title.clone(),
+                pane_count: self.panes.len(),
+            })
     }
 
     pub fn grid_resizer(&self) -> Option<&GridPicker> {
@@ -8737,6 +9740,12 @@ impl App {
                     return TabLabel {
                         title: self.tab_title.clone(),
                         active: true,
+                        selected: self.selected_grids.contains(&index),
+                        waiting: tab_has_waiting_agent(
+                            &self.panes,
+                            &self.sleeping,
+                            self.launch_plan.as_ref(),
+                        ),
                         activity: self.panes.iter().any(|pane| pane.active),
                         exited: !self.panes.is_empty() && self.panes.iter().all(|pane| pane.exited),
                     };
@@ -8746,6 +9755,8 @@ impl App {
                     return TabLabel {
                         title: format!("Grid {}", index + 1),
                         active: false,
+                        selected: self.selected_grids.contains(&index),
+                        waiting: false,
                         activity: false,
                         exited: false,
                     };
@@ -8754,6 +9765,12 @@ impl App {
                 TabLabel {
                     title: tab.title.clone(),
                     active: false,
+                    selected: self.selected_grids.contains(&index),
+                    waiting: tab_has_waiting_agent(
+                        &tab.panes,
+                        &tab.sleeping,
+                        tab.launch_plan.as_ref(),
+                    ),
                     activity: tab.panes.iter().any(|pane| pane.active),
                     exited: !tab.panes.is_empty() && tab.panes.iter().all(|pane| pane.exited),
                 }
@@ -8866,6 +9883,48 @@ impl App {
         self.background_job_rows
             .iter()
             .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
+    }
+
+    fn ports_button_at(&self, x: u16, y: u16) -> bool {
+        self.ports_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn port_row_at(&self, x: u16, y: u16) -> Option<usize> {
+        self.port_rows
+            .iter()
+            .find_map(|(index, rect)| rect_contains(*rect, x, y).then_some(*index))
+    }
+
+    pub fn port_inspector_view(&self) -> Option<PortInspectorView> {
+        self.port_inspector.open.then(|| PortInspectorView {
+            ports: self
+                .port_inspector
+                .ports
+                .iter()
+                .map(|port| AgentPortView {
+                    port: port.port,
+                    pid: port.pid,
+                    process: port.process.clone(),
+                    owner: port.owner.clone(),
+                })
+                .collect(),
+            cursor: self
+                .port_inspector
+                .cursor
+                .min(self.port_inspector.ports.len().saturating_sub(1)),
+            pending_terminate: self.port_inspector.pending_terminate,
+            refreshing: self.port_inspector.refreshing,
+            error: self.port_inspector.error.clone(),
+        })
+    }
+
+    pub fn agent_port_count(&self) -> usize {
+        self.port_inspector.ports.len()
+    }
+
+    pub fn port_inspector_open(&self) -> bool {
+        self.port_inspector.open
     }
 
     pub fn background_jobs_view(&self) -> Option<BackgroundJobsView> {
@@ -9161,11 +10220,15 @@ impl App {
         }
     }
 
+    fn sync_pane_sizes_for_current_layout(&mut self) {
+        self.rects = self.pane_rects(self.grid_area);
+        self.sync_pane_sizes();
+    }
+
     fn sync_initial_pane_sizes(&mut self, terminal: &Tui) -> Result<()> {
         let size = terminal.size().context("failed to read terminal size")?;
         self.grid_area = Rect::new(0, 1, size.width, size.height.saturating_sub(3));
-        self.rects = self.pane_rects(self.grid_area);
-        self.sync_pane_sizes();
+        self.sync_pane_sizes_for_current_layout();
         Ok(())
     }
 
@@ -9212,8 +10275,10 @@ impl App {
         self.status = "refreshing auth profiles".into();
 
         thread::spawn(move || {
-            let result = auth::discover_profiles_with_usage(&auth_config)
-                .map_err(|error| format!("{error:#}"));
+            let result = diagnostics::recovering("the auth profile refresh", || {
+                auth::discover_profiles_with_usage(&auth_config)
+                    .map_err(|error| format!("{error:#}"))
+            });
             let _ = tx.send(result);
         });
     }
@@ -9416,6 +10481,12 @@ impl App {
         Ok(())
     }
 
+    fn resume_command(&self) -> Option<String> {
+        self.session_recorder
+            .as_ref()
+            .map(SessionRecorder::resume_command)
+    }
+
     fn save_session_snapshot(&mut self) -> Result<()> {
         let Some(plan) = self.launch_plan.clone() else {
             return Ok(());
@@ -9500,6 +10571,83 @@ fn agent_shell_fallback_spec(
     shell_spec.auth_kind = None;
     shell_spec.auth_dir = None;
     Ok(Some((shell_spec, agent_label, shell_label)))
+}
+
+#[derive(Debug, Clone)]
+pub struct PortInspectorView {
+    pub ports: Vec<AgentPortView>,
+    pub cursor: usize,
+    pub pending_terminate: Option<u32>,
+    pub refreshing: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentPortView {
+    pub port: u16,
+    pub pid: u32,
+    pub process: String,
+    pub owner: String,
+}
+
+#[derive(Debug, Default)]
+struct PortInspectorState {
+    open: bool,
+    ports: Vec<AgentPort>,
+    cursor: usize,
+    pending_terminate: Option<u32>,
+    refreshing: bool,
+    last_scan: Option<Instant>,
+    error: Option<String>,
+}
+
+impl PortInspectorState {
+    fn close(&mut self) {
+        self.open = false;
+        self.pending_terminate = None;
+    }
+
+    fn move_cursor(&mut self, delta: isize) {
+        if self.ports.is_empty() {
+            self.cursor = 0;
+        } else {
+            self.cursor = (self.cursor as isize + delta)
+                .clamp(0, self.ports.len().saturating_sub(1) as isize)
+                as usize;
+        }
+        self.pending_terminate = None;
+    }
+
+    fn clamp_cursor(&mut self) {
+        self.cursor = self.cursor.min(self.ports.len().saturating_sub(1));
+        if self
+            .pending_terminate
+            .is_some_and(|pid| !self.ports.iter().any(|port| port.pid == pid))
+        {
+            self.pending_terminate = None;
+        }
+    }
+}
+
+fn agent_recovery_targets(exited: &[bool], specs: &[PaneLaunchSpec]) -> Vec<usize> {
+    exited
+        .iter()
+        .zip(specs)
+        .enumerate()
+        .filter_map(|(index, (exited, spec))| {
+            (*exited && spec.agent_label().is_some()).then_some(index)
+        })
+        .collect()
+}
+
+fn port_owner_label(tab_title: &str, pane_names: &[Option<String>], index: usize) -> String {
+    let pane = pane_names
+        .get(index)
+        .and_then(|name| name.as_deref())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Pane {}", index + 1));
+    format!("{tab_title} / {pane}")
 }
 
 fn adaptive_output_frame_interval(refresh_ms: i32, pane_count: usize) -> Duration {
@@ -9684,6 +10832,31 @@ fn pane_awareness_state(
     } else {
         "active"
     }
+}
+
+fn tab_has_waiting_agent(
+    panes: &[PtyPane],
+    sleeping: &BTreeSet<usize>,
+    launch_plan: Option<&LaunchPlan>,
+) -> bool {
+    // Quiet output is the local attention signal; limiting it to known agent
+    // launch specs keeps ordinary idle shells from lighting up their tabs.
+    let Some(plan) = launch_plan else {
+        return false;
+    };
+
+    panes.iter().enumerate().any(|(index, pane)| {
+        pane_needs_user_input(
+            plan.panes.get(index).is_some_and(PaneLaunchSpec::is_agent),
+            sleeping.contains(&index),
+            pane.exited,
+            pane.output_quiet(),
+        )
+    })
+}
+
+fn pane_needs_user_input(is_agent: bool, sleeping: bool, exited: bool, output_quiet: bool) -> bool {
+    is_agent && !sleeping && !exited && output_quiet
 }
 
 fn bounded_tail_chars(value: &str, max_chars: usize) -> (String, bool) {
@@ -10127,17 +11300,18 @@ fn goal_target_index(
         .iter()
         .find(|target| target.pane_number == pane_number)
         .ok_or_else(|| format!("pane {pane_number} was not an available target"))?;
-    let index = current
+    let (index, state) = current
         .iter()
-        .position(|pane| {
+        .enumerate()
+        .find(|(_, pane)| {
             pane.pane_id == target.pane_id && pane.pane_generation == target.pane_generation
         })
         .ok_or_else(|| format!("pane {pane_number} changed before dispatch"))?;
-    if current[index].unavailable {
+    if state.unavailable {
         return Err(format!("pane {pane_number} became unavailable"));
     }
-    if current[index].screen_revision != target.screen_revision
-        || current[index].input_revision != target.input_revision
+    if state.screen_revision != target.screen_revision
+        || state.input_revision != target.input_revision
     {
         return Err(format!("pane {pane_number} changed before dispatch"));
     }
@@ -10169,10 +11343,15 @@ fn goal_command_plan<'a>(
     for command in commands {
         match goal_target_index(targets, command.pane, current) {
             Ok(index) => {
-                let target = &targets[targets
+                // `goal_target_index` only succeeds for a pane that is in
+                // `targets`, so this lookup mirrors the one it already made.
+                let Some(target) = targets
                     .iter()
-                    .position(|target| target.pane_number == command.pane)
-                    .expect("validated goal target")];
+                    .find(|target| target.pane_number == command.pane)
+                else {
+                    failures.push(format!("pane {} was not an available target", command.pane));
+                    continue;
+                };
                 let key = GoalCommandKey {
                     pane_id: target.pane_id,
                     pane_generation: target.pane_generation,
@@ -10500,12 +11679,54 @@ fn trim_goal_buffer(buffer: &mut String) {
     }
     buffer.drain(..keep_from);
 }
-fn paste_and_enter_bytes(text: &str) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(text.len() + 16);
+/// Terminals hand pasted line breaks to the child as carriage returns, and must
+/// not let the payload smuggle in its own paste terminator.
+fn normalize_paste_text(text: &str) -> String {
+    text.replace("\x1b[201~", "")
+        .replace("\r\n", "\r")
+        .replace('\n', "\r")
+}
+
+/// Encodes pasted text for a pane, bracketing it when the program running there
+/// enabled bracketed paste so the whole block arrives as one paste instead of
+/// one Enter per line.
+fn paste_bytes(text: &str, bracketed: bool) -> Vec<u8> {
+    let text = normalize_paste_text(text);
+    if !bracketed {
+        return text.into_bytes();
+    }
+
+    let mut bytes = Vec::with_capacity(text.len() + 12);
     bytes.extend_from_slice(b"\x1b[200~");
     bytes.extend_from_slice(text.as_bytes());
-    bytes.extend_from_slice(b"\x1b[201~\r");
+    bytes.extend_from_slice(b"\x1b[201~");
     bytes
+}
+
+fn paste_and_enter_bytes(text: &str) -> Vec<u8> {
+    let mut bytes = paste_bytes(text, true);
+    bytes.push(b'\r');
+    bytes
+}
+
+fn paste_burst_char(event: &Event) -> Option<char> {
+    let Event::Key(key) = event else {
+        return None;
+    };
+    if key.kind != KeyEventKind::Press
+        || key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
+    {
+        return None;
+    }
+
+    match key.code {
+        KeyCode::Char(ch) => Some(ch),
+        KeyCode::Enter => Some('\n'),
+        KeyCode::Tab => Some('\t'),
+        _ => None,
+    }
 }
 
 fn toggle_selection(selected: &mut BTreeSet<usize>, index: usize) -> bool {
@@ -10523,7 +11744,10 @@ fn spawn_hidden_command(
     event_tx: mpsc::UnboundedSender<CommandRunEvent>,
 ) {
     thread::spawn(move || {
-        let event = match run_shell_command(&command, &cwd) {
+        let output = diagnostics::recovering("the command", || {
+            run_shell_command(&command, &cwd).map_err(|error| format!("{error:#}"))
+        });
+        let event = match output {
             Ok(output) => CommandRunEvent {
                 command,
                 stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
@@ -10536,7 +11760,7 @@ fn spawn_hidden_command(
                 stdout: String::new(),
                 stderr: String::new(),
                 exit_code: None,
-                error: Some(format!("{error:#}")),
+                error: Some(error),
             },
         };
         let _ = event_tx.send(event);
@@ -10671,9 +11895,10 @@ fn selected_swap_pair(selected: &BTreeSet<usize>) -> SwapSelection {
         0 | 1 => SwapSelection::NeedsMore,
         2 => {
             let mut selected = selected.iter().copied();
-            let first = selected.next().expect("pair has a first index");
-            let second = selected.next().expect("pair has a second index");
-            SwapSelection::Pair(first, second)
+            match (selected.next(), selected.next()) {
+                (Some(first), Some(second)) => SwapSelection::Pair(first, second),
+                _ => SwapSelection::NeedsMore,
+            }
         }
         _ => SwapSelection::TooMany,
     }
@@ -10699,6 +11924,15 @@ fn swapped_index(index: usize, first: usize, second: usize) -> usize {
     } else {
         index
     }
+}
+
+fn tab_index_after_close(active: usize, tab_count: usize) -> Option<usize> {
+    (tab_count > 1).then(|| active.min(tab_count - 2))
+}
+
+fn swap_grid_slots<T>(slots: &mut [T], active: &mut usize, first: usize, second: usize) {
+    slots.swap(first, second);
+    *active = swapped_index(*active, first, second);
 }
 
 fn wrapped_row_focus_target(
@@ -10843,6 +12077,22 @@ fn exited_recovery_action_for(key: KeyEvent) -> Option<ExitedRecoveryAction> {
             _ => None,
         },
         _ => None,
+    }
+}
+
+fn close_grid_confirmation_action(key: KeyEvent) -> CloseGridConfirmationAction {
+    if key.modifiers.contains(KeyModifiers::ALT) || key.modifiers.contains(KeyModifiers::CONTROL) {
+        return CloseGridConfirmationAction::Continue;
+    }
+    match key.code {
+        KeyCode::Enter => CloseGridConfirmationAction::Confirm,
+        KeyCode::Esc => CloseGridConfirmationAction::Cancel,
+        KeyCode::Char(ch) => match ch.to_ascii_lowercase() {
+            'y' => CloseGridConfirmationAction::Confirm,
+            'n' => CloseGridConfirmationAction::Cancel,
+            _ => CloseGridConfirmationAction::Continue,
+        },
+        _ => CloseGridConfirmationAction::Continue,
     }
 }
 
@@ -11696,10 +12946,116 @@ mod tests {
     }
 
     #[test]
+    fn pasted_line_breaks_become_carriage_returns() {
+        assert_eq!(normalize_paste_text("one\ntwo"), "one\rtwo");
+        assert_eq!(normalize_paste_text("one\r\ntwo\n"), "one\rtwo\r");
+        assert_eq!(normalize_paste_text("one\rtwo"), "one\rtwo");
+    }
+
+    #[test]
+    fn pasted_text_cannot_close_the_bracketed_region_early() {
+        assert_eq!(
+            paste_bytes("safe\x1b[201~rm -rf /\n", true),
+            b"\x1b[200~saferm -rf /\r\x1b[201~".to_vec()
+        );
+    }
+
+    #[test]
+    fn paste_is_bracketed_only_when_the_pane_program_asked_for_it() {
+        assert_eq!(
+            paste_bytes("one\ntwo", true),
+            b"\x1b[200~one\rtwo\x1b[201~".to_vec()
+        );
+        assert_eq!(paste_bytes("one\ntwo", false), b"one\rtwo".to_vec());
+    }
+
+    #[test]
+    fn agent_commands_still_paste_and_submit() {
+        assert_eq!(
+            paste_and_enter_bytes("echo hi"),
+            b"\x1b[200~echo hi\x1b[201~\r".to_vec()
+        );
+    }
+
+    #[test]
+    fn paste_bursts_only_collect_unmodified_text_keys() {
+        let press = |code, modifiers| Event::Key(KeyEvent::new(code, modifiers));
+
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Char('a'), KeyModifiers::NONE)),
+            Some('a')
+        );
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Char('A'), KeyModifiers::SHIFT)),
+            Some('A')
+        );
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Enter, KeyModifiers::NONE)),
+            Some('\n')
+        );
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            None
+        );
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Char('t'), KeyModifiers::ALT)),
+            None
+        );
+        assert_eq!(
+            paste_burst_char(&press(KeyCode::Up, KeyModifiers::NONE)),
+            None
+        );
+        assert_eq!(paste_burst_char(&Event::FocusGained), None);
+    }
+
+    #[test]
     fn swapped_index_follows_the_swapped_pair() {
         assert_eq!(swapped_index(0, 0, 2), 2);
         assert_eq!(swapped_index(2, 0, 2), 0);
         assert_eq!(swapped_index(4, 0, 2), 4);
+    }
+
+    #[test]
+    fn closing_a_grid_keeps_the_next_slot_or_falls_back_to_the_previous_one() {
+        assert_eq!(tab_index_after_close(0, 3), Some(0));
+        assert_eq!(tab_index_after_close(1, 3), Some(1));
+        assert_eq!(tab_index_after_close(2, 3), Some(1));
+        assert_eq!(tab_index_after_close(0, 1), None);
+    }
+
+    #[test]
+    fn close_grid_confirmation_requires_an_explicit_choice() {
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Confirm
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('Y'), KeyModifiers::SHIFT)),
+            CloseGridConfirmationAction::Confirm
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Cancel
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            CloseGridConfirmationAction::Cancel
+        );
+        assert_eq!(
+            close_grid_confirmation_action(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT)),
+            CloseGridConfirmationAction::Continue
+        );
+    }
+
+    #[test]
+    fn swapping_grid_slots_moves_the_active_grid_with_its_contents() {
+        let mut grids = vec!["frontend", "backend", "tests"];
+        let mut active = 0;
+
+        swap_grid_slots(&mut grids, &mut active, 0, 2);
+
+        assert_eq!(grids, vec!["tests", "backend", "frontend"]);
+        assert_eq!(active, 2);
     }
 
     #[test]
@@ -11882,6 +13238,12 @@ mod tests {
             agent_shell_fallback_spec(&config, &shell_spec, &shell_spec.cwd)
                 .expect("terminal fallback check")
                 .is_none()
+        );
+
+        let specs = vec![spec.clone(), spec.clone(), shell_spec.clone(), spec.clone()];
+        assert_eq!(
+            agent_recovery_targets(&[true, true, true, true], &specs),
+            vec![0, 1, 3]
         );
     }
 
@@ -12417,57 +13779,206 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
 fn setup_terminal(enable_mouse: bool) -> Result<Tui> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(
+    if let Err(error) = execute!(
         stdout,
         EnterAlternateScreen,
         EnableBracketedPaste,
         EnableFocusChange
-    )?;
+    ) {
+        let _ = restore_terminal_output(&mut stdout, enable_mouse);
+        return Err(error).context("failed to initialize terminal screen state");
+    }
     if enable_mouse {
-        execute!(stdout, EnableMouseCapture)?;
+        if let Err(error) = execute!(stdout, EnableMouseCapture) {
+            let _ = restore_terminal_output(&mut stdout, enable_mouse);
+            return Err(error).context("failed to enable terminal mouse capture");
+        }
     }
     let backend = CrosstermBackend::new(stdout);
-    Terminal::new(backend).context("failed to create terminal")
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(error) => {
+            let mut stdout = io::stdout();
+            let _ = restore_terminal_output(&mut stdout, enable_mouse);
+            Err(error).context("failed to create terminal")
+        }
+    }
 }
 
 fn teardown_terminal(terminal: &mut Tui, enable_mouse: bool) -> Result<()> {
-    disable_raw_mode()?;
-    if enable_mouse {
-        execute!(terminal.backend_mut(), DisableMouseCapture)?;
-    }
-    execute!(
-        terminal.backend_mut(),
-        DisableBracketedPaste,
-        DisableFocusChange,
-        DisableMouseCapture,
-        LeaveAlternateScreen
-    )?;
-    terminal.show_cursor()?;
-    Ok(())
+    restore_terminal_output(terminal.backend_mut(), enable_mouse)
 }
 
 fn suspend_terminal(terminal: &mut Tui) -> Result<()> {
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        DisableBracketedPaste,
-        DisableFocusChange,
-        DisableMouseCapture,
-        LeaveAlternateScreen
-    )?;
-    terminal.show_cursor()?;
-    Ok(())
+    restore_terminal_output(terminal.backend_mut(), true)
 }
 
 fn resume_terminal(terminal: &mut Tui) -> Result<()> {
     enable_raw_mode()?;
-    execute!(
+    if let Err(error) = execute!(
         terminal.backend_mut(),
         EnterAlternateScreen,
         EnableBracketedPaste,
         EnableFocusChange
-    )?;
+    ) {
+        let _ = restore_terminal_output(terminal.backend_mut(), true);
+        return Err(error).context("failed to restore terminal screen state");
+    }
     Ok(())
+}
+
+fn restore_terminal_output(output: &mut impl Write, enable_mouse: bool) -> Result<()> {
+    let mut first_error = disable_raw_mode()
+        .err()
+        .map(|error| anyhow!(error).context("failed to disable raw terminal mode"));
+
+    macro_rules! attempt {
+        ($command:expr, $context:literal) => {
+            if let Err(error) = execute!(output, $command) {
+                if first_error.is_none() {
+                    first_error = Some(anyhow!(error).context($context));
+                }
+            }
+        };
+    }
+
+    if enable_mouse {
+        attempt!(
+            DisableMouseCapture,
+            "failed to disable terminal mouse capture"
+        );
+    }
+    attempt!(DisableBracketedPaste, "failed to disable bracketed paste");
+    attempt!(DisableFocusChange, "failed to disable focus tracking");
+    attempt!(
+        DisableMouseCapture,
+        "failed to reset terminal mouse capture"
+    );
+    attempt!(LeaveAlternateScreen, "failed to leave alternate screen");
+    attempt!(Show, "failed to restore terminal cursor");
+
+    first_error.map_or(Ok(()), Err)
+}
+
+/// Render bookkeeping the event loop carries between iterations.
+///
+/// It lives in a struct rather than in locals so the loop body can be a method
+/// that `run_loop` calls behind `catch_unwind`.
+struct LoopState {
+    immediate_render: bool,
+    output_render: bool,
+    last_render: Instant,
+    mouse_capture_enabled: bool,
+}
+
+enum LoopStep {
+    Continue,
+    Quit,
+}
+
+/// Rolling allowance for failures the event loop recovers from.
+///
+/// Recovering forever would be worse than exiting: a session that panics on
+/// every frame would spin without ever telling the user why. The window means a
+/// long session is not condemned by failures it already shrugged off.
+struct FailureBudget {
+    window_started: Instant,
+    count: u32,
+    max: u32,
+}
+
+impl FailureBudget {
+    const WINDOW: Duration = Duration::from_secs(60);
+
+    fn new(max: u32) -> Self {
+        Self {
+            window_started: Instant::now(),
+            count: 0,
+            max,
+        }
+    }
+
+    /// Records a failure, returning true when the loop should give up.
+    fn record(&mut self) -> bool {
+        if self.window_started.elapsed() >= Self::WINDOW {
+            self.window_started = Instant::now();
+            self.count = 0;
+        }
+        self.count = self.count.saturating_add(1);
+        self.count > self.max
+    }
+
+    fn count(&self) -> u32 {
+        self.count
+    }
+}
+
+struct TerminalRestoreGuard {
+    enable_mouse: bool,
+    armed: bool,
+}
+
+impl TerminalRestoreGuard {
+    fn new(enable_mouse: bool) -> Self {
+        Self {
+            enable_mouse,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = restore_terminal_output(&mut io::stdout(), self.enable_mouse);
+        }
+    }
+}
+
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync + 'static>;
+
+struct TerminalPanicHookGuard {
+    previous: std::sync::Arc<std::sync::Mutex<Option<PanicHook>>>,
+}
+
+impl TerminalPanicHookGuard {
+    fn install(enable_mouse: bool) -> Self {
+        let previous = std::sync::Arc::new(std::sync::Mutex::new(Some(std::panic::take_hook())));
+        let hook_previous = previous.clone();
+        let ui_thread = thread::current().id();
+        std::panic::set_hook(Box::new(move |info| {
+            // A shielded panic is about to be caught and recovered, so the
+            // alternate screen has to survive it.
+            if thread::current().id() == ui_thread && !diagnostics::panics_are_shielded() {
+                let _ = restore_terminal_output(&mut io::stdout(), enable_mouse);
+            }
+            let guard = hook_previous
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(previous) = guard.as_ref() {
+                previous(info);
+            }
+        }));
+        Self { previous }
+    }
+}
+
+impl Drop for TerminalPanicHookGuard {
+    fn drop(&mut self) {
+        let _installed = std::panic::take_hook();
+        let previous = self
+            .previous
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(previous) = previous {
+            std::panic::set_hook(previous);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -12490,6 +14001,50 @@ mod selection_tests {
             byte_budget.record(32 * 1024);
         }
         assert!(!byte_budget.within_size_limits());
+    }
+
+    /// The event loop recovers from failures instead of exiting, so the budget
+    /// is the only thing stopping a session that panics on every frame from
+    /// spinning silently forever.
+    #[test]
+    fn the_failure_budget_gives_up_only_after_its_allowance() {
+        let mut budget = FailureBudget::new(3);
+        for expected in 1..=3 {
+            assert!(!budget.record(), "failure {expected} is within the allowance");
+            assert_eq!(budget.count(), expected);
+        }
+        assert!(budget.record(), "the fourth failure exhausts the allowance");
+
+        // A window that has elapsed starts the count over, so a long session is
+        // not condemned by failures it already recovered from.
+        budget.window_started = Instant::now() - FailureBudget::WINDOW;
+        assert!(!budget.record());
+        assert_eq!(budget.count(), 1);
+    }
+
+    /// A worker thread answers over a channel. A panicking worker that never
+    /// answers leaves its request in flight for the rest of the session, so the
+    /// panic has to come back as an error instead.
+    #[test]
+    fn a_panicking_worker_reports_an_error_instead_of_going_silent() {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let panicked =
+            diagnostics::recovering::<u8>("the test worker", || panic!("worker exploded"));
+        let succeeded = diagnostics::recovering("the test worker", || Ok(7_u8));
+        let failed =
+            diagnostics::recovering::<u8>("the test worker", || Err("ordinary failure".into()));
+        std::panic::set_hook(previous);
+
+        let message = panicked.expect_err("a panicking worker must report a failure");
+        assert!(message.contains("the test worker"), "message: {message}");
+        assert!(message.contains("worker exploded"), "message: {message}");
+        assert_eq!(succeeded, Ok(7));
+        assert_eq!(failed, Err("ordinary failure".into()));
+        assert!(
+            !diagnostics::panics_are_shielded(),
+            "the shield must lift once the panic is handled"
+        );
     }
 
     #[test]
@@ -12596,6 +14151,15 @@ mod selection_tests {
         assert!(!activity_summary_request_eligible(
             &state, false, true, true, now
         ));
+    }
+
+    #[test]
+    fn waiting_tabs_require_a_live_awake_quiet_agent() {
+        assert!(pane_needs_user_input(true, false, false, true));
+        assert!(!pane_needs_user_input(false, false, false, true));
+        assert!(!pane_needs_user_input(true, true, false, true));
+        assert!(!pane_needs_user_input(true, false, true, true));
+        assert!(!pane_needs_user_input(true, false, false, false));
     }
 
     #[test]
@@ -13223,5 +14787,33 @@ mod selection_tests {
             .find(|row| row.label == "AI activity summaries")
             .expect("AI activity summary row");
         assert_eq!(summaries.value, "on");
+    }
+
+    #[test]
+    fn port_inspector_navigation_clears_termination_confirmation() {
+        let mut inspector = PortInspectorState {
+            open: true,
+            ports: vec![
+                AgentPort {
+                    port: 3000,
+                    pid: 30,
+                    process: "node".into(),
+                    owner: "Grid 1 / Pane 1".into(),
+                },
+                AgentPort {
+                    port: 8080,
+                    pid: 80,
+                    process: "python".into(),
+                    owner: "Grid 1 / Pane 2".into(),
+                },
+            ],
+            pending_terminate: Some(30),
+            ..PortInspectorState::default()
+        };
+
+        inspector.move_cursor(1);
+
+        assert_eq!(inspector.cursor, 1);
+        assert_eq!(inspector.pending_terminate, None);
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -580,8 +580,12 @@ fn mask_email(email: &str) -> String {
     let Some((local, domain)) = email.split_once('@') else {
         return email.to_string();
     };
-    if local.len() > 4 {
-        format!("{}...@{domain}", &local[..4])
+    // Count characters, not bytes: a byte slice of a non-ASCII local part can
+    // land mid-character, and slicing there panics.
+    let mut kept = local.chars();
+    let prefix = kept.by_ref().take(4).collect::<String>();
+    if kept.next().is_some() {
+        format!("{prefix}...@{domain}")
     } else {
         format!("{local}@{domain}")
     }
@@ -623,6 +627,20 @@ mod tests {
     };
 
     use super::*;
+
+    /// Byte-slicing the local part panicked whenever the fourth byte landed
+    /// inside a character, which any non-ASCII address can do. The address comes
+    /// out of an agent's credential file, so it is not GridBash's to validate.
+    #[test]
+    fn masking_a_multibyte_email_keeps_whole_characters() {
+        assert_eq!(mask_email("aé😀xx@example.com"), "aé😀x...@example.com");
+        assert_eq!(mask_email("日本語のなまえ@example.com"), "日本語の...@example.com");
+        assert_eq!(mask_email("abcde@example.com"), "abcd...@example.com");
+        assert_eq!(mask_email("abcd@example.com"), "abcd@example.com");
+        assert_eq!(mask_email("a@example.com"), "a@example.com");
+        assert_eq!(mask_email("@example.com"), "@example.com");
+        assert_eq!(mask_email("not-an-email"), "not-an-email");
+    }
 
     struct TempHome {
         path: PathBuf,

--- a/src/bin/gridbash-voice.rs
+++ b/src/bin/gridbash-voice.rs
@@ -150,8 +150,12 @@ mod linux {
             .play()
             .context("failed to start microphone capture")?;
         loop {
-            if state.lock().expect("capture state poisoned").done {
-                break;
+            match state.lock() {
+                Ok(guard) if !guard.done => drop(guard),
+                // A poisoned lock means the capture callback panicked. Stop
+                // waiting rather than spinning on state nothing will update
+                // again; the `into_inner` below reports it.
+                Ok(_) | Err(_) => break,
             }
             thread::sleep(Duration::from_millis(25));
         }
@@ -199,6 +203,11 @@ mod linux {
         T: Sample,
         f32: FromSample<T>,
     {
+        // `chunks_exact(0)` panics, and this runs on the audio callback thread
+        // where a panic poisons the capture state.
+        if channels == 0 {
+            return;
+        }
         let Ok(mut state) = state.try_lock() else {
             return;
         };
@@ -230,9 +239,11 @@ mod linux {
         (0..output_len)
             .map(|index| {
                 let source = index as f64 * ratio;
-                let left = source.floor() as usize;
-                let right = (left + 1).min(input.len() - 1);
-                let blend = (source - left as f64) as f32;
+                // Rounding can push the scaled index one past the last sample.
+                let last = input.len().saturating_sub(1);
+                let left = (source.floor() as usize).min(last);
+                let right = left.saturating_add(1).min(last);
+                let blend = (source - left as f64).clamp(0.0, 1.0) as f32;
                 input[left] * (1.0 - blend) + input[right] * blend
             })
             .collect()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,6 +118,10 @@ pub struct ResumeArgs {
     /// Resume the most recently updated session without prompting.
     #[arg(long)]
     pub latest: bool,
+
+    /// Permanently delete the selected saved session instead of resuming it.
+    #[arg(long, conflicts_with_all = ["list", "latest"])]
+    pub delete: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/src/codex_sqlite.rs
+++ b/src/codex_sqlite.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use directories::ProjectDirs;
 use fs4::{FileExt, TryLockError};
+use rusqlite::{Connection, OpenFlags};
 
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
@@ -18,6 +19,8 @@ const CODEX_SQLITE_HOME_ENV: &str = "CODEX_SQLITE_HOME";
 const GRIDBASH_MANAGED_CODEX_SQLITE_ENV: &str = "GRIDBASH_MANAGED_CODEX_SQLITE_HOME";
 const DEFAULT_CODEX_HOME_SCOPE: &str = "<default>";
 const MAX_CODEX_SQLITE_LANES: usize = 4096;
+const CODEX_STATE_DB_PREFIX: &str = "state_";
+const CODEX_STATE_DB_SUFFIX: &str = ".sqlite";
 
 pub(crate) struct CodexSqlitePool {
     root: PathBuf,
@@ -37,6 +40,7 @@ impl Drop for CodexSqliteLease {
 
 pub(crate) struct PaneCodexSqlite {
     pub(crate) env: Vec<(OsString, OsString)>,
+    pub(crate) home: Option<PathBuf>,
     pub(crate) lease: Option<CodexSqliteLease>,
 }
 
@@ -73,6 +77,7 @@ impl CodexSqlitePool {
         if has_explicit_sqlite_home(pane_env, inherited_sqlite_home, inherited_managed_home) {
             return Ok(PaneCodexSqlite {
                 env: Vec::new(),
+                home: explicit_sqlite_home(pane_env, inherited_sqlite_home),
                 lease: None,
             });
         }
@@ -86,6 +91,7 @@ impl CodexSqlitePool {
                 (CODEX_SQLITE_HOME_ENV.into(), home.clone()),
                 (GRIDBASH_MANAGED_CODEX_SQLITE_ENV.into(), home),
             ],
+            home: Some(lease.home.clone()),
             lease: Some(lease),
         })
     }
@@ -120,6 +126,14 @@ impl CodexSqlitePool {
 
             match FileExt::try_lock(&lock) {
                 Ok(()) => {
+                    // Codex keeps an interrupted backfill claim for 15 minutes, while a new
+                    // startup waits only 30 seconds. Exclusive ownership of the GridBash lane
+                    // proves its previous pane is gone, so make that checkpoint claimable again.
+                    if prepare_released_lane(&home).is_err() {
+                        // Leave a busy or unreadable database untouched and use another lane.
+                        let _ = FileExt::unlock(&lock);
+                        continue;
+                    }
                     return Ok(CodexSqliteLease { home, _lock: lock });
                 }
                 Err(TryLockError::WouldBlock) => continue,
@@ -135,6 +149,152 @@ impl CodexSqlitePool {
             "all {MAX_CODEX_SQLITE_LANES} Codex SQLite lanes are currently in use under {}",
             scope_root.display()
         )
+    }
+}
+
+pub(crate) fn latest_thread_id(
+    home: &Path,
+    cwd: &Path,
+    not_before_ms: u64,
+) -> Result<Option<String>> {
+    let Some(path) = latest_state_db(home)? else {
+        return Ok(None);
+    };
+    let connection = Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("failed to open Codex state DB {}", path.display()))?;
+    connection.busy_timeout(std::time::Duration::from_millis(250))?;
+
+    let columns = connection
+        .prepare("PRAGMA table_info(threads)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if !columns.iter().any(|column| column == "id") || !columns.iter().any(|column| column == "cwd")
+    {
+        return Ok(None);
+    }
+
+    let timestamp_column = [
+        "recency_at_ms",
+        "updated_at_ms",
+        "created_at_ms",
+        "updated_at",
+        "created_at",
+    ]
+    .into_iter()
+    .find(|candidate| columns.iter().any(|column| column == candidate));
+    let Some(timestamp_column) = timestamp_column else {
+        return Ok(None);
+    };
+    let seconds_column = !timestamp_column.ends_with("_ms");
+    let query = format!(
+        "SELECT id, cwd, {timestamp_column} FROM threads \
+         WHERE {timestamp_column} IS NOT NULL ORDER BY {timestamp_column} DESC LIMIT 128"
+    );
+    let mut statement = connection.prepare(&query)?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+    let expected_cwd = normalized_path(cwd);
+    for row in rows {
+        let (id, row_cwd, timestamp) = row?;
+        let timestamp_ms = if seconds_column {
+            timestamp.saturating_mul(1_000)
+        } else {
+            timestamp
+        };
+        if timestamp_ms >= i64::try_from(not_before_ms).unwrap_or(i64::MAX)
+            && normalized_path(Path::new(&row_cwd)) == expected_cwd
+        {
+            return Ok(Some(id));
+        }
+    }
+    Ok(None)
+}
+
+fn latest_state_db(home: &Path) -> Result<Option<PathBuf>> {
+    let mut candidates = fs::read_dir(home)
+        .with_context(|| format!("failed to inspect Codex SQLite home {}", home.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter_map(|path| {
+            let name = path.file_name()?.to_str()?;
+            let version = name
+                .strip_prefix(CODEX_STATE_DB_PREFIX)?
+                .strip_suffix(CODEX_STATE_DB_SUFFIX)?
+                .parse::<u64>()
+                .ok()?;
+            Some((version, path))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(version, _)| *version);
+    Ok(candidates.pop().map(|(_, path)| path))
+}
+
+fn normalized_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase()
+}
+
+fn prepare_released_lane(home: &Path) -> Result<()> {
+    let entries = fs::read_dir(home)
+        .with_context(|| format!("failed to inspect Codex SQLite lane {}", home.display()))?;
+    for entry in entries {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to inspect an entry in Codex SQLite lane {}",
+                home.display()
+            )
+        })?;
+        if !entry
+            .file_type()
+            .with_context(|| format!("failed to inspect {}", entry.path().display()))?
+            .is_file()
+        {
+            continue;
+        }
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(OsStr::to_str) else {
+            continue;
+        };
+        if !name.starts_with(CODEX_STATE_DB_PREFIX) || !name.ends_with(CODEX_STATE_DB_SUFFIX) {
+            continue;
+        }
+        reset_interrupted_backfill(&path).with_context(|| {
+            format!(
+                "failed to prepare released Codex SQLite state DB {}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn reset_interrupted_backfill(path: &Path) -> rusqlite::Result<bool> {
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    connection.busy_timeout(std::time::Duration::from_millis(250))?;
+    match connection.execute(
+        "UPDATE backfill_state SET status = 'pending' WHERE id = 1 AND status = 'running'",
+        [],
+    ) {
+        Ok(changed) => Ok(changed > 0),
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table: backfill_state") =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -162,6 +322,21 @@ fn has_explicit_sqlite_home(
 
     let inherited_is_managed = inherited_home.is_some() && inherited_home == inherited_managed_home;
     inherited_home.is_some_and(non_empty_os_str) && !inherited_is_managed
+}
+
+fn explicit_sqlite_home(
+    pane_env: &BTreeMap<String, String>,
+    inherited_home: Option<&OsStr>,
+) -> Option<PathBuf> {
+    pane_env
+        .get(CODEX_SQLITE_HOME_ENV)
+        .and_then(|value| non_empty(value))
+        .map(PathBuf::from)
+        .or_else(|| {
+            inherited_home
+                .filter(|value| non_empty_os_str(value))
+                .map(PathBuf::from)
+        })
 }
 
 fn codex_home_scope(
@@ -204,6 +379,61 @@ fn stable_scope_id(value: &OsStr) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_backfill_state(path: &Path, status: &str, watermark: &str) {
+        let connection = Connection::open(path).expect("open test state db");
+        connection
+            .execute_batch(
+                "CREATE TABLE backfill_state (\
+                    id INTEGER PRIMARY KEY,\
+                    status TEXT NOT NULL,\
+                    last_watermark TEXT,\
+                    last_success_at INTEGER,\
+                    updated_at INTEGER NOT NULL\
+                );",
+            )
+            .expect("create backfill state");
+        connection
+            .execute(
+                "INSERT INTO backfill_state \
+                    (id, status, last_watermark, last_success_at, updated_at) \
+                 VALUES (1, ?1, ?2, NULL, 123)",
+                (status, watermark),
+            )
+            .expect("insert backfill state");
+    }
+
+    fn read_backfill_state(path: &Path) -> (String, String, i64) {
+        let connection = Connection::open(path).expect("open test state db");
+        connection
+            .query_row(
+                "SELECT status, last_watermark, updated_at FROM backfill_state WHERE id = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read backfill state")
+    }
+
+    fn write_threads(path: &Path, rows: &[(&str, &str, i64)]) {
+        let connection = Connection::open(path).expect("open test state DB");
+        connection
+            .execute_batch(
+                "CREATE TABLE threads (\
+                    id TEXT PRIMARY KEY,\
+                    cwd TEXT NOT NULL,\
+                    recency_at_ms INTEGER NOT NULL\
+                );",
+            )
+            .expect("create threads table");
+        for (id, cwd, recency_at_ms) in rows {
+            connection
+                .execute(
+                    "INSERT INTO threads (id, cwd, recency_at_ms) VALUES (?1, ?2, ?3)",
+                    (id, cwd, recency_at_ms),
+                )
+                .expect("insert thread");
+        }
+    }
 
     struct TestRoot(PathBuf);
 
@@ -284,6 +514,117 @@ mod tests {
             .for_pane_with_inherited(&pane_env, None, None, None)
             .expect("recycled lease");
         assert_eq!(sqlite_home(&recycled), first_home);
+    }
+
+    #[test]
+    fn released_lane_resumes_an_interrupted_backfill_without_losing_its_checkpoint() {
+        let root = TestRoot::new();
+        let pool = root.pool();
+        let scope = stable_scope_id(OsStr::new(DEFAULT_CODEX_HOME_SCOPE));
+        let lane = root.0.join(scope).join("lane-1");
+        fs::create_dir_all(&lane).expect("create lane");
+        let state_db = lane.join("state_5.sqlite");
+        write_backfill_state(&state_db, "running", "sessions/checkpoint.jsonl");
+
+        let lease = pool
+            .for_pane_with_inherited(&BTreeMap::new(), None, None, None)
+            .expect("acquire interrupted lane");
+
+        assert_eq!(sqlite_home(&lease), lane);
+        assert_eq!(
+            read_backfill_state(&state_db),
+            ("pending".into(), "sessions/checkpoint.jsonl".into(), 123)
+        );
+    }
+
+    #[test]
+    fn released_lane_preserves_a_completed_backfill() {
+        let root = TestRoot::new();
+        let pool = root.pool();
+        let scope = stable_scope_id(OsStr::new(DEFAULT_CODEX_HOME_SCOPE));
+        let lane = root.0.join(scope).join("lane-1");
+        fs::create_dir_all(&lane).expect("create lane");
+        let state_db = lane.join("state_5.sqlite");
+        write_backfill_state(&state_db, "complete", "sessions/complete.jsonl");
+
+        let lease = pool
+            .for_pane_with_inherited(&BTreeMap::new(), None, None, None)
+            .expect("acquire completed lane");
+
+        assert_eq!(sqlite_home(&lease), lane);
+        assert_eq!(
+            read_backfill_state(&state_db),
+            ("complete".into(), "sessions/complete.jsonl".into(), 123)
+        );
+    }
+
+    #[test]
+    fn finds_the_latest_matching_thread_created_after_the_pane_started() {
+        let root = TestRoot::new();
+        let lane = root.0.join("lane-1");
+        fs::create_dir_all(&lane).expect("create lane");
+        write_threads(
+            &lane.join("state_5.sqlite"),
+            &[
+                (
+                    "019f7b81-de49-7782-8186-a3dc2c644c61",
+                    r"C:\work\fluent",
+                    1_000,
+                ),
+                (
+                    "019f7b81-e026-7d12-a013-25f4763f4bce",
+                    r"\\?\C:\work\fluent",
+                    3_000,
+                ),
+                (
+                    "019f7b81-e2cd-71c1-84dd-9f09622cf74e",
+                    r"C:\work\other",
+                    4_000,
+                ),
+            ],
+        );
+
+        assert_eq!(
+            latest_thread_id(&lane, Path::new(r"C:/work/fluent"), 2_000)
+                .expect("find thread")
+                .as_deref(),
+            Some("019f7b81-e026-7d12-a013-25f4763f4bce")
+        );
+        assert_eq!(
+            latest_thread_id(&lane, Path::new(r"C:/work/fluent"), 3_001)
+                .expect("filter old thread"),
+            None
+        );
+    }
+
+    #[test]
+    fn active_lane_backfill_state_is_not_changed_by_another_lease() {
+        let root = TestRoot::new();
+        let pool = root.pool();
+        let pane_env = BTreeMap::new();
+        let active = pool
+            .for_pane_with_inherited(&pane_env, None, None, None)
+            .expect("acquire active lane");
+        let active_state_db = sqlite_home(&active).join("state_5.sqlite");
+        write_backfill_state(
+            &active_state_db,
+            "running",
+            "sessions/active-checkpoint.jsonl",
+        );
+
+        let other = pool
+            .for_pane_with_inherited(&pane_env, None, None, None)
+            .expect("acquire another lane");
+
+        assert_ne!(sqlite_home(&other), sqlite_home(&active));
+        assert_eq!(
+            read_backfill_state(&active_state_db),
+            (
+                "running".into(),
+                "sessions/active-checkpoint.jsonl".into(),
+                123
+            )
+        );
     }
 
     #[test]

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -49,21 +49,21 @@ const SHELL_PREFERENCE: &[&str] = &["zsh", "bash", "fish", "sh", "pwsh"];
 #[cfg(all(not(windows), not(target_os = "macos")))]
 const SHELL_PREFERENCE: &[&str] = &["bash", "zsh", "fish", "sh", "pwsh"];
 
-const CANVAS_BG: Color = Color::Rgb(4, 6, 11);
-const PANEL_BG: Color = Color::Rgb(8, 12, 19);
-const RAISED_BG: Color = Color::Rgb(13, 20, 30);
-const SUNKEN_BG: Color = Color::Rgb(7, 11, 18);
-const HAIRLINE: Color = Color::Rgb(30, 45, 60);
-const HAIRLINE_HI: Color = Color::Rgb(56, 84, 108);
-const MUTED: Color = Color::Rgb(104, 122, 140);
-const TEXT: Color = Color::Rgb(226, 236, 245);
-const TERMINAL_GREEN: Color = Color::Rgb(94, 234, 240);
-const DIM_GREEN: Color = Color::Rgb(182, 140, 255);
-const SOFT_GREEN: Color = Color::Rgb(112, 243, 186);
+const CANVAS_BG: Color = Color::Rgb(0, 5, 2);
+const PANEL_BG: Color = Color::Rgb(1, 10, 5);
+const RAISED_BG: Color = Color::Rgb(2, 16, 8);
+const SUNKEN_BG: Color = Color::Rgb(1, 8, 4);
+const HAIRLINE: Color = Color::Rgb(18, 76, 40);
+const HAIRLINE_HI: Color = Color::Rgb(34, 120, 64);
+const MUTED: Color = Color::Rgb(72, 128, 88);
+const TEXT: Color = Color::Rgb(214, 255, 224);
+const TERMINAL_GREEN: Color = Color::Rgb(91, 255, 139);
+const DIM_GREEN: Color = Color::Rgb(50, 176, 92);
+const SOFT_GREEN: Color = Color::Rgb(159, 255, 183);
 const AMBER: Color = Color::Rgb(255, 196, 92);
 const ALERT_RED: Color = Color::Rgb(255, 118, 118);
-const RESIZE_ACCENT: Color = Color::Rgb(88, 166, 255);
-const RESIZE_FILL: Color = Color::Rgb(14, 32, 58);
+const RESIZE_ACCENT: Color = Color::Rgb(91, 255, 139);
+const RESIZE_FILL: Color = Color::Rgb(5, 35, 18);
 
 /// Three-row wordmark. Every glyph is a box-drawing character, so the banner
 /// occupies exactly 29 single-width columns wherever GridBash can draw borders.
@@ -1493,7 +1493,7 @@ fn text_row(
     let value_style = Style::default().fg(if focused {
         TEXT
     } else {
-        Color::Rgb(176, 190, 205)
+        Color::Rgb(150, 210, 170)
     });
 
     if start > 0 {
@@ -1594,7 +1594,7 @@ fn draw_preview_cell(frame: &mut Frame<'_>, rect: Rect, cell: &PreviewCell) {
     let border = if !cell.revealed {
         HAIRLINE
     } else if cell.shimmer {
-        Color::Rgb(238, 248, 255)
+        Color::Rgb(232, 255, 240)
     } else {
         cell.accent
     };
@@ -1732,9 +1732,9 @@ fn paint_starfield(frame: &mut Frame<'_>, area: Rect, tick: u64, seed: u64) {
                 continue;
             }
             let (glyph, color) = match (noise >> 8).wrapping_add(tick / 6) % 14 {
-                0 => ("*", Color::Rgb(96, 132, 164)),
-                1 | 2 => ("·", Color::Rgb(62, 92, 118)),
-                _ => ("·", Color::Rgb(26, 40, 54)),
+                0 => ("*", Color::Rgb(74, 150, 96)),
+                1 | 2 => ("·", Color::Rgb(44, 104, 62)),
+                _ => ("·", Color::Rgb(16, 52, 30)),
             };
             if let Some(cell) = buffer.cell_mut((x, y)) {
                 cell.set_symbol(glyph).set_fg(color);
@@ -2168,33 +2168,15 @@ fn square_preview_rects(area: Rect, grid: GridSize) -> Vec<Rect> {
         return Vec::new();
     }
 
-    let gap_y = if area.height >= rows.saturating_mul(2).saturating_sub(1) {
-        1
-    } else {
-        0
-    };
-    let gap_x = if area.width >= columns.saturating_mul(4).saturating_sub(2) {
-        2
-    } else if area.width >= columns.saturating_mul(3).saturating_sub(1) {
-        1
-    } else {
-        0
-    };
-
-    let row_gaps = rows.saturating_sub(1).saturating_mul(gap_y);
-    let column_gaps = columns.saturating_sub(1).saturating_mul(gap_x);
-    let height_fit = area.height.saturating_sub(row_gaps) / rows;
-    let width_fit = area.width.saturating_sub(column_gaps) / columns / 2;
+    // Cells sit flush against one another so the preview reads as a single grid
+    // instead of scattered tiles. Each cell draws its own border, so touching
+    // edges look like the interior rules of one table.
+    let height_fit = area.height / rows;
+    let width_fit = area.width / columns / 2;
     let side_height = height_fit.min(width_fit).max(1);
     let side_width = side_height.saturating_mul(2).max(1);
-    let total_height = rows
-        .saturating_mul(side_height)
-        .saturating_add(row_gaps)
-        .min(area.height);
-    let total_width = columns
-        .saturating_mul(side_width)
-        .saturating_add(column_gaps)
-        .min(area.width);
+    let total_height = rows.saturating_mul(side_height).min(area.height);
+    let total_width = columns.saturating_mul(side_width).min(area.width);
     let start_y = area
         .y
         .saturating_add(area.height.saturating_sub(total_height) / 2);
@@ -2206,8 +2188,8 @@ fn square_preview_rects(area: Rect, grid: GridSize) -> Vec<Rect> {
     for row in 0..rows {
         for column in 0..columns {
             rects.push(Rect {
-                x: start_x.saturating_add(column.saturating_mul(side_width.saturating_add(gap_x))),
-                y: start_y.saturating_add(row.saturating_mul(side_height.saturating_add(gap_y))),
+                x: start_x.saturating_add(column.saturating_mul(side_width)),
+                y: start_y.saturating_add(row.saturating_mul(side_height)),
                 width: side_width,
                 height: side_height,
             });
@@ -2898,6 +2880,65 @@ mod tests {
             assert!(
                 settled.contains(&format!("main-pane-{pane:02}")),
                 "pane {pane} missing its branch label"
+            );
+        }
+    }
+
+    /// The preview stands in for the real grid, so its cells sit flush: touching
+    /// edges read as one table rather than a scatter of tiles.
+    #[test]
+    fn preview_cells_touch_without_gaps() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 120,
+            height: 40,
+        };
+        let grid = GridSize {
+            rows: 3,
+            columns: 3,
+        };
+        let rects = square_preview_rects(area, grid);
+        assert_eq!(rects.len(), 9);
+
+        for row in 0..3 {
+            for column in 0..3 {
+                let cell = rects[row * 3 + column];
+                if column > 0 {
+                    let left = rects[row * 3 + column - 1];
+                    assert_eq!(
+                        left.x + left.width,
+                        cell.x,
+                        "column {column} leaves a horizontal gap"
+                    );
+                }
+                if row > 0 {
+                    let above = rects[(row - 1) * 3 + column];
+                    assert_eq!(
+                        above.y + above.height,
+                        cell.y,
+                        "row {row} leaves a vertical gap"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The composer shares the resume picker's phosphor-green palette, so its
+    /// accents must actually be green rather than the cyan they replaced.
+    #[test]
+    fn accent_palette_is_phosphor_green() {
+        for (name, color) in [
+            ("TERMINAL_GREEN", TERMINAL_GREEN),
+            ("DIM_GREEN", DIM_GREEN),
+            ("SOFT_GREEN", SOFT_GREEN),
+        ] {
+            let Color::Rgb(red, green, blue) = color else {
+                panic!("{name} must be an rgb colour");
+            };
+            assert!(
+                green > red && green > blue,
+                "{name} is not green: rgb({red}, {green}, {blue})"
             );
         }
     }

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -1,8 +1,10 @@
 use std::{
-    env,
+    env, fs,
     io::Stdout,
     path::{Path, PathBuf},
-    time::Duration,
+    sync::mpsc::{self as std_mpsc, Receiver, Sender},
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, anyhow};
@@ -13,16 +15,18 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
 };
 
 use crate::{
-    auth::{self, AuthProfile},
     config::Config,
-    layout::GridSize,
+    diagnostics,
+    layout::{GridSize, MAX_PANES},
     profiles::{Profile, find_profile, is_agent_profile, is_terminal_profile, startup_profiles},
     setup::LaunchPlan,
-    worktrees::ManagedWorktreeOptions,
+    worktrees::{
+        ManagedWorktreeOptions, WorktreeReadiness, managed_branch_name, probe_worktree_readiness,
+    },
 };
 
 type ComposerTerminal = Terminal<CrosstermBackend<Stdout>>;
@@ -30,106 +34,142 @@ type ComposerTerminal = Terminal<CrosstermBackend<Stdout>>;
 const DEFAULT_ROWS: usize = 2;
 const DEFAULT_COLUMNS: usize = 3;
 const MAX_DIMENSION: usize = 10;
-const STARTUP_PREVIEW: PreviewPalette = PreviewPalette {
-    border: Color::Rgb(95, 214, 150),
-    light: Color::Rgb(43, 128, 84),
-    mid: Color::Rgb(28, 96, 65),
-    dark: Color::Rgb(15, 65, 49),
-};
-const RESIZE_PREVIEW: PreviewPalette = PreviewPalette {
-    border: Color::Rgb(88, 166, 255),
-    light: Color::Rgb(47, 129, 247),
-    mid: Color::Rgb(31, 91, 191),
-    dark: Color::Rgb(15, 50, 110),
-};
+const MAX_NAME_CHARS: usize = 40;
+const MAX_SUGGESTIONS: usize = 64;
+/// Length of one animation step. The event loop polls faster than this so
+/// motion stays smooth without the composer ever busy-spinning.
+const FRAME_MS: u64 = 40;
+/// How long the project path must hold still before the git probe runs.
+const PROBE_DEBOUNCE: Duration = Duration::from_millis(160);
 
+#[cfg(windows)]
+const SHELL_PREFERENCE: &[&str] = &["git-bash", "bash", "pwsh", "powershell", "cmd"];
+#[cfg(target_os = "macos")]
+const SHELL_PREFERENCE: &[&str] = &["zsh", "bash", "fish", "sh", "pwsh"];
+#[cfg(all(not(windows), not(target_os = "macos")))]
+const SHELL_PREFERENCE: &[&str] = &["bash", "zsh", "fish", "sh", "pwsh"];
+
+const CANVAS_BG: Color = Color::Rgb(4, 6, 11);
+const PANEL_BG: Color = Color::Rgb(8, 12, 19);
+const RAISED_BG: Color = Color::Rgb(13, 20, 30);
+const SUNKEN_BG: Color = Color::Rgb(7, 11, 18);
+const HAIRLINE: Color = Color::Rgb(30, 45, 60);
+const HAIRLINE_HI: Color = Color::Rgb(56, 84, 108);
+const MUTED: Color = Color::Rgb(104, 122, 140);
+const TEXT: Color = Color::Rgb(226, 236, 245);
+const TERMINAL_GREEN: Color = Color::Rgb(94, 234, 240);
+const DIM_GREEN: Color = Color::Rgb(182, 140, 255);
+const SOFT_GREEN: Color = Color::Rgb(112, 243, 186);
+const AMBER: Color = Color::Rgb(255, 196, 92);
+const ALERT_RED: Color = Color::Rgb(255, 118, 118);
+const RESIZE_ACCENT: Color = Color::Rgb(88, 166, 255);
+const RESIZE_FILL: Color = Color::Rgb(14, 32, 58);
+
+/// Three-row wordmark. Every glyph is a box-drawing character, so the banner
+/// occupies exactly 29 single-width columns wherever GridBash can draw borders.
+const WORDMARK: [&str; 3] = [
+    "╔═╗ ╦═╗ ╦ ╔╦╗ ╔╗  ╔═╗ ╔═╗ ╦ ╦",
+    "║ ╦ ╠╦╝ ║  ║║ ╠╩╗ ╠═╣ ╚═╗ ╠═╣",
+    "╚═╝ ╩╚═ ╩ ═╩╝ ╚═╝ ╩ ╩ ╚═╝ ╩ ╩",
+];
+const WORDMARK_WIDTH: u16 = 29;
+
+/// Everything the composer hands back when the user launches a grid.
+#[derive(Debug, Clone)]
+pub struct ComposerOutcome {
+    pub title: String,
+    pub plan: LaunchPlan,
+}
+
+/// The new-grid screen: four inputs (rows, columns, name, project), a live
+/// preview of the grid that is about to exist, and nothing else to decide.
+/// Managed worktrees are on whenever the repository can host them, and every
+/// pane starts in the platform shell.
 pub struct Composer {
-    current_dir: PathBuf,
-    project_input: String,
-    project_error: Option<String>,
-    editing_project: bool,
-    worktree_options: ManagedWorktreeOptions,
-    worktrees_enabled: bool,
-    picker: GridPicker,
-    profiles: Vec<StartupProfile>,
-    profile_cursor: usize,
-    auth_profiles: Vec<AuthProfile>,
-    auth_cursor: usize,
-    active_field: StartupField,
-}
-
-#[derive(Debug, Clone)]
-struct StartupProfile {
-    name: String,
-    title: String,
-    profile: Profile,
-    agent: bool,
-    terminal: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GridPickerMode {
-    Startup,
-    Resize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GridPickerAction {
-    Continue,
-    Confirm(GridSize),
-    Cancel,
-}
-
-#[derive(Debug, Clone)]
-pub struct GridPicker {
-    initial: GridSize,
+    /// Folder that relative paths resolve against. Fixed for the composer's
+    /// lifetime so completion never drifts while the user types.
+    base_dir: PathBuf,
+    project: TextField,
+    project_dir: Option<PathBuf>,
+    project_touched: bool,
+    name: TextField,
+    default_name: String,
     rows: usize,
     columns: usize,
-    active_field: DimensionField,
-    pane_summaries: Vec<Option<String>>,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct PreviewPalette {
-    border: Color,
-    light: Color,
-    mid: Color,
-    dark: Color,
+    active: Field,
+    suggestions: Suggestions,
+    profile_name: String,
+    profile_title: String,
+    worktree_options: ManagedWorktreeOptions,
+    worktrees_enabled: bool,
+    readiness: Option<WorktreeReadiness>,
+    probe_tx: Sender<(PathBuf, WorktreeReadiness)>,
+    probe_rx: Receiver<(PathBuf, WorktreeReadiness)>,
+    probing: Option<PathBuf>,
+    probe_due: Option<(PathBuf, Instant)>,
+    notice: Option<Notice>,
+    started: Instant,
+    shape_changed: Instant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DimensionField {
+pub enum Field {
     Rows,
     Columns,
+    Name,
+    Project,
+}
+
+impl Field {
+    pub const ALL: [Self; 4] = [Self::Rows, Self::Columns, Self::Name, Self::Project];
+
+    fn is_text(self) -> bool {
+        matches!(self, Self::Name | Self::Project)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Notice {
+    text: String,
+    level: NoticeLevel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoticeLevel {
+    Error,
+    Warn,
+    Info,
+}
+
+/// A single-line editor: value plus a character-indexed cursor.
+#[derive(Debug, Clone, Default)]
+struct TextField {
+    value: String,
+    cursor: usize,
+    limit: Option<usize>,
+}
+
+/// Directory completions for the project field. `stem` records the text the
+/// list was generated from so repeated Tab presses cycle instead of rebuilding.
+/// `siblings` is everything in the parent folder, so the browser can show where
+/// else the grid could land; `matches` is the subset Tab walks through.
+#[derive(Debug, Clone, Default)]
+struct Suggestions {
+    stem: String,
+    siblings: Vec<String>,
+    matches: Vec<String>,
+    index: Option<usize>,
 }
 
 enum ComposerEvent {
     Continue,
-    Launch(LaunchPlan),
+    Launch(Box<ComposerOutcome>),
     Quit,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StartupField {
-    Profile,
-    Auth,
-    Rows,
-    Columns,
-    Worktrees,
+enum TextTarget {
+    Name,
     Project,
-    Launch,
-}
-
-impl StartupField {
-    const ALL: [Self; 7] = [
-        Self::Profile,
-        Self::Auth,
-        Self::Rows,
-        Self::Columns,
-        Self::Worktrees,
-        Self::Project,
-        Self::Launch,
-    ];
 }
 
 impl Composer {
@@ -137,85 +177,70 @@ impl Composer {
         current_dir: PathBuf,
         worktrees: Option<ManagedWorktreeOptions>,
         config: &Config,
+        default_name: &str,
     ) -> Result<Self> {
-        let grid = GridSize {
+        let (profile_name, profile) = resolve_shell_profile(config)?;
+        Self::with_profile(current_dir, worktrees, default_name, profile_name, profile)
+    }
+
+    fn with_profile(
+        current_dir: PathBuf,
+        worktrees: Option<ManagedWorktreeOptions>,
+        default_name: &str,
+        profile_name: String,
+        profile: Profile,
+    ) -> Result<Self> {
+        let base_dir = current_dir.canonicalize().unwrap_or(current_dir);
+        let worktree_options = worktrees.unwrap_or(ManagedWorktreeOptions::new("gridbash".into())?);
+        let (probe_tx, probe_rx) = std_mpsc::channel();
+
+        let mut composer = Self {
+            project: TextField::new(display_path(&base_dir), None),
+            project_dir: Some(base_dir.clone()),
+            project_touched: false,
+            name: TextField::new(default_name, Some(MAX_NAME_CHARS)),
+            default_name: default_name.to_string(),
+            base_dir,
             rows: DEFAULT_ROWS,
             columns: DEFAULT_COLUMNS,
-        };
-        let profiles = startup_profiles(config)
-            .into_iter()
-            .map(|(name, profile)| {
-                let agent = is_agent_profile(&name, &profile);
-                StartupProfile {
-                    title: profile.display_name(&name),
-                    agent,
-                    terminal: is_terminal_profile(&name) && !agent,
-                    name,
-                    profile,
-                }
-            })
-            .collect::<Vec<_>>();
-        if profiles.is_empty() {
-            return Err(anyhow!(
-                "no agent or terminal profiles are available; install Codex, Claude, or a supported shell"
-            ));
-        }
-
-        let has_agent = profiles.iter().any(|profile| profile.agent);
-        let preferred = env::var("GRIDBASH_PROFILE").ok().or_else(|| {
-            config.defaults.profile.clone().filter(|name| {
-                !profiles
-                    .iter()
-                    .find(|profile| profile.name == *name)
-                    .is_some_and(|profile| profile.terminal)
-                    || !has_agent
-            })
-        });
-        let profile_cursor = preferred
-            .as_deref()
-            .and_then(|preferred| {
-                profiles
-                    .iter()
-                    .position(|profile| profile.name == preferred)
-            })
-            .unwrap_or(0);
-        let current_dir = current_dir.canonicalize().unwrap_or(current_dir);
-        let project_input = display_path(&current_dir);
-        let worktrees_enabled = worktrees.is_some();
-        let worktree_options = worktrees.unwrap_or(ManagedWorktreeOptions::new("gridbash".into())?);
-
-        Ok(Self {
-            current_dir,
-            project_input,
-            project_error: None,
-            editing_project: false,
+            active: Field::Rows,
+            suggestions: Suggestions::default(),
+            profile_title: profile.display_name(&profile_name),
+            profile_name,
             worktree_options,
-            worktrees_enabled,
-            picker: GridPicker::new(grid),
-            profiles,
-            profile_cursor,
-            auth_profiles: auth::discover_profiles(&config.auth)?,
-            auth_cursor: 0,
-            active_field: StartupField::Profile,
-        })
+            worktrees_enabled: true,
+            readiness: None,
+            probe_tx,
+            probe_rx,
+            probing: None,
+            probe_due: None,
+            notice: None,
+            started: Instant::now(),
+            shape_changed: Instant::now(),
+        };
+        composer.refresh_suggestions();
+        composer.request_probe(true);
+        Ok(composer)
     }
 
     pub fn run(
         &mut self,
         terminal: &mut ComposerTerminal,
         config: &Config,
-    ) -> Result<Option<LaunchPlan>> {
+    ) -> Result<Option<ComposerOutcome>> {
         loop {
             terminal.draw(|frame| self.draw(frame, config))?;
+            self.drain_probes();
+            self.settle_probe();
 
-            if !event::poll(Duration::from_millis(50))? {
+            if !event::poll(Duration::from_millis(FRAME_MS / 2))? {
                 continue;
             }
 
             let result = match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key, config),
-                Event::Paste(text) if self.editing_project => {
-                    self.project_input.push_str(&text);
+                Event::Paste(text) => {
+                    self.paste(&text);
                     ComposerEvent::Continue
                 }
                 _ => ComposerEvent::Continue,
@@ -223,372 +248,1635 @@ impl Composer {
 
             match result {
                 ComposerEvent::Continue => {}
-                ComposerEvent::Launch(plan) => return Ok(Some(plan)),
+                ComposerEvent::Launch(outcome) => return Ok(Some(*outcome)),
                 ComposerEvent::Quit => return Ok(None),
             }
         }
     }
 
+    // ----------------------------------------------------------------- input
+
     fn handle_key(&mut self, key: KeyEvent, config: &Config) -> ComposerEvent {
-        if self.editing_project {
-            if is_enter_key(key) {
-                self.commit_project_input();
-                return ComposerEvent::Continue;
-            }
-
-            match key.code {
-                KeyCode::Esc => {
-                    self.editing_project = false;
-                    self.project_input = display_path(&self.current_dir);
-                    self.project_error = None;
-                }
-                KeyCode::Backspace => {
-                    self.project_input.pop();
-                    self.project_error = None;
-                }
-                KeyCode::Char(ch) => {
-                    self.project_input.push(ch);
-                    self.project_error = None;
-                }
-                _ => {}
-            }
-            return ComposerEvent::Continue;
-        }
-
         if is_enter_key(key) {
-            return match self.launch_plan(config) {
-                Ok(plan) => ComposerEvent::Launch(plan),
+            return match self.build_outcome(config) {
+                Ok(outcome) => ComposerEvent::Launch(Box::new(outcome)),
                 Err(error) => {
-                    self.project_error = Some(format!("{error:#}"));
+                    self.notice = Some(Notice {
+                        text: format!("{error:#}"),
+                        level: NoticeLevel::Error,
+                    });
                     ComposerEvent::Continue
                 }
             };
         }
 
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+
         match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => ComposerEvent::Quit,
-            KeyCode::Up | KeyCode::Char('k') | KeyCode::BackTab => {
-                self.move_field(-1);
-                ComposerEvent::Continue
-            }
-            KeyCode::Down | KeyCode::Char('j') | KeyCode::Tab => {
-                self.move_field(1);
-                ComposerEvent::Continue
-            }
-            KeyCode::Left | KeyCode::Char('h') => {
-                self.adjust_active(-1);
-                ComposerEvent::Continue
-            }
-            KeyCode::Right | KeyCode::Char('l') => {
-                self.adjust_active(1);
-                ComposerEvent::Continue
-            }
-            KeyCode::Char('w') => {
+            KeyCode::Esc => return ComposerEvent::Quit,
+            KeyCode::Char('c') if ctrl => return ComposerEvent::Quit,
+            KeyCode::Char('w') if alt => {
                 self.worktrees_enabled = !self.worktrees_enabled;
-                ComposerEvent::Continue
+                self.notice = None;
+                return ComposerEvent::Continue;
             }
-            KeyCode::Char('e') if self.active_field == StartupField::Project => {
-                self.editing_project = true;
-                self.project_error = None;
-                ComposerEvent::Continue
+            KeyCode::Tab if self.active == Field::Project => {
+                self.complete_project();
+                return ComposerEvent::Continue;
             }
-            _ => ComposerEvent::Continue,
+            KeyCode::Tab | KeyCode::Down => {
+                self.move_field(1);
+                return ComposerEvent::Continue;
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.move_field(-1);
+                return ComposerEvent::Continue;
+            }
+            _ => {}
+        }
+
+        match self.active {
+            Field::Rows | Field::Columns => self.handle_shape_key(key),
+            Field::Name => self.handle_text_key(key, ctrl, TextTarget::Name),
+            Field::Project => self.handle_text_key(key, ctrl, TextTarget::Project),
+        }
+        ComposerEvent::Continue
+    }
+
+    fn handle_shape_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Left | KeyCode::Char('-') | KeyCode::Char('_') => self.adjust_shape(-1),
+            KeyCode::Right | KeyCode::Char('+') | KeyCode::Char('=') => self.adjust_shape(1),
+            KeyCode::Home => self.set_shape(1),
+            KeyCode::End => self.set_shape(MAX_DIMENSION),
+            KeyCode::Char(ch) if ch.is_ascii_digit() => {
+                let digit = ch.to_digit(10).unwrap_or(1) as usize;
+                // 0 reads as "all the way up", the way the resize picker works.
+                self.set_shape(if digit == 0 { MAX_DIMENSION } else { digit });
+            }
+            _ => {}
         }
     }
 
-    fn launch_plan(&self, config: &Config) -> Result<LaunchPlan> {
-        let selected = self.selected_profile();
-        let profile = find_profile(config, &selected.name)?;
-        let grid = self.picker.grid();
-        let worktrees = self.worktrees_enabled.then_some(&self.worktree_options);
-        let mut plan = LaunchPlan::from_launch_options(
-            selected.name.clone(),
+    fn handle_text_key(&mut self, key: KeyEvent, ctrl: bool, target: TextTarget) {
+        let changed = {
+            let field = match target {
+                TextTarget::Name => &mut self.name,
+                TextTarget::Project => &mut self.project,
+            };
+            match key.code {
+                KeyCode::Char('u') if ctrl => field.clear(),
+                KeyCode::Char('w') if ctrl => field.delete_word(),
+                KeyCode::Char('a') if ctrl => {
+                    field.home();
+                    false
+                }
+                KeyCode::Char('e') if ctrl => {
+                    field.end();
+                    false
+                }
+                KeyCode::Char(ch) if !ctrl => field.insert(ch),
+                KeyCode::Backspace => field.backspace(),
+                KeyCode::Delete => field.delete(),
+                KeyCode::Left => {
+                    field.move_cursor(-1);
+                    false
+                }
+                KeyCode::Right => {
+                    field.move_cursor(1);
+                    false
+                }
+                KeyCode::Home => {
+                    field.home();
+                    false
+                }
+                KeyCode::End => {
+                    field.end();
+                    false
+                }
+                _ => false,
+            }
+        };
+
+        if !changed {
+            return;
+        }
+
+        self.notice = None;
+        if matches!(target, TextTarget::Project) {
+            self.project_touched = true;
+            self.refresh_suggestions();
+            self.refresh_project();
+        }
+    }
+
+    fn paste(&mut self, text: &str) {
+        let clean = text
+            .chars()
+            .filter(|ch| !ch.is_control())
+            .collect::<String>();
+        if clean.is_empty() {
+            return;
+        }
+
+        match self.active {
+            Field::Name => {
+                self.name.insert_str(&clean);
+            }
+            Field::Project => {
+                self.project.insert_str(&clean);
+                self.project_touched = true;
+                self.refresh_suggestions();
+                self.refresh_project();
+            }
+            Field::Rows | Field::Columns => return,
+        }
+        self.notice = None;
+    }
+
+    fn move_field(&mut self, delta: isize) {
+        let current = Field::ALL
+            .iter()
+            .position(|field| *field == self.active)
+            .unwrap_or(0);
+        let next = (current as isize + delta).rem_euclid(Field::ALL.len() as isize) as usize;
+        self.active = Field::ALL[next];
+        if self.active == Field::Project {
+            self.refresh_suggestions();
+        }
+    }
+
+    fn adjust_shape(&mut self, delta: isize) {
+        let value = match self.active {
+            Field::Columns => self.columns,
+            _ => self.rows,
+        };
+        self.set_shape((value as isize + delta).clamp(1, MAX_DIMENSION as isize) as usize);
+    }
+
+    fn set_shape(&mut self, value: usize) {
+        let value = value.clamp(1, MAX_DIMENSION);
+        let slot = match self.active {
+            Field::Columns => &mut self.columns,
+            _ => &mut self.rows,
+        };
+        if *slot == value {
+            return;
+        }
+        *slot = value;
+        self.shape_changed = Instant::now();
+        self.notice = None;
+    }
+
+    // ------------------------------------------------------------ completion
+
+    fn refresh_suggestions(&mut self) {
+        let value = self.project.value.clone();
+        let (siblings, matches) = scan_folders(&value, &self.base_dir);
+        self.suggestions = Suggestions {
+            stem: value,
+            siblings,
+            matches,
+            index: None,
+        };
+    }
+
+    fn complete_project(&mut self) {
+        let stale = self.suggestions.stem != self.project.value
+            && self.suggestions.applied() != Some(&self.project.value);
+        if stale {
+            self.refresh_suggestions();
+        }
+        if self.suggestions.matches.is_empty() {
+            self.notice = Some(Notice {
+                text: "no folders match that path".into(),
+                level: NoticeLevel::Warn,
+            });
+            return;
+        }
+
+        // The first Tab extends to the prefix every candidate shares, the way a
+        // shell would. Once there is nothing left to share, Tab cycles.
+        if self.suggestions.index.is_none() && self.suggestions.matches.len() > 1 {
+            let shared = longest_common_prefix(&self.suggestions.matches);
+            if shared.chars().count() > self.project.value.chars().count() {
+                self.apply_completion(shared);
+                return;
+            }
+        }
+
+        let next = match self.suggestions.index {
+            Some(index) => (index + 1) % self.suggestions.matches.len(),
+            None => 0,
+        };
+        self.suggestions.index = Some(next);
+        let mut candidate = self.suggestions.matches[next].clone();
+        if self.suggestions.matches.len() == 1 && has_subdirectories(&candidate, &self.base_dir) {
+            candidate.push(separator_for(&candidate));
+        }
+        self.apply_completion(candidate);
+    }
+
+    fn apply_completion(&mut self, value: String) {
+        self.project.set(value);
+        self.project_touched = true;
+        self.notice = None;
+        self.refresh_project();
+    }
+
+    fn refresh_project(&mut self) {
+        match resolve_project_path(&self.project.value, &self.base_dir) {
+            Ok(path) => {
+                let changed = self.project_dir.as_deref() != Some(path.as_path());
+                self.project_dir = Some(path);
+                if changed {
+                    self.request_probe(false);
+                }
+            }
+            Err(_) => self.project_dir = None,
+        }
+    }
+
+    // -------------------------------------------------------- worktree probe
+
+    /// Ask a worker thread whether the selected folder can host one managed
+    /// worktree per pane. `git status` is slow on big repositories, so it never
+    /// runs on the draw thread.
+    fn request_probe(&mut self, immediate: bool) {
+        let Some(target) = self.project_dir.clone() else {
+            return;
+        };
+        if self.probing.as_deref() == Some(target.as_path()) {
+            return;
+        }
+        self.readiness = None;
+        if immediate {
+            self.spawn_probe(target);
+        } else {
+            self.probe_due = Some((target, Instant::now()));
+        }
+    }
+
+    fn settle_probe(&mut self) {
+        let Some((target, requested)) = self.probe_due.clone() else {
+            return;
+        };
+        if requested.elapsed() < PROBE_DEBOUNCE {
+            return;
+        }
+        self.probe_due = None;
+        if self.project_dir.as_deref() == Some(target.as_path()) {
+            self.spawn_probe(target);
+        }
+    }
+
+    fn spawn_probe(&mut self, target: PathBuf) {
+        self.probing = Some(target.clone());
+        let tx = self.probe_tx.clone();
+        thread::spawn(move || {
+            // A panicking probe would leave the composer waiting on a result
+            // that never arrives.
+            let readiness = diagnostics::recovering("the worktree probe", || {
+                Ok(probe_worktree_readiness(&target))
+            })
+            .unwrap_or_else(|reason| WorktreeReadiness::Blocked { reason });
+            let _ = tx.send((target, readiness));
+        });
+    }
+
+    fn drain_probes(&mut self) {
+        while let Ok((path, readiness)) = self.probe_rx.try_recv() {
+            if self.project_dir.as_deref() == Some(path.as_path()) {
+                self.readiness = Some(readiness);
+                self.probing = None;
+            }
+        }
+    }
+
+    fn worktrees_active(&self) -> bool {
+        self.worktrees_enabled
+            && self
+                .readiness
+                .as_ref()
+                .is_some_and(WorktreeReadiness::is_ready)
+    }
+
+    fn branch_label(&self, index: usize) -> Option<String> {
+        let base_slug = self.readiness.as_ref()?.base_slug()?;
+        self.worktrees_active()
+            .then(|| managed_branch_name(&self.worktree_options.prefix, base_slug, index))
+    }
+
+    // ---------------------------------------------------------------- launch
+
+    fn grid(&self) -> GridSize {
+        GridSize {
+            rows: self.rows,
+            columns: self.columns,
+        }
+    }
+
+    fn title(&self) -> String {
+        let name = self
+            .name
+            .value
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if name.is_empty() {
+            self.default_name.clone()
+        } else {
+            name
+        }
+    }
+
+    fn build_outcome(&self, config: &Config) -> Result<ComposerOutcome> {
+        let Some(cwd) = self.project_dir.clone() else {
+            return Err(resolve_project_path(&self.project.value, &self.base_dir)
+                .err()
+                .unwrap_or_else(|| anyhow!("project folder is not usable")));
+        };
+        let profile = find_profile(config, &self.profile_name)?;
+        let grid = self.grid();
+        let worktrees = self.worktrees_active().then_some(&self.worktree_options);
+        let plan = LaunchPlan::from_launch_options(
+            self.profile_name.clone(),
             profile,
-            self.current_dir.clone(),
+            cwd,
             grid.count(),
             grid,
             worktrees,
         )?;
 
-        if let Some(profile) = self.selected_auth_profile() {
-            for pane in &mut plan.panes {
-                pane.auth_name = Some(profile.name.clone());
-            }
-        }
-        Ok(plan)
+        Ok(ComposerOutcome {
+            title: self.title(),
+            plan,
+        })
     }
 
-    fn selected_profile(&self) -> &StartupProfile {
-        &self.profiles[self.profile_cursor.min(self.profiles.len() - 1)]
+    // --------------------------------------------------------------- drawing
+
+    fn frame_tick(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64 / FRAME_MS
     }
 
-    fn compatible_auth_profiles(&self) -> Vec<&AuthProfile> {
-        let kind = self.selected_profile().profile.agent_kind;
-        self.auth_profiles
-            .iter()
-            .filter(|profile| Some(profile.kind) == kind)
-            .collect()
-    }
-
-    fn selected_auth_profile(&self) -> Option<&AuthProfile> {
-        self.auth_cursor
-            .checked_sub(1)
-            .and_then(|index| self.compatible_auth_profiles().get(index).copied())
-    }
-
-    fn move_field(&mut self, delta: isize) {
-        let current = StartupField::ALL
-            .iter()
-            .position(|field| *field == self.active_field)
-            .unwrap_or(0);
-        let next = (current as isize + delta).rem_euclid(StartupField::ALL.len() as isize);
-        self.active_field = StartupField::ALL[next as usize];
-    }
-
-    fn adjust_active(&mut self, delta: isize) {
-        match self.active_field {
-            StartupField::Profile => {
-                self.profile_cursor = (self.profile_cursor as isize + delta)
-                    .rem_euclid(self.profiles.len() as isize)
-                    as usize;
-                self.auth_cursor = 0;
-            }
-            StartupField::Auth => {
-                let choices = self.compatible_auth_profiles().len() + 1;
-                self.auth_cursor =
-                    (self.auth_cursor as isize + delta).rem_euclid(choices as isize) as usize;
-            }
-            StartupField::Rows => {
-                self.picker.active_field = DimensionField::Rows;
-                self.picker.adjust_active(delta);
-            }
-            StartupField::Columns => {
-                self.picker.active_field = DimensionField::Columns;
-                self.picker.adjust_active(delta);
-            }
-            StartupField::Worktrees => self.worktrees_enabled = !self.worktrees_enabled,
-            StartupField::Project | StartupField::Launch => {}
-        }
-    }
-
-    fn commit_project_input(&mut self) {
-        match resolve_project_path(&self.project_input, &self.current_dir) {
-            Ok(path) => {
-                self.current_dir = path;
-                self.project_input = display_path(&self.current_dir);
-                self.project_error = None;
-                self.editing_project = false;
-            }
-            Err(error) => self.project_error = Some(error.to_string()),
-        }
-    }
-
-    fn draw(&self, frame: &mut Frame<'_>, config: &Config) {
+    fn draw(&self, frame: &mut Frame<'_>, _config: &Config) {
         let area = frame.area();
-        frame.render_widget(background(), area);
         frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(CANVAS_BG)),
+            area,
+        );
+        let tick = self.frame_tick();
+
+        let panel = if area.width >= 90 && area.height >= 26 {
+            inset(area, 2, 1)
+        } else {
+            area
+        };
+        if panel.width < 10 || panel.height < 6 {
+            return;
+        }
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .title(" Create Agent Workspace ")
-            .border_style(Style::default().fg(Color::Cyan))
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(HAIRLINE_HI))
+            .title(chrome_title())
+            .title_bottom(chrome_footer_title(&self.profile_title))
             .style(panel_style());
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        let inner = block.inner(panel);
+        frame.render_widget(block, panel);
+        paint_border_runner(frame, panel, tick);
 
+        let content = inset(inner, if inner.width >= 8 { 2 } else { 0 }, 0);
+        if content.width == 0 || content.height == 0 {
+            return;
+        }
+
+        let header_height = if content.height >= 22 {
+            5
+        } else if content.height >= 18 {
+            4
+        } else {
+            1
+        };
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(4),
-                Constraint::Length(8),
-                Constraint::Min(5),
-                Constraint::Length(4),
+                Constraint::Length(header_height),
+                Constraint::Min(8),
+                Constraint::Length(3),
             ])
-            .split(inner);
-        self.draw_workspace_header(frame, chunks[0]);
-        self.draw_workspace_fields(frame, chunks[1], config);
-        self.picker
-            .draw_preview(frame, chunks[2], GridPickerMode::Startup);
-        self.draw_workspace_controls(frame, chunks[3]);
+            .split(content);
+
+        self.draw_header(frame, chunks[0], tick);
+
+        let body = chunks[1];
+        if body.width >= 80 {
+            let split = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Percentage(48),
+                    Constraint::Length(1),
+                    Constraint::Percentage(52),
+                ])
+                .split(body);
+            self.draw_form(frame, split[0], tick);
+            self.draw_preview(frame, split[2], tick);
+        } else {
+            self.draw_form(frame, body, tick);
+        }
+
+        self.draw_footer(frame, chunks[2], tick);
     }
 
-    fn draw_workspace_header(&self, frame: &mut Frame<'_>, area: Rect) {
-        let selected = self.selected_profile();
-        let mode = if selected.terminal {
-            "Raw terminal grid"
-        } else if selected.agent {
-            "Managed agent workspace"
-        } else {
-            "Custom command workspace"
-        };
-        let detail = if selected.terminal {
-            "Shells stay unmodified; managed auth applies only to agents GridBash launches."
-        } else if selected.agent {
-            "GridBash launches, isolates, monitors, and coordinates every pane."
-        } else {
-            "GridBash arranges this command in real PTYs; the command owns its login behavior."
-        };
-        let lines = vec![
-            Line::from(Span::styled(
-                mode,
-                Style::default()
-                    .fg(if selected.terminal {
-                        Color::Gray
-                    } else {
-                        Color::LightCyan
-                    })
-                    .add_modifier(Modifier::BOLD),
-            )),
-            Line::from(Span::styled(detail, Style::default().fg(Color::Gray))),
-        ];
-        frame.render_widget(
-            Paragraph::new(lines)
-                .alignment(Alignment::Center)
+    fn draw_header(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.height == 0 {
+            return;
+        }
+        if area.height < 3 || area.width < WORDMARK_WIDTH {
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        "GRIDBASH",
+                        Style::default()
+                            .fg(TERMINAL_GREEN)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled("  ·  ", Style::default().fg(HAIRLINE_HI)),
+                    Span::styled(self.telemetry_line(), Style::default().fg(MUTED)),
+                ]))
                 .style(panel_style()),
-            area,
-        );
-    }
+                area,
+            );
+            return;
+        }
 
-    fn draw_workspace_fields(&self, frame: &mut Frame<'_>, area: Rect, config: &Config) {
-        let selected = self.selected_profile();
-        let profile_kind = if selected.terminal {
-            "Raw terminal"
-        } else if selected.agent {
-            "Agent"
-        } else {
-            "Command"
-        };
-        let (auth_value, auth_hint) = self.auth_display(config);
-        let project_value = if self.editing_project {
-            format!("{}▌", self.project_input)
-        } else {
-            self.project_input.clone()
-        };
-        let project_hint = self
-            .project_error
-            .clone()
-            .unwrap_or_else(|| "e edits the project folder".into());
-        let lines = vec![
-            workspace_row(
-                self.active_field == StartupField::Profile,
-                "Profile",
-                format!("{profile_kind} · {}", selected.title),
-                format!("{} ({})", selected.profile.command, selected.name),
-            ),
-            workspace_row(
-                self.active_field == StartupField::Auth,
-                "Auth",
-                auth_value,
-                auth_hint,
-            ),
-            workspace_row(
-                self.active_field == StartupField::Rows,
-                "Rows",
-                self.picker.rows.to_string(),
-                "1–10",
-            ),
-            workspace_row(
-                self.active_field == StartupField::Columns,
-                "Columns",
-                self.picker.columns.to_string(),
-                format!("{} panes total", self.picker.grid().count()),
-            ),
-            workspace_row(
-                self.active_field == StartupField::Worktrees,
-                "Worktrees",
-                if self.worktrees_enabled { "on" } else { "off" },
-                if self.worktrees_enabled {
-                    "one isolated git worktree per pane"
-                } else {
-                    "all panes use the project folder"
-                },
-            ),
-            workspace_row(
-                self.active_field == StartupField::Project,
-                "Project",
-                project_value,
-                project_hint,
-            ),
-            workspace_row(
-                self.active_field == StartupField::Launch,
-                "Launch",
-                "Start workspace",
-                "Enter",
-            ),
-        ];
-        frame.render_widget(Paragraph::new(lines).style(panel_style()), area);
-    }
+        paint_starfield(frame, area, tick, 0x51D3);
 
-    fn draw_workspace_controls(&self, frame: &mut Frame<'_>, area: Rect) {
-        let lines = vec![
-            Line::from(""),
+        let split = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(WORDMARK_WIDTH), Constraint::Min(0)])
+            .split(area);
+        draw_wordmark(frame, split[0], tick);
+
+        let stats = split[1];
+        if stats.width < 14 {
+            return;
+        }
+        let stats = inset(stats, 2, 0);
+        let panes = self.grid().count();
+        let mut lines = vec![
             Line::from(vec![
-                Span::styled("Up/Down", Style::default().fg(Color::Yellow)),
-                Span::raw(" field  "),
-                Span::styled("Left/Right", Style::default().fg(Color::Yellow)),
-                Span::raw(" change  "),
-                Span::styled("e", Style::default().fg(Color::Yellow)),
-                Span::raw(" edit project  "),
-                Span::styled("Enter", Style::default().fg(Color::Yellow)),
-                Span::raw(" launch  "),
-                Span::styled("q", Style::default().fg(Color::Yellow)),
-                Span::raw(" quit"),
+                Span::styled(
+                    format!("{panes:02}"),
+                    Style::default()
+                        .fg(SOFT_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" PANES   ", Style::default().fg(MUTED)),
+                Span::styled(
+                    format!("{}×{}", self.rows, self.columns),
+                    Style::default()
+                        .fg(TERMINAL_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
             ]),
+            Line::from(self.worktree_status_spans()),
         ];
+        if stats.height >= 3 {
+            lines.push(Line::from(vec![
+                Span::styled("▸ ", Style::default().fg(DIM_GREEN)),
+                Span::styled(self.profile_title.to_uppercase(), Style::default().fg(TEXT)),
+                Span::styled(" in every pane", Style::default().fg(MUTED)),
+            ]));
+        }
         frame.render_widget(
             Paragraph::new(lines)
-                .alignment(Alignment::Center)
+                .alignment(Alignment::Right)
                 .style(panel_style()),
+            stats,
+        );
+    }
+
+    fn telemetry_line(&self) -> String {
+        format!(
+            "{} panes · {} · {}",
+            self.grid().count(),
+            self.profile_title,
+            if self.worktrees_active() {
+                "worktrees"
+            } else {
+                "shared folder"
+            }
+        )
+    }
+
+    fn worktree_status_spans(&self) -> Vec<Span<'static>> {
+        let (dot, label, color) = match (&self.readiness, self.worktrees_enabled) {
+            (_, false) => ("○", "WORKTREES OFF", MUTED),
+            (None, _) => ("◌", "CHECKING REPO", MUTED),
+            (Some(WorktreeReadiness::Ready { .. }), _) => ("●", "WORKTREES ON", SOFT_GREEN),
+            (Some(WorktreeReadiness::Blocked { .. }), _) => ("▲", "SHARED FOLDER", AMBER),
+        };
+        vec![
+            Span::styled(format!("{dot} "), Style::default().fg(color)),
+            Span::styled(label, Style::default().fg(color)),
+        ]
+    }
+
+    // ------------------------------------------------------------------ form
+
+    fn draw_form(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.width < 22 || area.height < 6 {
+            return;
+        }
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(4), Constraint::Min(4)])
+            .split(area);
+
+        self.draw_shape(frame, chunks[0], tick);
+        self.draw_identity(frame, chunks[1], tick);
+    }
+
+    fn draw_shape(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.height < 4 {
+            return;
+        }
+        let block = section_block(
+            "01",
+            "SHAPE",
+            self.active_in(&[Field::Rows, Field::Columns]),
+        );
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let width = inner.width as usize;
+        let lines = vec![
+            shape_row("ROWS", self.rows, self.active == Field::Rows, tick, width),
+            shape_row(
+                "COLUMNS",
+                self.columns,
+                self.active == Field::Columns,
+                tick,
+                width,
+            ),
+        ];
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
+            inner,
+        );
+    }
+
+    fn draw_identity(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.height < 4 {
+            return;
+        }
+        let block = section_block(
+            "02",
+            "IDENTITY",
+            self.active_in(&[Field::Name, Field::Project]),
+        );
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let value_width = (inner.width as usize).saturating_sub(13).max(6);
+        let hint_width = (inner.width as usize).saturating_sub(11).max(6);
+        let mut lines = vec![
+            text_row(
+                "NAME",
+                &self.name,
+                self.active == Field::Name,
+                tick,
+                value_width,
+                None,
+                DIM_GREEN,
+            ),
+            hint_row(Span::styled(
+                truncate(
+                    &if self.name.value.trim().is_empty() {
+                        format!("defaults to {}", self.default_name)
+                    } else {
+                        "tab name for this grid".into()
+                    },
+                    hint_width,
+                ),
+                Style::default().fg(MUTED),
+            )),
+            text_row(
+                "PROJECT",
+                &self.project,
+                self.active == Field::Project,
+                tick,
+                value_width,
+                self.project_ghost().as_deref(),
+                TERMINAL_GREEN,
+            ),
+            hint_row(self.project_state_span(hint_width)),
+        ];
+        lines.truncate(inner.height as usize);
+
+        let used = lines.len() as u16;
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
+            Rect {
+                height: used.min(inner.height),
+                ..inner
+            },
+        );
+
+        let remaining = inner.height.saturating_sub(used);
+        if remaining >= 2 {
+            self.draw_suggestions(
+                frame,
+                Rect {
+                    y: inner.y.saturating_add(used),
+                    height: remaining,
+                    ..inner
+                },
+            );
+        }
+    }
+
+    /// Live folder browser for the project field. It stays on screen even when
+    /// the field is not focused, so the panel always shows where else the grid
+    /// could land instead of a block of dead space.
+    fn draw_suggestions(&self, frame: &mut Frame<'_>, area: Rect) {
+        let focused = self.active == Field::Project;
+        let folders = &self.suggestions.siblings;
+        let matches = &self.suggestions.matches;
+        let selected = self
+            .suggestions
+            .applied()
+            .filter(|_| focused)
+            .and_then(|applied| folders.iter().position(|folder| folder == applied));
+
+        let mut lines = vec![Line::from(vec![
+            Span::styled("╌╌ ", Style::default().fg(HAIRLINE)),
+            Span::styled(
+                match (folders.len(), focused) {
+                    (0, _) => "NOTHING TO BROWSE HERE".to_string(),
+                    (total, true) => {
+                        format!("{} OF {total} MATCH · TAB CYCLES", matches.len())
+                    }
+                    (total, false) => format!("{total} NEARBY {}", plural("FOLDER", total)),
+                },
+                Style::default().fg(HAIRLINE_HI),
+            ),
+        ])];
+
+        let capacity = area.height.saturating_sub(1) as usize;
+        // Keep the Tab-selected row on screen, otherwise lead with the first
+        // candidate Tab would land on.
+        let anchor = selected
+            .or_else(|| folders.iter().position(|folder| matches.contains(folder)))
+            .unwrap_or(0);
+        let start = if folders.len() > capacity && anchor + 1 > capacity {
+            anchor + 1 - capacity
+        } else {
+            0
+        };
+        let width = area.width.saturating_sub(6) as usize;
+        // When the list overflows, the last row becomes the "+N more" counter,
+        // so the room for entries shrinks by one and N has to account for it.
+        let mut room = capacity;
+        let mut hidden = folders.len().saturating_sub(start + room);
+        if hidden > 0 {
+            room = capacity.saturating_sub(1);
+            hidden = folders.len().saturating_sub(start + room);
+        }
+
+        for (offset, candidate) in folders.iter().enumerate().skip(start).take(room) {
+            let is_selected = selected == Some(offset);
+            let is_match = matches.contains(candidate);
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD)
+            } else if is_match && focused {
+                Style::default().fg(TEXT)
+            } else {
+                Style::default().fg(if is_match { MUTED } else { HAIRLINE_HI })
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    if is_selected { " ▸ " } else { "   " },
+                    Style::default().fg(if is_selected { TERMINAL_GREEN } else { HAIRLINE }),
+                ),
+                Span::styled(
+                    format!(" {} ", truncate(&leaf_name(candidate), width)),
+                    style,
+                ),
+            ]));
+        }
+
+        if hidden > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("   +{hidden} more"),
+                Style::default().fg(HAIRLINE_HI),
+            )));
+        }
+
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
             area,
         );
     }
 
-    fn auth_display(&self, config: &Config) -> (String, String) {
-        let selected = self.selected_profile();
-        if selected.terminal {
-            return (
-                "unmanaged".into(),
-                "normal shell environment; no command interception".into(),
-            );
+    /// Dim text after the cursor showing what Tab would fill in.
+    fn project_ghost(&self) -> Option<String> {
+        if self.active != Field::Project || self.project.cursor != self.project.len() {
+            return None;
         }
-        let Some(kind) = selected.profile.agent_kind else {
-            return (
-                "tool login".into(),
-                "this agent manages its own authentication".into(),
-            );
-        };
-        if let Some(profile) = self.selected_auth_profile() {
-            let account = profile
-                .account_label
-                .as_deref()
-                .map(|label| format!(" · {label}"))
-                .unwrap_or_default();
-            return (
-                profile.name.clone(),
-                format!(
-                    "{} profile · {}{account}",
-                    kind.display_name(),
-                    profile.status_label()
-                ),
-            );
+        if self.suggestions.index.is_some() {
+            return None;
         }
-        if config.auth.auto_cycle {
-            return (
-                "launch policy".into(),
-                "round-robin across ready profiles for this agent".into(),
-            );
-        }
-        match config.auth.defaults.get(kind) {
-            Some(name) => (
-                "launch policy".into(),
-                format!("configured {} default: {name}", kind.display_name()),
+        self.suggestions
+            .matches
+            .first()?
+            .strip_prefix(self.project.value.as_str())
+            .filter(|rest| !rest.is_empty())
+            .map(str::to_string)
+    }
+
+    fn project_state_span(&self, width: usize) -> Span<'static> {
+        match (&self.project_dir, self.project_touched) {
+            (Some(path), _) => Span::styled(
+                format!("✓ {}", short_path(path, width.saturating_sub(2))),
+                Style::default().fg(SOFT_GREEN),
             ),
-            None => (
-                "normal login".into(),
-                format!("use the default {} account", kind.display_name()),
+            (None, true) => Span::styled(
+                truncate("folder not found yet · keep typing or press Tab", width),
+                Style::default().fg(AMBER),
+            ),
+            (None, false) => Span::styled(
+                truncate("choose a project folder", width),
+                Style::default().fg(MUTED),
             ),
         }
     }
+
+    fn active_in(&self, fields: &[Field]) -> bool {
+        fields.contains(&self.active)
+    }
+
+    // --------------------------------------------------------------- preview
+
+    fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.width < 20 || area.height < 6 {
+            return;
+        }
+        let block = section_block("03", "LIVE GRID", false);
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let header_height = if inner.height >= 10 { 3 } else { 1 };
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(header_height), Constraint::Min(1)])
+            .split(inner);
+
+        let mut lines = vec![Line::from(vec![
+            Span::styled(
+                format!("{:02}", self.rows),
+                Style::default()
+                    .fg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" ROWS  ×  ", Style::default().fg(MUTED)),
+            Span::styled(
+                format!("{:02}", self.columns),
+                Style::default()
+                    .fg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" COLS  =  ", Style::default().fg(MUTED)),
+            Span::styled(
+                format!("{:02}", self.grid().count()),
+                Style::default()
+                    .fg(SOFT_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" PANES", Style::default().fg(MUTED)),
+        ])];
+        if header_height >= 3 {
+            lines.push(Line::from(self.isolation_spans()));
+        }
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
+            chunks[0],
+        );
+
+        let stage = chunks[1];
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SUNKEN_BG)),
+            stage,
+        );
+        paint_starfield(frame, stage, tick, 0x9F17);
+
+        let since_change = self.shape_changed.elapsed().as_millis() as u64;
+        let folder = self
+            .project_dir
+            .as_deref()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .map(str::to_string);
+        let total = self.grid().count();
+
+        for (index, rect) in square_preview_rects(inset(stage, 1, 0), self.grid())
+            .into_iter()
+            .enumerate()
+        {
+            let row = index / self.columns.max(1);
+            let column = index % self.columns.max(1);
+            draw_preview_cell(
+                frame,
+                rect,
+                &PreviewCell {
+                    accent: cell_accent(index, total),
+                    // Cells wake up in a diagonal wave whenever the shape changes.
+                    revealed: since_change >= (row as u64 + column as u64) * 35 + 20,
+                    shimmer: shimmer_hits(tick, row, column, self.rows + self.columns),
+                    title: format!("{:02}", index + 1),
+                    subtitle: self
+                        .branch_label(index)
+                        .map(|branch| leaf_after(&branch))
+                        .or_else(|| folder.clone()),
+                    fill: SUNKEN_BG,
+                },
+            );
+        }
+    }
+
+    fn isolation_spans(&self) -> Vec<Span<'static>> {
+        if let Some(branch) = self.branch_label(0) {
+            let last = self
+                .branch_label(self.grid().count().saturating_sub(1))
+                .map(|value| leaf_after(&value))
+                .unwrap_or_default();
+            return vec![
+                Span::styled("⎇ ", Style::default().fg(SOFT_GREEN)),
+                Span::styled(branch, Style::default().fg(TEXT)),
+                Span::styled(
+                    if self.grid().count() > 1 {
+                        format!(" … {last}")
+                    } else {
+                        String::new()
+                    },
+                    Style::default().fg(MUTED),
+                ),
+            ];
+        }
+
+        let reason = match (&self.readiness, self.worktrees_enabled) {
+            (_, false) => "worktrees off · alt+w re-enables".to_string(),
+            (None, _) => "checking git worktree readiness…".to_string(),
+            (Some(readiness), _) => readiness
+                .reason()
+                .map(|reason| format!("shared folder · {reason}"))
+                .unwrap_or_else(|| "shared folder".into()),
+        };
+        vec![
+            Span::styled("⌂ ", Style::default().fg(AMBER)),
+            Span::styled(reason, Style::default().fg(MUTED)),
+        ]
+    }
+
+    // ---------------------------------------------------------------- footer
+
+    fn draw_footer(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.height == 0 {
+            return;
+        }
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Min(0),
+            ])
+            .split(area);
+
+        let notice = self.notice.clone().unwrap_or_else(|| self.hint_notice());
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(
+                    notice.level.glyph(),
+                    Style::default().fg(notice.level.color()),
+                ),
+                Span::styled(notice.text, Style::default().fg(notice.level.color())),
+            ]))
+            .alignment(Alignment::Center)
+            .style(panel_style()),
+            rows[0],
+        );
+
+        frame.render_widget(
+            Paragraph::new(launch_bar(self.grid().count(), tick, rows[1].width))
+                .alignment(Alignment::Center)
+                .style(panel_style()),
+            rows[1],
+        );
+
+        if rows[2].height > 0 {
+            frame.render_widget(
+                Paragraph::new(self.controls_line(rows[2].width))
+                    .alignment(Alignment::Center)
+                    .style(panel_style()),
+                rows[2],
+            );
+        }
+    }
+
+    fn hint_notice(&self) -> Notice {
+        let text = match self.active {
+            Field::Rows | Field::Columns => "type a digit, or ←/→ to resize the grid",
+            Field::Name => "name this grid so its tab is easy to find",
+            Field::Project => "Tab completes folders · Tab again cycles matches",
+        };
+        Notice {
+            text: text.into(),
+            level: NoticeLevel::Info,
+        }
+    }
+
+    fn controls_line(&self, width: u16) -> Line<'static> {
+        let mut spans = vec![
+            keycap("↑↓"),
+            label("FIELD"),
+            keycap("←→"),
+            label(if self.active.is_text() {
+                "CURSOR"
+            } else {
+                "SIZE"
+            }),
+            keycap("TAB"),
+            label(if self.active == Field::Project {
+                "COMPLETE"
+            } else {
+                "NEXT"
+            }),
+        ];
+        if width >= 78 {
+            spans.push(keycap("ALT+W"));
+            spans.push(label("WORKTREES"));
+        }
+        spans.push(keycap("ESC"));
+        spans.push(label("CANCEL"));
+        Line::from(spans)
+    }
+}
+
+impl NoticeLevel {
+    fn color(self) -> Color {
+        match self {
+            Self::Error => ALERT_RED,
+            Self::Warn => AMBER,
+            Self::Info => MUTED,
+        }
+    }
+
+    fn glyph(self) -> &'static str {
+        match self {
+            Self::Error => "✕ ",
+            Self::Warn => "▲ ",
+            Self::Info => "› ",
+        }
+    }
+}
+
+impl Suggestions {
+    fn applied(&self) -> Option<&String> {
+        self.index.and_then(|index| self.matches.get(index))
+    }
+}
+
+impl TextField {
+    fn new(value: impl Into<String>, limit: Option<usize>) -> Self {
+        let value = value.into();
+        let cursor = value.chars().count();
+        Self {
+            value,
+            cursor,
+            limit,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.value.chars().count()
+    }
+
+    fn byte_index(&self, cursor: usize) -> usize {
+        self.value
+            .char_indices()
+            .nth(cursor)
+            .map(|(index, _)| index)
+            .unwrap_or(self.value.len())
+    }
+
+    fn insert(&mut self, ch: char) -> bool {
+        if ch.is_control() || self.limit.is_some_and(|limit| self.len() >= limit) {
+            return false;
+        }
+        let at = self.byte_index(self.cursor);
+        self.value.insert(at, ch);
+        self.cursor += 1;
+        true
+    }
+
+    fn insert_str(&mut self, text: &str) -> bool {
+        let mut inserted = false;
+        for ch in text.chars() {
+            inserted |= self.insert(ch);
+        }
+        inserted
+    }
+
+    fn backspace(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= 1;
+        self.remove_char_at(self.cursor)
+    }
+
+    fn delete(&mut self) -> bool {
+        if self.cursor >= self.len() {
+            return false;
+        }
+        self.remove_char_at(self.cursor)
+    }
+
+    /// `String::remove` panics at the end of the string, so only call it for a
+    /// character index the value actually holds.
+    fn remove_char_at(&mut self, cursor: usize) -> bool {
+        let at = self.byte_index(cursor);
+        if at >= self.value.len() {
+            return false;
+        }
+        self.value.remove(at);
+        true
+    }
+
+    /// Backspace over one path segment: trailing separators first, then the
+    /// name in front of them.
+    fn delete_word(&mut self) -> bool {
+        let mut removed = false;
+        while self.cursor > 0 && self.char_before().is_some_and(is_path_boundary) {
+            removed |= self.backspace();
+        }
+        while self.cursor > 0 && self.char_before().is_some_and(|ch| !is_path_boundary(ch)) {
+            removed |= self.backspace();
+        }
+        removed
+    }
+
+    fn char_before(&self) -> Option<char> {
+        self.value.chars().nth(self.cursor.checked_sub(1)?)
+    }
+
+    fn clear(&mut self) -> bool {
+        if self.value.is_empty() {
+            return false;
+        }
+        self.value.clear();
+        self.cursor = 0;
+        true
+    }
+
+    fn set(&mut self, value: String) {
+        self.value = value;
+        self.cursor = self.len();
+    }
+
+    fn move_cursor(&mut self, delta: isize) {
+        self.cursor = (self.cursor as isize + delta).clamp(0, self.len() as isize) as usize;
+    }
+
+    fn home(&mut self) {
+        self.cursor = 0;
+    }
+
+    fn end(&mut self) {
+        self.cursor = self.len();
+    }
+}
+
+fn is_path_boundary(ch: char) -> bool {
+    matches!(ch, '/' | '\\' | ' ')
+}
+
+// -------------------------------------------------------------------- widgets
+
+fn chrome_title() -> Line<'static> {
+    Line::from(vec![
+        Span::styled("─┤ ", Style::default().fg(HAIRLINE_HI)),
+        Span::styled("◆", Style::default().fg(SOFT_GREEN)),
+        Span::styled(
+            " NEW GRID ",
+            Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("├─", Style::default().fg(HAIRLINE_HI)),
+    ])
+}
+
+fn chrome_footer_title(profile: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("─┤ ", Style::default().fg(HAIRLINE)),
+        Span::styled(profile.to_uppercase(), Style::default().fg(HAIRLINE_HI)),
+        Span::styled(" ├─", Style::default().fg(HAIRLINE)),
+    ])
+    .alignment(Alignment::Right)
+}
+
+fn section_block(index: &'static str, label: &'static str, active: bool) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(if active { HAIRLINE_HI } else { HAIRLINE }))
+        .title(Line::from(vec![
+            Span::styled(
+                format!(" {index} "),
+                Style::default().fg(if active { DIM_GREEN } else { HAIRLINE_HI }),
+            ),
+            Span::styled(
+                format!("{label} "),
+                Style::default()
+                    .fg(if active { TEXT } else { MUTED })
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]))
+        .style(Style::default().bg(RAISED_BG))
+}
+
+fn shape_row(label: &str, value: usize, focused: bool, tick: u64, width: usize) -> Line<'static> {
+    let mut spans = vec![
+        focus_marker(focused, TERMINAL_GREEN, tick),
+        Span::styled(format!("{label:<9}"), field_label_style(focused)),
+        Span::styled(
+            format!(" {value:02} "),
+            if focused {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+                    .fg(TERMINAL_GREEN)
+                    .bg(SUNKEN_BG)
+                    .add_modifier(Modifier::BOLD)
+            },
+        ),
+    ];
+
+    if width >= 28 {
+        spans.push(Span::raw("  "));
+        for slot in 0..MAX_DIMENSION {
+            let (glyph, color) = if slot < value {
+                let ramp = lerp_color(
+                    TERMINAL_GREEN,
+                    DIM_GREEN,
+                    slot as f32 / (MAX_DIMENSION - 1) as f32,
+                );
+                let leading = focused && slot + 1 == value;
+                ("█", if leading { pulse(ramp, tick) } else { ramp })
+            } else {
+                ("▒", HAIRLINE)
+            };
+            spans.push(Span::styled(glyph, Style::default().fg(color)));
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn text_row(
+    label: &str,
+    field: &TextField,
+    focused: bool,
+    tick: u64,
+    width: usize,
+    ghost: Option<&str>,
+    accent: Color,
+) -> Line<'static> {
+    let mut spans = vec![
+        focus_marker(focused, accent, tick),
+        Span::styled(format!("{label:<9}"), field_label_style(focused)),
+    ];
+
+    let chars = field.value.chars().collect::<Vec<_>>();
+    let visible = width.max(6);
+    // Clamp before scrolling: a cursor left past the end of a replaced value
+    // would put `start` beyond `end`, and `clamp` panics when its bounds cross.
+    let caret = field.cursor.min(chars.len());
+    // Scroll the window so the cursor is always on screen.
+    let start = if chars.len() < visible {
+        0
+    } else {
+        caret.saturating_sub(visible.saturating_sub(1))
+    };
+    let end = (start + visible).min(chars.len()).max(start);
+    let value_style = Style::default().fg(if focused {
+        TEXT
+    } else {
+        Color::Rgb(176, 190, 205)
+    });
+
+    if start > 0 {
+        spans.push(Span::styled("…", Style::default().fg(HAIRLINE_HI)));
+    }
+    let cursor = caret.clamp(start, end);
+    spans.push(Span::styled(
+        chars
+            .get(start..cursor)
+            .unwrap_or_default()
+            .iter()
+            .collect::<String>(),
+        value_style,
+    ));
+
+    if focused {
+        let blink = tick % 16 < 11;
+        match chars.get(cursor) {
+            Some(ch) if cursor < end => spans.push(Span::styled(
+                ch.to_string(),
+                if blink {
+                    Style::default().fg(Color::Black).bg(accent)
+                } else {
+                    value_style
+                },
+            )),
+            _ => spans.push(Span::styled(
+                if blink { "▌" } else { " " },
+                Style::default().fg(accent),
+            )),
+        }
+    }
+
+    let tail = if focused {
+        (cursor + 1).min(end)
+    } else {
+        cursor
+    };
+    if tail < end {
+        spans.push(Span::styled(
+            chars[tail..end].iter().collect::<String>(),
+            value_style,
+        ));
+    }
+
+    if let Some(ghost) = ghost {
+        let room = visible.saturating_sub(end.saturating_sub(start));
+        if room > 1 {
+            spans.push(Span::styled(
+                truncate(ghost, room),
+                Style::default().fg(HAIRLINE_HI),
+            ));
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn hint_row(hint: Span<'static>) -> Line<'static> {
+    Line::from(vec![Span::raw("           "), hint])
+}
+
+fn focus_marker(focused: bool, accent: Color, tick: u64) -> Span<'static> {
+    Span::styled(
+        if focused { "▌ " } else { "  " },
+        Style::default().fg(if focused {
+            pulse(accent, tick)
+        } else {
+            HAIRLINE
+        }),
+    )
+}
+
+fn field_label_style(focused: bool) -> Style {
+    Style::default()
+        .fg(if focused { TEXT } else { MUTED })
+        .add_modifier(if focused {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        })
+}
+
+struct PreviewCell {
+    accent: Color,
+    revealed: bool,
+    shimmer: bool,
+    title: String,
+    subtitle: Option<String>,
+    fill: Color,
+}
+
+fn draw_preview_cell(frame: &mut Frame<'_>, rect: Rect, cell: &PreviewCell) {
+    if rect.width < 2 || rect.height < 2 {
+        return;
+    }
+
+    let border = if !cell.revealed {
+        HAIRLINE
+    } else if cell.shimmer {
+        Color::Rgb(238, 248, 255)
+    } else {
+        cell.accent
+    };
+    // Clear first: the stage behind this cell is dusted with starfield glyphs,
+    // and a Block only restyles cells, it does not overwrite their symbols.
+    frame.render_widget(Clear, rect);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(Style::default().fg(border))
+        .style(Style::default().bg(if cell.revealed { cell.fill } else { CANVAS_BG }));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    if !cell.revealed || inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let mut lines = vec![Line::from(Span::styled(
+        cell.title.clone(),
+        Style::default()
+            .fg(if cell.shimmer { Color::White } else { TEXT })
+            .add_modifier(Modifier::BOLD),
+    ))];
+    // Below this width a branch name is all ellipsis, so the number stands alone.
+    if inner.height >= 3 && inner.width >= 12 {
+        if let Some(subtitle) = cell.subtitle.as_deref() {
+            lines.push(Line::from(Span::styled(
+                truncate(subtitle, inner.width as usize),
+                Style::default().fg(dim_color(cell.accent)),
+            )));
+        }
+    }
+
+    let text_height = (lines.len() as u16).min(inner.height);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true }),
+        Rect {
+            y: inner.y + inner.height.saturating_sub(text_height) / 2,
+            height: text_height,
+            ..inner
+        },
+    );
+}
+
+/// The launch affordance: a solid bar with a highlight sweeping across it.
+fn launch_bar(panes: usize, tick: u64, width: u16) -> Line<'static> {
+    let text = if width >= 56 {
+        format!("  ▶  LAUNCH {panes} PANES   ·   ENTER  ")
+    } else {
+        format!("  ▶  LAUNCH {panes}  ·  ENTER  ")
+    };
+    let chars = text.chars().collect::<Vec<_>>();
+    let len = chars.len().max(1);
+    let sweep = (tick % (len as u64 + 14)) as f32 - 7.0;
+
+    let spans = chars
+        .into_iter()
+        .enumerate()
+        .map(|(index, ch)| {
+            let base = lerp_color(SOFT_GREEN, TERMINAL_GREEN, index as f32 / len as f32);
+            let distance = (index as f32 - sweep).abs();
+            let background = if distance < 3.0 {
+                lerp_color(Color::White, base, distance / 3.0)
+            } else {
+                base
+            };
+            Span::styled(
+                ch.to_string(),
+                Style::default()
+                    .fg(Color::Rgb(3, 12, 10))
+                    .bg(background)
+                    .add_modifier(Modifier::BOLD),
+            )
+        })
+        .collect::<Vec<_>>();
+    Line::from(spans)
+}
+
+fn draw_wordmark(frame: &mut Frame<'_>, area: Rect, tick: u64) {
+    let sweep = (tick % (WORDMARK_WIDTH as u64 + 26)) as f32 - 13.0;
+    for (row, text) in WORDMARK.iter().enumerate() {
+        let y = area.y.saturating_add(row as u16);
+        if y >= area.bottom() {
+            break;
+        }
+        let spans = text
+            .chars()
+            .enumerate()
+            .map(|(column, ch)| {
+                let base = lerp_color(
+                    TERMINAL_GREEN,
+                    DIM_GREEN,
+                    column as f32 / WORDMARK_WIDTH as f32,
+                );
+                let distance = (column as f32 - sweep).abs() + row as f32 * 0.6;
+                let color = if distance < 4.0 {
+                    lerp_color(Color::White, base, distance / 4.0)
+                } else {
+                    base
+                };
+                Span::styled(
+                    ch.to_string(),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                )
+            })
+            .collect::<Vec<_>>();
+        frame.render_widget(
+            Paragraph::new(Line::from(spans)),
+            Rect {
+                x: area.x,
+                y,
+                width: area.width,
+                height: 1,
+            },
+        );
+    }
+}
+
+/// Sparse drifting dust. Written straight into the buffer so it costs one cell
+/// write per star instead of a span per column.
+fn paint_starfield(frame: &mut Frame<'_>, area: Rect, tick: u64, seed: u64) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let drift = tick / 14;
+    let buffer = frame.buffer_mut();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            let noise = hash3(x as u64, (y as u64).wrapping_add(drift), seed);
+            if noise % 29 != 0 {
+                continue;
+            }
+            let (glyph, color) = match (noise >> 8).wrapping_add(tick / 6) % 14 {
+                0 => ("*", Color::Rgb(96, 132, 164)),
+                1 | 2 => ("·", Color::Rgb(62, 92, 118)),
+                _ => ("·", Color::Rgb(26, 40, 54)),
+            };
+            if let Some(cell) = buffer.cell_mut((x, y)) {
+                cell.set_symbol(glyph).set_fg(color);
+            }
+        }
+    }
+}
+
+/// A short bright comet running clockwise around the dialog border.
+fn paint_border_runner(frame: &mut Frame<'_>, rect: Rect, tick: u64) {
+    if rect.width < 4 || rect.height < 4 {
+        return;
+    }
+    let perimeter = border_perimeter(rect);
+    if perimeter == 0 {
+        return;
+    }
+
+    let head = (tick % u64::from(perimeter)) as u16;
+    let buffer = frame.buffer_mut();
+    for trail in 0..6u16 {
+        // Walk backwards in `u32` so a wide dialog cannot overflow the sum.
+        let index =
+            ((u32::from(head) + u32::from(perimeter) - u32::from(trail)) % u32::from(perimeter))
+                as u16;
+        let (x, y) = perimeter_point(rect, index);
+        let color = lerp_color(TERMINAL_GREEN, HAIRLINE_HI, trail as f32 / 6.0);
+        if let Some(cell) = buffer.cell_mut((x, y)) {
+            cell.set_fg(color);
+        }
+    }
+}
+
+/// Number of border cells `perimeter_point` walks, saturating rather than
+/// overflowing `u16` for an implausibly large rect.
+fn border_perimeter(rect: Rect) -> u16 {
+    rect.width
+        .saturating_sub(1)
+        .saturating_add(rect.height.saturating_sub(1))
+        .saturating_mul(2)
+}
+
+fn perimeter_point(rect: Rect, index: u16) -> (u16, u16) {
+    let across = rect.width.saturating_sub(1);
+    let down = rect.height.saturating_sub(1);
+    let perimeter = border_perimeter(rect);
+    let index = if perimeter == 0 { 0 } else { index % perimeter };
+
+    // Each branch subtracts only within the side it has already matched, so the
+    // differences stay non-negative; the adds saturate because `Rect` fields are
+    // caller-supplied.
+    if index < across {
+        (rect.x.saturating_add(index), rect.y)
+    } else if index < across.saturating_add(down) {
+        (
+            rect.x.saturating_add(across),
+            rect.y.saturating_add(index - across),
+        )
+    } else if index < across.saturating_add(down).saturating_add(across) {
+        (
+            rect.x
+                .saturating_add(across)
+                .saturating_sub(index - across - down),
+            rect.y.saturating_add(down),
+        )
+    } else {
+        (
+            rect.x,
+            rect.y
+                .saturating_add(down)
+                .saturating_sub(index.saturating_sub(across + down + across)),
+        )
+    }
+}
+
+fn shimmer_hits(tick: u64, row: usize, column: usize, span: usize) -> bool {
+    let period = (span + 10) as u64;
+    tick / 2 % period == (row + column) as u64
+}
+
+fn cell_accent(index: usize, total: usize) -> Color {
+    let position = if total <= 1 {
+        0.0
+    } else {
+        index as f32 / (total - 1) as f32
+    };
+    if position < 0.5 {
+        lerp_color(TERMINAL_GREEN, DIM_GREEN, position * 2.0)
+    } else {
+        lerp_color(DIM_GREEN, SOFT_GREEN, (position - 0.5) * 2.0)
+    }
+}
+
+// ------------------------------------------------------------------ plumbing
+
+fn resolve_shell_profile(config: &Config) -> Result<(String, Profile)> {
+    resolve_shell_profile_from(
+        config,
+        env::var("GRIDBASH_PROFILE").ok(),
+        env::var("GRIDBASH_INVOKING_PROFILE").ok(),
+    )
+}
+
+/// The composer always builds a shell grid, so a configured agent default never
+/// wins here; agents are chosen per pane once the grid is up.
+fn resolve_shell_profile_from(
+    config: &Config,
+    environment_profile: Option<String>,
+    invoking_profile: Option<String>,
+) -> Result<(String, Profile)> {
+    let available = startup_profiles(config);
+    let pick = |name: &str| available.iter().find(|(key, _)| key == name).cloned();
+
+    if let Some(found) = environment_profile.and_then(|name| pick(&name)) {
+        return Ok(found);
+    }
+    if let Some(found) = invoking_profile.and_then(|name| pick(&name)) {
+        return Ok(found);
+    }
+    if let Some(found) = config
+        .defaults
+        .profile
+        .clone()
+        .and_then(|name| pick(&name))
+        .filter(|(name, profile)| is_terminal_profile(name) || !is_agent_profile(name, profile))
+    {
+        return Ok(found);
+    }
+    if let Some(found) = SHELL_PREFERENCE.iter().find_map(|name| pick(name)) {
+        return Ok(found);
+    }
+    if let Some(found) = config.defaults.profile.clone().and_then(|name| pick(&name)) {
+        return Ok(found);
+    }
+
+    available
+        .iter()
+        .find(|(name, profile)| !is_agent_profile(name, profile))
+        .or_else(|| available.first())
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!("no launchable shell was found; install Git Bash or another supported shell")
+        })
 }
 
 fn is_enter_key(key: KeyEvent) -> bool {
@@ -599,38 +1887,12 @@ fn is_enter_key(key: KeyEvent) -> bool {
         && matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M')))
 }
 
-fn workspace_row(
-    selected: bool,
-    label: impl Into<String>,
-    value: impl Into<String>,
-    hint: impl Into<String>,
-) -> Line<'static> {
-    let marker = if selected { ">" } else { " " };
-    let value_style = if selected {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::LightCyan)
-    };
-    Line::from(vec![
-        Span::styled(
-            format!("{marker} {:<10}", label.into()),
-            Style::default().fg(if selected { Color::Yellow } else { Color::Gray }),
-        ),
-        Span::styled(format!(" {} ", value.into()), value_style),
-        Span::raw("  "),
-        Span::styled(hint.into(), Style::default().fg(Color::DarkGray)),
-    ])
-}
-
 fn resolve_project_path(input: &str, base: &Path) -> Result<PathBuf> {
     let input = input.trim();
     if input.is_empty() {
         return Err(anyhow!("project folder cannot be empty"));
     }
-    let path = PathBuf::from(input);
+    let path = PathBuf::from(expand_home(input));
     let path = if path.is_absolute() {
         path
     } else {
@@ -646,6 +1908,340 @@ fn resolve_project_path(input: &str, base: &Path) -> Result<PathBuf> {
         .with_context(|| format!("failed to resolve project folder {}", display_path(&path)))
 }
 
+/// Read the folder `input` points into once and return `(siblings, matches)`,
+/// both as full replacement text so the user's separator style and any `~`
+/// prefix survive completion.
+fn scan_folders(input: &str, base: &Path) -> (Vec<String>, Vec<String>) {
+    let (parent_text, prefix) = split_completion_input(input);
+    let parent = absolute_from(parent_text, base).unwrap_or_else(|| base.to_path_buf());
+
+    let Ok(entries) = fs::read_dir(&parent) else {
+        return (Vec::new(), Vec::new());
+    };
+    let mut names = entries
+        .flatten()
+        .filter(is_directory_entry)
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        // Hidden folders only show up once the user asks for them.
+        .filter(|name| !name.starts_with('.') || prefix.starts_with('.'))
+        .collect::<Vec<_>>();
+    names.sort_by_key(|name| (name.to_lowercase(), name.clone()));
+    names.truncate(MAX_SUGGESTIONS);
+
+    let needle = prefix.to_lowercase();
+    let siblings = names
+        .into_iter()
+        .map(|name| format!("{parent_text}{name}"))
+        .collect::<Vec<_>>();
+    let matches = siblings
+        .iter()
+        .filter(|candidate| leaf_name(candidate).to_lowercase().starts_with(&needle))
+        .cloned()
+        .collect();
+    (siblings, matches)
+}
+
+fn split_completion_input(input: &str) -> (&str, &str) {
+    match input.rfind(['/', '\\']) {
+        Some(index) => input.split_at(index + 1),
+        None => ("", input),
+    }
+}
+
+fn absolute_from(text: &str, base: &Path) -> Option<PathBuf> {
+    if text.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(expand_home(text));
+    Some(if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    })
+}
+
+fn has_subdirectories(candidate: &str, base: &Path) -> bool {
+    let Some(path) = absolute_from(candidate, base) else {
+        return false;
+    };
+    fs::read_dir(path)
+        .map(|entries| entries.flatten().any(|entry| is_directory_entry(&entry)))
+        .unwrap_or(false)
+}
+
+/// This runs once per entry on every keystroke in the project field. `file_type`
+/// comes from the directory enumeration itself, so only symlinks pay for a stat.
+fn is_directory_entry(entry: &fs::DirEntry) -> bool {
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_dir() => true,
+        Ok(file_type) if file_type.is_symlink() => entry.path().is_dir(),
+        _ => false,
+    }
+}
+
+fn separator_for(value: &str) -> char {
+    if value.contains('/') {
+        '/'
+    } else if value.contains('\\') {
+        '\\'
+    } else {
+        std::path::MAIN_SEPARATOR
+    }
+}
+
+fn expand_home(value: &str) -> String {
+    let Some(rest) = value.strip_prefix('~') else {
+        return value.to_string();
+    };
+    if !(rest.is_empty() || rest.starts_with('/') || rest.starts_with('\\')) {
+        return value.to_string();
+    }
+    let Some(home) = home_dir() else {
+        return value.to_string();
+    };
+    format!("{}{rest}", home.display())
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir())
+}
+
+fn longest_common_prefix(values: &[String]) -> String {
+    let Some(first) = values.first() else {
+        return String::new();
+    };
+    let mut shared = first.chars().collect::<Vec<_>>();
+    for value in values.iter().skip(1) {
+        let candidate = value.chars().collect::<Vec<_>>();
+        let keep = shared
+            .iter()
+            .zip(candidate.iter())
+            .take_while(|(left, right)| left.eq_ignore_ascii_case(right))
+            .count();
+        shared.truncate(keep);
+        if shared.is_empty() {
+            break;
+        }
+    }
+    shared.into_iter().collect()
+}
+
+fn leaf_name(path: &str) -> String {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    match trimmed.rfind(['/', '\\']) {
+        Some(index) => trimmed[index + 1..].to_string(),
+        None => trimmed.to_string(),
+    }
+}
+
+fn plural(word: &str, count: usize) -> String {
+    if count == 1 {
+        word.to_string()
+    } else {
+        format!("{word}S")
+    }
+}
+
+fn leaf_after(branch: &str) -> String {
+    branch
+        .rsplit_once('/')
+        .map(|(_, leaf)| leaf.to_string())
+        .unwrap_or_else(|| branch.to_string())
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let chars = value.chars().collect::<Vec<_>>();
+    if chars.len() <= width {
+        return value.to_string();
+    }
+    chars
+        .into_iter()
+        .take(width.saturating_sub(1))
+        .chain(std::iter::once('…'))
+        .collect()
+}
+
+fn short_path(path: &Path, width: usize) -> String {
+    let text = display_path(path);
+    let length = text.chars().count();
+    if length <= width {
+        return text;
+    }
+    let tail = text
+        .chars()
+        .skip(length.saturating_sub(width.saturating_sub(1)))
+        .collect::<String>();
+    format!("…{tail}")
+}
+
+fn display_path(path: &Path) -> String {
+    let text = path.display().to_string();
+    text.strip_prefix(r"\\?\").unwrap_or(&text).to_string()
+}
+
+fn keycap(text: &'static str) -> Span<'static> {
+    Span::styled(
+        format!(" {text} "),
+        Style::default()
+            .fg(TERMINAL_GREEN)
+            .bg(RAISED_BG)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn label(text: &'static str) -> Span<'static> {
+    Span::styled(format!(" {text}   "), Style::default().fg(MUTED))
+}
+
+fn panel_style() -> Style {
+    Style::default().fg(TEXT).bg(PANEL_BG)
+}
+
+fn inset(area: Rect, x: u16, y: u16) -> Rect {
+    Rect {
+        x: area.x.saturating_add(x),
+        y: area.y.saturating_add(y),
+        width: area.width.saturating_sub(x.saturating_mul(2)),
+        height: area.height.saturating_sub(y.saturating_mul(2)),
+    }
+}
+
+fn pulse(color: Color, tick: u64) -> Color {
+    let phase = (tick % 24) as f32 / 24.0;
+    let amount = (phase * std::f32::consts::TAU).sin().abs() * 0.45;
+    lerp_color(color, Color::White, amount)
+}
+
+fn dim_color(color: Color) -> Color {
+    lerp_color(color, CANVAS_BG, 0.45)
+}
+
+fn lerp_color(from: Color, to: Color, amount: f32) -> Color {
+    let amount = amount.clamp(0.0, 1.0);
+    let (from_r, from_g, from_b) = rgb_parts(from);
+    let (to_r, to_g, to_b) = rgb_parts(to);
+    Color::Rgb(
+        lerp_channel(from_r, to_r, amount),
+        lerp_channel(from_g, to_g, amount),
+        lerp_channel(from_b, to_b, amount),
+    )
+}
+
+fn lerp_channel(from: u8, to: u8, amount: f32) -> u8 {
+    (from as f32 + (to as f32 - from as f32) * amount)
+        .round()
+        .clamp(0.0, 255.0) as u8
+}
+
+fn rgb_parts(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Rgb(red, green, blue) => (red, green, blue),
+        Color::White => (255, 255, 255),
+        Color::Black => (0, 0, 0),
+        _ => (128, 128, 128),
+    }
+}
+
+fn hash3(x: u64, y: u64, z: u64) -> u64 {
+    let mut value = x.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        ^ y.wrapping_mul(0xC2B2_AE3D_27D4_EB4F)
+        ^ z.wrapping_mul(0x1656_67B1_9E37_79F9);
+    value ^= value >> 29;
+    value = value.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value ^= value >> 32;
+    value
+}
+
+fn square_preview_rects(area: Rect, grid: GridSize) -> Vec<Rect> {
+    // The picker clamps its dimensions, but `GridSize` is a plain struct any
+    // caller can fill in. Capping here keeps a bad size from becoming a
+    // multi-billion-iteration loop and an allocation that cannot be satisfied.
+    let rows = grid.rows.min(MAX_PANES) as u16;
+    let columns = grid.columns.min(MAX_PANES) as u16;
+    if rows == 0 || columns == 0 || area.width == 0 || area.height == 0 {
+        return Vec::new();
+    }
+
+    let gap_y = if area.height >= rows.saturating_mul(2).saturating_sub(1) {
+        1
+    } else {
+        0
+    };
+    let gap_x = if area.width >= columns.saturating_mul(4).saturating_sub(2) {
+        2
+    } else if area.width >= columns.saturating_mul(3).saturating_sub(1) {
+        1
+    } else {
+        0
+    };
+
+    let row_gaps = rows.saturating_sub(1).saturating_mul(gap_y);
+    let column_gaps = columns.saturating_sub(1).saturating_mul(gap_x);
+    let height_fit = area.height.saturating_sub(row_gaps) / rows;
+    let width_fit = area.width.saturating_sub(column_gaps) / columns / 2;
+    let side_height = height_fit.min(width_fit).max(1);
+    let side_width = side_height.saturating_mul(2).max(1);
+    let total_height = rows
+        .saturating_mul(side_height)
+        .saturating_add(row_gaps)
+        .min(area.height);
+    let total_width = columns
+        .saturating_mul(side_width)
+        .saturating_add(column_gaps)
+        .min(area.width);
+    let start_y = area
+        .y
+        .saturating_add(area.height.saturating_sub(total_height) / 2);
+    let start_x = area
+        .x
+        .saturating_add(area.width.saturating_sub(total_width) / 2);
+
+    let mut rects = Vec::with_capacity(usize::from(rows) * usize::from(columns));
+    for row in 0..rows {
+        for column in 0..columns {
+            rects.push(Rect {
+                x: start_x.saturating_add(column.saturating_mul(side_width.saturating_add(gap_x))),
+                y: start_y.saturating_add(row.saturating_mul(side_height.saturating_add(gap_y))),
+                width: side_width,
+                height: side_height,
+            });
+        }
+    }
+    rects
+}
+
+// -------------------------------------------------------------- grid resizer
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GridPickerAction {
+    Continue,
+    Confirm(GridSize),
+    Cancel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DimensionField {
+    Rows,
+    Columns,
+}
+
+/// Resize overlay for a grid that is already running.
+#[derive(Debug, Clone)]
+pub struct GridPicker {
+    initial: GridSize,
+    rows: usize,
+    columns: usize,
+    active_field: DimensionField,
+    pane_summaries: Vec<Option<String>>,
+    opened: Instant,
+}
+
 impl GridPicker {
     pub fn new(grid: GridSize) -> Self {
         Self {
@@ -654,6 +2250,7 @@ impl GridPicker {
             columns: grid.columns,
             active_field: DimensionField::Rows,
             pane_summaries: Vec::new(),
+            opened: Instant::now(),
         }
     }
 
@@ -727,115 +2324,118 @@ impl GridPicker {
         }
     }
 
-    pub fn draw(&self, frame: &mut Frame<'_>, mode: GridPickerMode, cwd: Option<&Path>) {
+    pub fn draw(&self, frame: &mut Frame<'_>, cwd: Option<&Path>) {
         let area = frame.area();
-        frame.render_widget(background(), area);
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(CANVAS_BG)),
+            area,
+        );
+        let tick = self.opened.elapsed().as_millis() as u64 / FRAME_MS;
 
-        let panel = area;
-        frame.render_widget(Clear, panel);
+        let panel = if area.width >= 90 && area.height >= 26 {
+            inset(area, 2, 1)
+        } else {
+            area
+        };
+        if panel.width < 10 || panel.height < 6 {
+            return;
+        }
+
         let block = Block::default()
             .borders(Borders::ALL)
-            .title(match mode {
-                GridPickerMode::Startup => " GridBash Startup ",
-                GridPickerMode::Resize => " GridBash Resize ",
-            })
-            .border_style(Style::default().fg(Color::Cyan))
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(HAIRLINE_HI))
+            .title(Line::from(vec![
+                Span::styled("─┤ ", Style::default().fg(HAIRLINE_HI)),
+                Span::styled("◆", Style::default().fg(RESIZE_ACCENT)),
+                Span::styled(
+                    " RESIZE GRID ",
+                    Style::default().fg(TEXT).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("├─", Style::default().fg(HAIRLINE_HI)),
+            ]))
             .style(panel_style());
         let inner = block.inner(panel);
         frame.render_widget(block, panel);
+        paint_border_runner(frame, panel, tick);
 
+        let content = inset(inner, if inner.width >= 8 { 2 } else { 0 }, 0);
+        if content.width == 0 || content.height < 6 {
+            return;
+        }
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
+                Constraint::Length(2),
+                Constraint::Min(4),
                 Constraint::Length(3),
-                Constraint::Min(8),
-                Constraint::Length(5),
             ])
-            .split(inner);
+            .split(content);
 
-        self.draw_header(frame, chunks[0], mode, cwd);
-        self.draw_preview(frame, chunks[1], mode);
-        self.draw_controls(frame, chunks[2], mode);
+        self.draw_header(frame, chunks[0], cwd);
+        self.draw_preview(frame, chunks[1], tick);
+        self.draw_controls(frame, chunks[2]);
     }
 
-    fn draw_header(
-        &self,
-        frame: &mut Frame<'_>,
-        area: Rect,
-        mode: GridPickerMode,
-        cwd: Option<&Path>,
-    ) {
-        let context = match mode {
-            GridPickerMode::Startup => cwd
-                .map(display_path)
-                .map(|cwd| ("cwd ", cwd))
-                .unwrap_or_else(|| ("", String::new())),
-            GridPickerMode::Resize => (
-                "current ",
-                format!("{}x{}", self.initial.rows, self.initial.columns),
-            ),
-        };
+    fn draw_header(&self, frame: &mut Frame<'_>, area: Rect, cwd: Option<&Path>) {
+        let context = cwd
+            .map(display_path)
+            .unwrap_or_else(|| format!("currently {}×{}", self.initial.rows, self.initial.columns));
         let lines = vec![
             Line::from(vec![
                 Span::styled(
-                    match mode {
-                        GridPickerMode::Startup => "Choose grid dimensions",
-                        GridPickerMode::Resize => "Resize active grid",
-                    },
+                    format!("{:02}", self.rows),
                     Style::default()
-                        .fg(Color::Cyan)
+                        .fg(RESIZE_ACCENT)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::raw("  "),
+                Span::styled(" ROWS  ×  ", Style::default().fg(MUTED)),
                 Span::styled(
-                    format!("{} panes", self.rows * self.columns),
-                    Style::default().fg(Color::Yellow),
+                    format!("{:02}", self.columns),
+                    Style::default()
+                        .fg(RESIZE_ACCENT)
+                        .add_modifier(Modifier::BOLD),
                 ),
+                Span::styled(" COLS  =  ", Style::default().fg(MUTED)),
+                Span::styled(
+                    format!("{:02}", self.grid().count()),
+                    Style::default()
+                        .fg(SOFT_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" PANES", Style::default().fg(MUTED)),
             ]),
-            Line::from(vec![
-                Span::styled(context.0, Style::default().fg(Color::DarkGray)),
-                Span::styled(context.1, Style::default().fg(Color::Gray)),
-            ]),
+            Line::from(Span::styled(context, Style::default().fg(MUTED))),
         ];
-
         frame.render_widget(Paragraph::new(lines).style(panel_style()), area);
     }
 
-    fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect, mode: GridPickerMode) {
-        let preview_area = inset(area, 1, 0);
-        let palette = match mode {
-            GridPickerMode::Startup => STARTUP_PREVIEW,
-            GridPickerMode::Resize => RESIZE_PREVIEW,
-        };
-        let rects = square_preview_rects(preview_area, self.grid());
+    fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SUNKEN_BG)),
+            area,
+        );
+        paint_starfield(frame, area, tick, 0x2C4B);
 
-        for (index, rect) in rects.into_iter().enumerate() {
-            if rect.width == 0 || rect.height == 0 {
-                continue;
-            }
-
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(palette.border))
-                .style(Style::default().bg(palette.dark));
-            let inner = block.inner(rect);
-            frame.render_widget(block, rect);
-            frame.render_widget(dithered_fill(index, inner, palette), inner);
-            if mode == GridPickerMode::Resize
-                && let Some(summary) = self.preview_summary(index)
-            {
-                frame.render_widget(
-                    Paragraph::new(summary)
-                        .alignment(Alignment::Center)
-                        .wrap(Wrap { trim: true })
-                        .style(
-                            Style::default()
-                                .fg(Color::White)
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    inner,
-                );
-            }
+        for (index, rect) in square_preview_rects(inset(area, 1, 0), self.grid())
+            .into_iter()
+            .enumerate()
+        {
+            let row = index / self.columns.max(1);
+            let column = index % self.columns.max(1);
+            draw_preview_cell(
+                frame,
+                rect,
+                &PreviewCell {
+                    accent: RESIZE_ACCENT,
+                    revealed: true,
+                    shimmer: shimmer_hits(tick, row, column, self.rows + self.columns),
+                    title: format!("{:02}", index + 1),
+                    subtitle: self.preview_summary(index).map(str::to_string),
+                    fill: RESIZE_FILL,
+                },
+            );
         }
     }
 
@@ -851,42 +2451,29 @@ impl GridPicker {
             .filter(|summary| !summary.trim().is_empty())
     }
 
-    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect, mode: GridPickerMode) {
+    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect) {
         let lines = vec![
-            Line::from(""),
             Line::from(vec![
                 control_box(self.active_field == DimensionField::Rows, self.rows),
                 Span::raw(" "),
-                Span::styled("rows", Style::default().fg(Color::Gray)),
-                Span::styled("  x  ", Style::default().fg(Color::DarkGray)),
+                Span::styled("rows", Style::default().fg(MUTED)),
+                Span::styled("  ×  ", Style::default().fg(HAIRLINE_HI)),
                 control_box(self.active_field == DimensionField::Columns, self.columns),
                 Span::raw(" "),
-                Span::styled("cols", Style::default().fg(Color::Gray)),
+                Span::styled("cols", Style::default().fg(MUTED)),
             ]),
             Line::from(""),
             Line::from(vec![
-                Span::styled("Up/Down", Style::default().fg(Color::Yellow)),
-                Span::raw(" change  "),
-                Span::styled("Left/Right", Style::default().fg(Color::Yellow)),
-                Span::raw(" switch  "),
-                Span::styled("Enter", Style::default().fg(Color::Yellow)),
-                Span::raw(match mode {
-                    GridPickerMode::Startup => " launch",
-                    GridPickerMode::Resize => " apply  ",
-                }),
-                if mode == GridPickerMode::Resize {
-                    Span::styled("Esc", Style::default().fg(Color::Yellow))
-                } else {
-                    Span::raw("")
-                },
-                if mode == GridPickerMode::Resize {
-                    Span::raw(" cancel")
-                } else {
-                    Span::raw("")
-                },
+                keycap("↑↓"),
+                label("CHANGE"),
+                keycap("←→"),
+                label("SWITCH"),
+                keycap("ENTER"),
+                label("APPLY"),
+                keycap("ESC"),
+                label("CANCEL"),
             ]),
         ];
-
         frame.render_widget(
             Paragraph::new(lines)
                 .alignment(Alignment::Center)
@@ -896,201 +2483,501 @@ impl GridPicker {
     }
 }
 
-fn display_path(path: &Path) -> String {
-    let text = path.display().to_string();
-    text.strip_prefix(r"\\?\").unwrap_or(&text).to_string()
-}
-
 fn control_box(active: bool, value: usize) -> Span<'static> {
     let style = if active {
         Style::default()
             .fg(Color::Black)
-            .bg(Color::Yellow)
+            .bg(RESIZE_ACCENT)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default()
-            .fg(Color::LightCyan)
-            .bg(Color::Rgb(20, 35, 44))
+            .fg(RESIZE_ACCENT)
+            .bg(SUNKEN_BG)
             .add_modifier(Modifier::BOLD)
     };
 
     Span::styled(format!(" {value:>2} "), style)
 }
 
-fn background() -> Paragraph<'static> {
-    Paragraph::new("").style(Style::default().bg(Color::Rgb(7, 11, 15)))
-}
-
-fn panel_style() -> Style {
-    Style::default()
-        .fg(Color::Rgb(230, 237, 243))
-        .bg(Color::Rgb(11, 15, 20))
-}
-
-fn inset(area: Rect, x: u16, y: u16) -> Rect {
-    Rect {
-        x: area.x.saturating_add(x),
-        y: area.y.saturating_add(y),
-        width: area.width.saturating_sub(x.saturating_mul(2)),
-        height: area.height.saturating_sub(y.saturating_mul(2)),
-    }
-}
-
-fn square_preview_rects(area: Rect, grid: GridSize) -> Vec<Rect> {
-    let rows = grid.rows as u16;
-    let columns = grid.columns as u16;
-    if rows == 0 || columns == 0 || area.width == 0 || area.height == 0 {
-        return Vec::new();
-    }
-
-    let gap_y = if area.height >= rows.saturating_mul(2).saturating_sub(1) {
-        1
-    } else {
-        0
-    };
-    let gap_x = if area.width >= columns.saturating_mul(4).saturating_sub(2) {
-        2
-    } else if area.width >= columns.saturating_mul(3).saturating_sub(1) {
-        1
-    } else {
-        0
-    };
-
-    let row_gaps = rows.saturating_sub(1).saturating_mul(gap_y);
-    let column_gaps = columns.saturating_sub(1).saturating_mul(gap_x);
-    let height_fit = area.height.saturating_sub(row_gaps) / rows;
-    let width_fit = area.width.saturating_sub(column_gaps) / columns / 2;
-    let side_height = height_fit.min(width_fit).max(1);
-    let side_width = side_height.saturating_mul(2).max(1);
-    let total_height = rows
-        .saturating_mul(side_height)
-        .saturating_add(row_gaps)
-        .min(area.height);
-    let total_width = columns
-        .saturating_mul(side_width)
-        .saturating_add(column_gaps)
-        .min(area.width);
-    let start_y = area.y + area.height.saturating_sub(total_height) / 2;
-    let start_x = area.x + area.width.saturating_sub(total_width) / 2;
-
-    let mut rects = Vec::with_capacity(grid.count());
-    for row in 0..rows {
-        for column in 0..columns {
-            rects.push(Rect {
-                x: start_x + column.saturating_mul(side_width.saturating_add(gap_x)),
-                y: start_y + row.saturating_mul(side_height.saturating_add(gap_y)),
-                width: side_width,
-                height: side_height,
-            });
-        }
-    }
-    rects
-}
-
-fn dithered_fill(index: usize, rect: Rect, palette: PreviewPalette) -> Paragraph<'static> {
-    let lines = (0..rect.height)
-        .map(|y| {
-            let mut spans = Vec::with_capacity(rect.width as usize);
-            for x in 0..rect.width {
-                let bg = match (x.saturating_mul(3) + y.saturating_mul(5) + index as u16) % 6 {
-                    0 | 3 => palette.light,
-                    1 | 4 => palette.mid,
-                    _ => palette.dark,
-                };
-                spans.push(Span::styled(" ", Style::default().bg(bg)));
-            }
-            Line::from(spans)
-        })
-        .collect::<Vec<_>>();
-
-    Paragraph::new(lines).style(Style::default().bg(palette.dark))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{
-        env, fs,
-        time::{SystemTime, UNIX_EPOCH},
-    };
-
-    use crossterm::event::KeyModifiers;
     use ratatui::backend::TestBackend;
 
     use crate::auth::AgentKind;
 
     use super::*;
 
+    const TEST_PROFILE: &str = "test-shell";
+
+    fn test_profile() -> Profile {
+        Profile {
+            command: env::current_exe()
+                .expect("test executable")
+                .display()
+                .to_string(),
+            args: Vec::new(),
+            title: Some("Test Shell".into()),
+            agent_kind: None,
+        }
+    }
+
+    fn shell_config() -> Config {
+        let mut config = Config::default();
+        config.profiles.insert(TEST_PROFILE.into(), test_profile());
+        config.set_default_profile(TEST_PROFILE);
+        config.auth.home = Some(env::temp_dir().join("gridbash-composer-no-auth-profiles"));
+        config
+    }
+
+    /// Build a composer with a fixed profile so ambient `GRIDBASH_PROFILE` /
+    /// `GRIDBASH_INVOKING_PROFILE` values cannot change what the test sees.
+    fn composer_in(dir: PathBuf) -> Composer {
+        Composer::with_profile(dir, None, "Grid 2", TEST_PROFILE.into(), test_profile())
+            .expect("composer")
+    }
+
+    fn composer() -> Composer {
+        composer_in(env::current_dir().expect("cwd"))
+    }
+
+    fn rendered(width: u16, height: u16, composer: &Composer, config: &Config) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
+        terminal
+            .draw(|frame| composer.draw(frame, config))
+            .expect("draw composer");
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>()
+    }
+
+    fn press(composer: &mut Composer, code: KeyCode, config: &Config) {
+        composer.handle_key(KeyEvent::new(code, KeyModifiers::NONE), config);
+    }
+
+    /// The scroll window is derived from the cursor. A cursor left past the end
+    /// of a replaced value pushed `start` beyond `end`, and `clamp` panics when
+    /// its bounds cross — mid-frame, with no way to recover the field.
     #[test]
-    fn launch_plan_uses_managed_agent_workspace_defaults() {
-        if env::var_os("GRIDBASH_PROFILE").is_some() {
-            return;
+    fn a_text_row_survives_a_cursor_past_the_end_of_its_value() {
+        let long = "C:/Users/Jason/Documents/GitHub/gridbash/src/composer.rs";
+        for cursor in [0, 4, long.chars().count(), long.chars().count() + 500, usize::MAX] {
+            for width in [0, 1, 6, 12, 400] {
+                let field = TextField {
+                    value: long.into(),
+                    cursor,
+                    limit: None,
+                };
+                let line = text_row("project", &field, true, 0, width, None, SOFT_GREEN);
+                assert!(
+                    !line.spans.is_empty(),
+                    "cursor {cursor} at width {width} must still render"
+                );
+            }
         }
 
-        let mut config = Config::default();
-        let profile = "managed-test";
-        config.profiles.insert(
-            profile.into(),
-            Profile {
-                command: env::current_exe()
-                    .expect("test executable")
-                    .display()
-                    .to_string(),
-                args: Vec::new(),
-                title: Some("Managed test agent".into()),
-                agent_kind: Some(AgentKind::Codex),
-            },
-        );
-        config.set_default_profile(profile);
-        config.auth.home = Some(env::temp_dir().join("gridbash-composer-no-auth-profiles"));
-        let current_dir = env::current_dir().expect("current dir");
+        // Non-ASCII values must window by character, not by byte.
+        let field = TextField {
+            value: "日本語のとてもながいパス/composer.rs".into(),
+            cursor: usize::MAX,
+            limit: None,
+        };
+        assert!(!text_row("project", &field, true, 0, 8, None, SOFT_GREEN).spans.is_empty());
+    }
 
-        let composer = Composer::new(current_dir.clone(), None, &config).expect("composer");
-        let expected_dir = composer.current_dir.clone();
-        let plan = composer.launch_plan(&config).expect("launch plan");
+    /// A character index at the end of the value maps to a byte index equal to
+    /// the value's length, and `String::remove` panics there.
+    #[test]
+    fn editing_a_text_field_with_a_desynced_cursor_does_not_panic() {
+        let mut field = TextField {
+            value: "café".into(),
+            cursor: 99,
+            limit: None,
+        };
 
-        assert_eq!(plan.grid.rows, DEFAULT_ROWS);
-        assert_eq!(plan.grid.columns, DEFAULT_COLUMNS);
-        assert_eq!(plan.panes.len(), DEFAULT_ROWS * DEFAULT_COLUMNS);
+        assert!(!field.delete(), "there is nothing after the end to delete");
+        assert!(!field.backspace(), "a cursor past the end removes nothing");
+        assert_eq!(field.value, "café");
+
+        field.cursor = field.len();
+        assert!(field.backspace());
+        assert_eq!(field.value, "caf");
+        assert!(field.delete_word());
+        assert!(field.value.is_empty());
+    }
+
+    #[test]
+    fn launches_a_shell_grid_with_the_default_shape() {
+        let config = shell_config();
+        let composer = composer();
+        let outcome = composer.build_outcome(&config).expect("outcome");
+
+        assert_eq!(outcome.title, "Grid 2");
+        assert_eq!(outcome.plan.grid.rows, DEFAULT_ROWS);
+        assert_eq!(outcome.plan.grid.columns, DEFAULT_COLUMNS);
+        assert_eq!(outcome.plan.panes.len(), DEFAULT_ROWS * DEFAULT_COLUMNS);
         assert!(
-            plan.panes
+            outcome
+                .plan
+                .panes
                 .iter()
-                .all(|pane| { pane.profile_name == profile && pane.cwd == expected_dir })
+                .all(|pane| pane.profile_name == TEST_PROFILE)
         );
     }
 
     #[test]
-    fn enter_launches_from_every_workspace_field() {
-        if env::var_os("GRIDBASH_PROFILE").is_some() {
-            return;
-        }
-
+    fn agent_defaults_never_win_over_a_real_shell() {
         let mut config = Config::default();
-        let profile = "managed-enter-test";
         config.profiles.insert(
-            profile.into(),
+            "codex".into(),
             Profile {
                 command: env::current_exe()
                     .expect("test executable")
                     .display()
                     .to_string(),
                 args: Vec::new(),
-                title: Some("Managed Enter test agent".into()),
+                title: Some("Codex".into()),
                 agent_kind: Some(AgentKind::Codex),
             },
         );
-        config.set_default_profile(profile);
-        config.auth.home = Some(env::temp_dir().join("gridbash-composer-enter-no-auth-profiles"));
-        let mut composer =
-            Composer::new(env::current_dir().expect("cwd"), None, &config).expect("composer");
+        config.set_default_profile("codex");
+        config.auth.home = Some(env::temp_dir().join("gridbash-composer-agent-default"));
 
-        for field in StartupField::ALL {
-            composer.active_field = field;
+        let (name, _) = resolve_shell_profile_from(&config, None, None).expect("shell profile");
+        assert_ne!(name, "codex");
+        assert!(
+            SHELL_PREFERENCE.contains(&name.as_str()),
+            "{name} is not a shell"
+        );
+    }
+
+    #[test]
+    fn explicit_profile_environment_still_wins() {
+        let config = shell_config();
+
+        let (name, _) =
+            resolve_shell_profile_from(&config, Some(TEST_PROFILE.into()), Some("cmd".into()))
+                .expect("shell profile");
+        assert_eq!(name, TEST_PROFILE);
+
+        // A configured non-agent default is honoured when nothing overrides it.
+        let (name, _) = resolve_shell_profile_from(&config, None, None).expect("shell profile");
+        assert_eq!(name, TEST_PROFILE);
+
+        // Unknown names fall through instead of failing the launch.
+        let (name, _) =
+            resolve_shell_profile_from(&config, Some("nope".into()), None).expect("shell profile");
+        assert_eq!(name, TEST_PROFILE);
+    }
+
+    #[test]
+    fn only_four_fields_are_reachable_and_enter_launches_from_each() {
+        let config = shell_config();
+        let mut composer = composer();
+
+        assert_eq!(
+            Field::ALL,
+            [Field::Rows, Field::Columns, Field::Name, Field::Project]
+        );
+        for field in Field::ALL {
+            composer.active = field;
             let event =
                 composer.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &config);
             assert!(
                 matches!(event, ComposerEvent::Launch(_)),
                 "Enter did not launch from {field:?}"
             );
+        }
+
+        // Down wraps through exactly the four fields.
+        composer.active = Field::Rows;
+        for expected in [Field::Columns, Field::Name, Field::Project, Field::Rows] {
+            press(&mut composer, KeyCode::Down, &config);
+            assert_eq!(composer.active, expected);
+        }
+
+        // Tab advances everywhere except Project, where it completes instead.
+        for expected in [Field::Columns, Field::Name, Field::Project] {
+            press(&mut composer, KeyCode::Tab, &config);
+            assert_eq!(composer.active, expected);
+        }
+        press(&mut composer, KeyCode::Tab, &config);
+        assert_eq!(composer.active, Field::Project);
+        press(&mut composer, KeyCode::BackTab, &config);
+        assert_eq!(composer.active, Field::Name);
+    }
+
+    #[test]
+    fn digits_and_arrows_shape_the_grid() {
+        let config = shell_config();
+        let mut composer = composer();
+
+        composer.active = Field::Rows;
+        press(&mut composer, KeyCode::Char('4'), &config);
+        composer.active = Field::Columns;
+        press(&mut composer, KeyCode::Char('0'), &config);
+        assert_eq!(composer.grid().rows, 4);
+        assert_eq!(composer.grid().columns, MAX_DIMENSION);
+
+        press(&mut composer, KeyCode::Left, &config);
+        assert_eq!(composer.grid().columns, MAX_DIMENSION - 1);
+        for _ in 0..20 {
+            press(&mut composer, KeyCode::Left, &config);
+        }
+        assert_eq!(composer.grid().columns, 1);
+        assert_eq!(composer.grid().rows, 4);
+    }
+
+    #[test]
+    fn typing_a_name_titles_the_grid_and_empty_names_fall_back() {
+        let config = shell_config();
+        let mut composer = composer();
+        composer.active = Field::Name;
+        for _ in 0..MAX_NAME_CHARS {
+            press(&mut composer, KeyCode::Backspace, &config);
+        }
+        assert_eq!(composer.title(), "Grid 2");
+
+        for ch in "  api  refactor ".chars() {
+            press(&mut composer, KeyCode::Char(ch), &config);
+        }
+        assert_eq!(composer.title(), "api refactor");
+    }
+
+    #[test]
+    fn tab_completes_and_then_cycles_project_folders() {
+        let root = env::temp_dir().join(format!("gridbash-complete-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        for name in ["alpha-one", "alpha-two", "beta"] {
+            fs::create_dir_all(root.join(name)).expect("fixture dir");
+        }
+        fs::create_dir_all(root.join("alpha-one").join("nested")).expect("nested dir");
+
+        let mut composer = composer_in(root.clone());
+        composer.active = Field::Project;
+
+        let base = display_path(&root.canonicalize().expect("canonical root"));
+        composer
+            .project
+            .set(format!("{base}{}alpha", std::path::MAIN_SEPARATOR));
+        composer.refresh_suggestions();
+        assert_eq!(composer.suggestions.matches.len(), 2);
+
+        // The first Tab only extends to the shared prefix instead of guessing.
+        composer.complete_project();
+        assert!(
+            composer.project.value.ends_with("alpha-"),
+            "got {}",
+            composer.project.value
+        );
+
+        composer.complete_project();
+        assert!(composer.project.value.ends_with("alpha-one"));
+        composer.complete_project();
+        assert!(composer.project.value.ends_with("alpha-two"));
+        composer.complete_project();
+        assert!(composer.project.value.ends_with("alpha-one"));
+        assert!(composer.project_dir.is_some());
+
+        // A unique match descends into the folder.
+        composer
+            .project
+            .set(format!("{base}{}b", std::path::MAIN_SEPARATOR));
+        composer.refresh_suggestions();
+        composer.complete_project();
+        assert!(composer.project.value.ends_with("beta"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn unresolvable_projects_block_launch_with_a_visible_reason() {
+        let config = shell_config();
+        let mut composer = composer();
+        composer.active = Field::Project;
+        composer
+            .project
+            .set("definitely-not-a-gridbash-project".into());
+        composer.refresh_project();
+        assert!(composer.project_dir.is_none());
+
+        let event = composer.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &config);
+        assert!(matches!(event, ComposerEvent::Continue));
+        let notice = composer.notice.clone().expect("notice");
+        assert_eq!(notice.level, NoticeLevel::Error);
+        assert!(notice.text.contains("does not exist"), "{}", notice.text);
+    }
+
+    #[test]
+    fn worktrees_stay_on_by_default_and_fall_back_when_the_repo_cannot_host_them() {
+        let config = shell_config();
+        let mut composer = composer();
+        assert!(composer.worktrees_enabled);
+
+        composer.readiness = Some(WorktreeReadiness::Ready {
+            base_slug: "main".into(),
+        });
+        assert!(composer.worktrees_active());
+        assert_eq!(
+            composer.branch_label(2).as_deref(),
+            Some("gridbash/main-pane-03")
+        );
+
+        composer.readiness = Some(WorktreeReadiness::Blocked {
+            reason: "uncommitted tracked changes in the base checkout".into(),
+        });
+        assert!(!composer.worktrees_active());
+        assert!(composer.branch_label(0).is_none());
+
+        composer.readiness = Some(WorktreeReadiness::Ready {
+            base_slug: "main".into(),
+        });
+        composer.handle_key(
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT),
+            &config,
+        );
+        assert!(!composer.worktrees_active());
+    }
+
+    #[test]
+    fn renders_the_full_dashboard_on_a_roomy_terminal() {
+        let config = shell_config();
+        let composer = composer();
+        let text = rendered(140, 40, &composer, &config);
+
+        assert!(text.contains("NEW GRID"));
+        assert!(text.contains(WORDMARK[1]), "wordmark row missing");
+        assert!(text.contains("SHAPE"));
+        assert!(text.contains("IDENTITY"));
+        assert!(text.contains("LIVE GRID"));
+        assert!(text.contains("ROWS"));
+        assert!(text.contains("COLUMNS"));
+        assert!(text.contains("NAME"));
+        assert!(text.contains("PROJECT"));
+        assert!(text.contains("LAUNCH"));
+        assert!(text.contains("PANES"));
+        // The knobs this revamp removed must not come back.
+        assert!(!text.contains("Auth"));
+        assert!(!text.contains("START WORKSPACE"));
+    }
+
+    #[test]
+    fn preview_cells_reveal_their_pane_number_and_branch() {
+        let config = shell_config();
+        let mut composer = composer();
+        composer.readiness = Some(WorktreeReadiness::Ready {
+            base_slug: "main".into(),
+        });
+
+        // Freshly changed shapes start dark and wake up in a diagonal wave. The
+        // summary line always names the first and last branch, so count labels
+        // rather than looking for any single one.
+        let labels = |text: &str| text.matches("main-pane-").count();
+        composer.shape_changed = Instant::now();
+        let booting = labels(&rendered(140, 40, &composer, &config));
+
+        composer.shape_changed = Instant::now() - Duration::from_secs(2);
+        let settled = rendered(140, 40, &composer, &config);
+        assert!(
+            labels(&settled) > booting,
+            "cells never revealed ({booting} labels before, {} after)",
+            labels(&settled)
+        );
+        for pane in 1..=composer.grid().count() {
+            assert!(
+                settled.contains(&format!("main-pane-{pane:02}")),
+                "pane {pane} missing its branch label"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_the_essentials_on_a_small_terminal() {
+        let config = shell_config();
+        let composer = composer();
+        let text = rendered(72, 18, &composer, &config);
+
+        assert!(text.contains("SHAPE"));
+        assert!(text.contains("IDENTITY"));
+        assert!(text.contains("LAUNCH"));
+        assert!(text.contains("ENTER"));
+    }
+
+    #[test]
+    fn draws_at_every_size_without_panicking() {
+        let config = shell_config();
+        let mut composer = composer();
+        composer.active = Field::Project;
+        composer.refresh_suggestions();
+
+        for width in [8u16, 20, 40, 72, 96, 140, 200] {
+            for height in [4u16, 8, 12, 18, 26, 40] {
+                let _ = rendered(width, height, &composer, &config);
+            }
+        }
+    }
+
+    #[test]
+    fn paints_the_animated_accents() {
+        let config = shell_config();
+        let composer = composer();
+        let mut terminal = Terminal::new(TestBackend::new(140, 40)).expect("test terminal");
+        terminal
+            .draw(|frame| composer.draw(frame, &config))
+            .expect("draw composer");
+        let buffer = terminal.backend().buffer();
+
+        assert!(
+            buffer.content().iter().any(|cell| cell.bg == RAISED_BG),
+            "expected raised panels"
+        );
+        assert!(
+            buffer.content().iter().any(|cell| cell.symbol() == "·"),
+            "expected starfield dust"
+        );
+    }
+
+    #[test]
+    #[ignore = "developer aid: cargo test -- --ignored --nocapture dump_composer"]
+    fn dump_composer() {
+        let config = shell_config();
+        let mut composer = composer();
+        composer.rows = 2;
+        composer.columns = 3;
+        composer.readiness = Some(WorktreeReadiness::Ready {
+            base_slug: "main".into(),
+        });
+        // Let the reveal animation finish so the dump shows the settled screen.
+        composer.shape_changed = Instant::now() - Duration::from_secs(2);
+        for (width, height, field) in [
+            (140u16, 40u16, Field::Rows),
+            (140, 40, Field::Project),
+            (96, 30, Field::Name),
+            (80, 24, Field::Rows),
+        ] {
+            composer.active = field;
+            composer.refresh_suggestions();
+            let mut terminal =
+                Terminal::new(TestBackend::new(width, height)).expect("test terminal");
+            terminal
+                .draw(|frame| composer.draw(frame, &config))
+                .expect("draw");
+            let buffer = terminal.backend().buffer();
+            println!("\n===== {width}x{height} focus={field:?} =====");
+            for row in 0..height {
+                let line = (0..width)
+                    .map(|column| {
+                        buffer
+                            .cell((column, row))
+                            .map(|cell| cell.symbol())
+                            .unwrap_or(" ")
+                    })
+                    .collect::<String>();
+                println!("|{}|", line.trim_end());
+            }
         }
     }
 
@@ -1111,90 +2998,6 @@ mod tests {
     }
 
     #[test]
-    fn raw_terminals_are_explicit_secondary_profiles() {
-        if env::var_os("GRIDBASH_PROFILE").is_some() {
-            return;
-        }
-
-        let mut config = Config::default();
-        let profile = "managed-test";
-        config.profiles.insert(
-            profile.into(),
-            Profile {
-                command: env::current_exe()
-                    .expect("test executable")
-                    .display()
-                    .to_string(),
-                args: Vec::new(),
-                title: Some("Managed test agent".into()),
-                agent_kind: Some(AgentKind::Codex),
-            },
-        );
-        config.set_default_profile(profile);
-        config.auth.home = Some(env::temp_dir().join("gridbash-composer-no-auth-profiles"));
-        let composer =
-            Composer::new(env::current_dir().expect("cwd"), None, &config).expect("composer");
-
-        assert!(!composer.selected_profile().terminal);
-        let first_terminal = composer
-            .profiles
-            .iter()
-            .position(|choice| choice.terminal)
-            .expect("raw terminal choice");
-        assert!(
-            composer.profiles[..first_terminal]
-                .iter()
-                .all(|choice| !choice.terminal)
-        );
-    }
-
-    #[test]
-    fn explicit_workspace_auth_is_applied_to_every_agent_pane() {
-        if env::var_os("GRIDBASH_PROFILE").is_some() {
-            return;
-        }
-
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let auth_home = env::temp_dir().join(format!("gridbash-composer-auth-{suffix}"));
-        let auth_dir = auth_home.join("codex-work");
-        fs::create_dir_all(&auth_dir).expect("auth profile dir");
-        fs::write(auth_dir.join(".profile-kind"), "codex").expect("profile kind");
-        fs::write(auth_dir.join("auth.json"), "{}").expect("auth marker");
-
-        let mut config = Config::default();
-        let profile = "managed-test";
-        config.profiles.insert(
-            profile.into(),
-            Profile {
-                command: env::current_exe()
-                    .expect("test executable")
-                    .display()
-                    .to_string(),
-                args: Vec::new(),
-                title: Some("Managed test agent".into()),
-                agent_kind: Some(AgentKind::Codex),
-            },
-        );
-        config.set_default_profile(profile);
-        config.auth.home = Some(auth_home.clone());
-        let mut composer =
-            Composer::new(env::current_dir().expect("cwd"), None, &config).expect("composer");
-        composer.auth_cursor = 1;
-
-        let plan = composer.launch_plan(&config).expect("launch plan");
-        assert!(
-            plan.panes
-                .iter()
-                .all(|pane| pane.auth_name.as_deref() == Some("codex-work"))
-        );
-
-        fs::remove_dir_all(auth_home).expect("remove auth fixture");
-    }
-
-    #[test]
     fn project_paths_must_resolve_to_existing_directories() {
         let cwd = env::current_dir().expect("cwd");
         assert_eq!(
@@ -1202,6 +3005,44 @@ mod tests {
             cwd.canonicalize().expect("canonical cwd")
         );
         assert!(resolve_project_path("definitely-not-a-gridbash-project", &cwd).is_err());
+    }
+
+    #[test]
+    fn text_field_edits_stay_on_character_boundaries() {
+        let mut field = TextField::new("héllo wörld", None);
+        field.home();
+        field.move_cursor(2);
+        assert!(field.insert('X'));
+        assert_eq!(field.value, "héXllo wörld");
+
+        field.end();
+        assert!(field.delete_word());
+        assert_eq!(field.value, "héXllo ");
+
+        let mut limited = TextField::new("", Some(2));
+        assert!(limited.insert('a'));
+        assert!(limited.insert('b'));
+        assert!(!limited.insert('c'));
+        assert_eq!(limited.value, "ab");
+    }
+
+    #[test]
+    fn perimeter_walk_stays_on_the_border() {
+        let rect = Rect {
+            x: 3,
+            y: 2,
+            width: 9,
+            height: 5,
+        };
+        for index in 0..64 {
+            let (x, y) = perimeter_point(rect, index);
+            assert!(x >= rect.x && x < rect.right(), "x {x} escaped {rect:?}");
+            assert!(y >= rect.y && y < rect.bottom(), "y {y} escaped {rect:?}");
+            assert!(
+                x == rect.x || x == rect.right() - 1 || y == rect.y || y == rect.bottom() - 1,
+                "({x},{y}) is not on the border of {rect:?}"
+            );
+        }
     }
 
     #[test]
@@ -1224,56 +3065,33 @@ mod tests {
     }
 
     #[test]
-    fn resize_picker_renders_active_cells_in_blue() {
-        let picker = GridPicker::new(GridSize {
-            rows: 2,
-            columns: 3,
-        });
-        let backend = TestBackend::new(80, 24);
-        let mut terminal = Terminal::new(backend).expect("test terminal");
-
-        terminal
-            .draw(|frame| picker.draw(frame, GridPickerMode::Resize, None))
-            .expect("draw picker");
-
-        let buffer = terminal.backend().buffer();
-        assert!(buffer.content().iter().any(|cell| {
-            matches!(
-                cell.bg,
-                Color::Rgb(47, 129, 247) | Color::Rgb(31, 91, 191) | Color::Rgb(15, 50, 110)
-            )
-        }));
-        assert!(
-            !buffer
-                .content()
-                .iter()
-                .any(|cell| cell.bg == STARTUP_PREVIEW.light)
-        );
-    }
-
-    #[test]
-    fn resize_picker_renders_available_activity_summaries() {
+    fn resize_picker_renders_in_its_own_blue_and_shows_summaries() {
         let picker = GridPicker::new(GridSize {
             rows: 1,
             columns: 2,
         })
         .with_pane_summaries(vec![Some("reviewing code".into()), None]);
-        let backend = TestBackend::new(80, 24);
-        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let mut terminal = Terminal::new(TestBackend::new(90, 28)).expect("test terminal");
 
         terminal
-            .draw(|frame| picker.draw(frame, GridPickerMode::Resize, None))
+            .draw(|frame| picker.draw(frame, None))
             .expect("draw picker");
 
-        let rendered = terminal
-            .backend()
-            .buffer()
+        let buffer = terminal.backend().buffer();
+        assert!(
+            buffer
+                .content()
+                .iter()
+                .any(|cell| cell.bg == RESIZE_FILL || cell.fg == RESIZE_ACCENT)
+        );
+        let text = buffer
             .content()
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
-        assert!(rendered.contains("reviewing code"));
-        assert!(!rendered.contains("waiting for output"));
+        assert!(text.contains("RESIZE GRID"));
+        assert!(text.contains("reviewing code"));
+        assert!(!text.contains("waiting for output"));
     }
 
     #[test]
@@ -1298,29 +3116,5 @@ mod tests {
         assert_eq!(picker.preview_summary(1), Some("one"));
         assert_eq!(picker.preview_summary(2), Some("three"));
         assert_eq!(picker.preview_summary(3), Some("four"));
-    }
-
-    #[test]
-    fn startup_picker_does_not_render_activity_summaries() {
-        let picker = GridPicker::new(GridSize {
-            rows: 1,
-            columns: 1,
-        })
-        .with_pane_summaries(vec![Some("resize only".into())]);
-        let backend = TestBackend::new(80, 24);
-        let mut terminal = Terminal::new(backend).expect("test terminal");
-
-        terminal
-            .draw(|frame| picker.draw(frame, GridPickerMode::Startup, None))
-            .expect("draw picker");
-
-        let rendered = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect::<String>();
-        assert!(!rendered.contains("resize only"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,10 @@ pub struct UiConfig {
         skip_serializing_if = "UiConfig::activity_badges_enabled"
     )]
     pub activity_badges: bool,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(
+        default = "UiConfig::default_confirm_quit",
+        skip_serializing_if = "UiConfig::confirm_quit_enabled"
+    )]
     pub confirm_quit: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub keep_terminals_running: bool,
@@ -92,7 +95,7 @@ impl Default for UiConfig {
         Self {
             compact_titles: false,
             activity_badges: Self::default_activity_badges(),
-            confirm_quit: false,
+            confirm_quit: Self::default_confirm_quit(),
             keep_terminals_running: false,
             scrollback_rows: Self::default_scrollback_rows(),
             refresh_ms: Self::default_refresh_ms(),
@@ -103,6 +106,10 @@ impl Default for UiConfig {
 
 impl UiConfig {
     pub fn default_activity_badges() -> bool {
+        true
+    }
+
+    pub fn default_confirm_quit() -> bool {
         true
     }
 
@@ -117,7 +124,7 @@ impl UiConfig {
     fn is_empty(&self) -> bool {
         !self.compact_titles
             && self.activity_badges == Self::default_activity_badges()
-            && !self.confirm_quit
+            && self.confirm_quit == Self::default_confirm_quit()
             && !self.keep_terminals_running
             && self.scrollback_rows == Self::default_scrollback_rows()
             && self.refresh_ms == Self::default_refresh_ms()
@@ -125,6 +132,10 @@ impl UiConfig {
     }
 
     fn activity_badges_enabled(value: &bool) -> bool {
+        *value
+    }
+
+    fn confirm_quit_enabled(value: &bool) -> bool {
         *value
     }
 
@@ -553,6 +564,26 @@ mod tests {
         let round_trip: Config = toml::from_str(&serialized).expect("round trip UI config");
         assert_eq!(round_trip.ui.palette, config.ui.palette);
         assert_eq!(round_trip.ui.refresh_ms, 32);
+    }
+
+    #[test]
+    fn quit_confirmation_defaults_on_and_can_be_disabled() {
+        let defaults: Config = toml::from_str("").expect("parse default config");
+        assert!(defaults.ui.confirm_quit);
+        assert!(
+            !toml::to_string(&defaults)
+                .expect("serialize default config")
+                .contains("confirm_quit")
+        );
+
+        let disabled: Config = toml::from_str("[ui]\nconfirm_quit = false\n")
+            .expect("parse disabled quit confirmation");
+        assert!(!disabled.ui.confirm_quit);
+        assert!(
+            toml::to_string(&disabled)
+                .expect("serialize disabled quit confirmation")
+                .contains("confirm_quit = false")
+        );
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -393,7 +393,8 @@ pub fn run_ctl(args: &CtlArgs) -> Result<()> {
         .or_else(|| env::var("GRIDBASH_CONTROL_SESSION").ok());
     let session = select_discovered_session(&sessions, requested_session.as_deref())?;
     let (command, token) = match &args.action {
-        CtlAction::List => unreachable!("list returned above"),
+        // Handled by the early return above.
+        CtlAction::List => return Ok(()),
         CtlAction::Panes => (ControlCommand::Describe, None),
         CtlAction::Send {
             panes,

--- a/src/copy_mode.rs
+++ b/src/copy_mode.rs
@@ -102,7 +102,9 @@ impl CopyMode {
             lines.push(String::new());
         }
         let line = lines.len().saturating_sub(1);
-        let column = line_char_len(&lines[line]).saturating_sub(1);
+        let column = lines
+            .get(line)
+            .map_or(0, |text| line_char_len(text).saturating_sub(1));
         let mut mode = Self {
             pane,
             lines,
@@ -278,27 +280,46 @@ impl CopyMode {
     }
 
     pub fn copy_text(&self) -> String {
+        // Every line index below is clamped: the cursor and the selection anchor
+        // are bookkeeping that a resize or a fresh capture can outdate, and a
+        // stale index would take down the whole TUI over a copy.
+        let last_line = self.lines.len().saturating_sub(1);
         let Some(selection) = self.selection else {
-            return self.lines[self.cursor.line].clone();
+            return self
+                .lines
+                .get(self.cursor.line)
+                .cloned()
+                .unwrap_or_default();
         };
 
         match selection.kind {
             SelectionKind::Lines => {
-                let start = selection.anchor.line.min(self.cursor.line);
-                let end = selection.anchor.line.max(self.cursor.line);
-                self.lines[start..=end].join("\n")
+                let start = selection.anchor.line.min(self.cursor.line).min(last_line);
+                let end = selection
+                    .anchor
+                    .line
+                    .max(self.cursor.line)
+                    .min(last_line)
+                    .max(start);
+                self.lines
+                    .get(start..=end)
+                    .unwrap_or_default()
+                    .join("\n")
             }
             SelectionKind::Characters => {
                 let (start, end) = normalize_points(selection.anchor, self.cursor);
                 let mut selected = Vec::new();
-                for line in start.line..=end.line {
+                for line in start.line.min(last_line)..=end.line.min(last_line) {
+                    let Some(text) = self.lines.get(line) else {
+                        continue;
+                    };
                     let from = if line == start.line { start.column } else { 0 };
                     let to = if line == end.line {
                         end.column.saturating_add(1)
                     } else {
-                        line_char_len(&self.lines[line])
+                        line_char_len(text)
                     };
-                    selected.push(slice_chars(&self.lines[line], from, to));
+                    selected.push(slice_chars(text, from, to));
                 }
                 selected.join("\n")
             }
@@ -392,7 +413,9 @@ impl CopyMode {
     }
 
     fn line_max_column(&self, line: usize) -> usize {
-        line_char_len(&self.lines[line]).saturating_sub(1)
+        self.lines
+            .get(line)
+            .map_or(0, |text| line_char_len(text).saturating_sub(1))
     }
 
     fn clamp_cursor_column(&mut self) {
@@ -527,6 +550,43 @@ mod tests {
         assert_eq!(view.rows.len(), 1);
         assert_eq!(view.rows[0].text, " ");
         assert_eq!(mode.copy_text(), "");
+    }
+
+    /// The cursor and the selection anchor are plain indices. Copying with one
+    /// pointing past the captured lines used to index straight out of bounds.
+    #[test]
+    fn copying_with_a_stale_cursor_or_anchor_does_not_panic() {
+        let mut mode = mode(&["alpha", "bravo"]);
+
+        mode.cursor = TextPoint {
+            line: 99,
+            column: 99,
+        };
+        assert_eq!(mode.copy_text(), "");
+        assert_eq!(mode.line_max_column(99), 0);
+
+        mode.selection = Some(Selection {
+            anchor: TextPoint {
+                line: 42,
+                column: 0,
+            },
+            kind: SelectionKind::Lines,
+        });
+        assert_eq!(mode.copy_text(), "bravo");
+
+        // Both ends are out of range, so the clamped range covers the last line
+        // in full rather than reaching for columns that are not there.
+        mode.selection = Some(Selection {
+            anchor: TextPoint {
+                line: 42,
+                column: 7,
+            },
+            kind: SelectionKind::Characters,
+        });
+        assert_eq!(mode.copy_text(), "bravo");
+
+        mode.cursor = TextPoint { line: 0, column: 1 };
+        assert_eq!(mode.copy_text(), "lpha\nbravo");
     }
 
     #[test]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,346 @@
+//! On-disk crash reporting.
+//!
+//! GridBash unwinds on panic, so a panic in the UI thread exits with status 101
+//! and prints to a terminal that is usually gone a moment later: no Windows
+//! Error Reporting entry, no minidump, no record of what happened. These
+//! reports are the only durable evidence after the process is gone.
+
+use std::{
+    cell::Cell,
+    fs::{self, OpenOptions},
+    io::Write,
+    panic::PanicHookInfo,
+    path::{Path, PathBuf},
+    thread,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use directories::ProjectDirs;
+
+/// Keep enough reports to cover a session's worth of restarts without letting
+/// the directory grow without bound.
+const MAX_REPORTS: usize = 50;
+
+thread_local! {
+    /// Set while this thread is about to catch and recover from a panic.
+    ///
+    /// A shielded panic still gets a report on disk, but nothing may print to
+    /// the terminal or tear down the alternate screen: the TUI keeps running,
+    /// and stderr output would land on top of it as garbage. It is per-thread
+    /// because a panic hook runs on the thread that panicked, and a worker
+    /// recovering from its own panic must not change what a UI-thread panic
+    /// does.
+    static SHIELDED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// True while a panic on this thread is expected to be caught and recovered
+/// rather than fatal.
+pub fn panics_are_shielded() -> bool {
+    SHIELDED.try_with(|shielded| shielded.get()).unwrap_or(false)
+}
+
+/// Suppresses terminal-visible panic output on this thread for as long as the
+/// guard lives.
+///
+/// The guard drops during unwinding as well as on the happy path, so the shield
+/// always lifts before the caught panic is handled.
+pub struct PanicShield {
+    previous: bool,
+}
+
+impl PanicShield {
+    pub fn new() -> Self {
+        let previous = SHIELDED
+            .try_with(|shielded| shielded.replace(true))
+            .unwrap_or(false);
+        Self { previous }
+    }
+}
+
+impl Drop for PanicShield {
+    fn drop(&mut self) {
+        let previous = self.previous;
+        let _ = SHIELDED.try_with(|shielded| shielded.set(previous));
+    }
+}
+
+/// Runs `work`, turning a panic into the error the work would have reported.
+///
+/// Worker threads answer the interface over a channel. A panicking worker never
+/// answers at all, so whatever it was asked to do stays in flight for the rest
+/// of the session, spinner and all. Reporting the panic as a failure keeps the
+/// request completable and puts the reason on screen.
+pub fn recovering<T>(label: &str, work: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+    let outcome = {
+        let _shield = PanicShield::new();
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(work))
+    };
+    match outcome {
+        Ok(result) => result,
+        Err(payload) => {
+            let detail = panic_payload_message(payload.as_ref());
+            record_recovered("tui", label, &detail);
+            Err(format!("{label} failed unexpectedly: {detail}"))
+        }
+    }
+}
+
+pub fn logs_dir() -> Option<PathBuf> {
+    ProjectDirs::from("", "", "GridBash").map(|dirs| dirs.data_local_dir().join("logs"))
+}
+
+/// Record panics to disk before delegating to the previously installed hook.
+///
+/// The UI thread's terminal-restoring hook chains to whatever hook it replaced,
+/// so installing this first means both the plain CLI paths and the full TUI
+/// report panics without either needing to know about the other.
+pub fn install_panic_logger(role: &'static str) {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        record_panic(info, role);
+        // The default hook writes the message and backtrace to stderr. That is
+        // what a plain CLI run wants, and exactly what a recovering TUI must
+        // not have painted over its alternate screen.
+        if !panics_are_shielded() {
+            previous(info);
+        }
+    }));
+}
+
+/// Write a panic report. Called from inside a panic hook, so every failure is
+/// swallowed: a second panic here would abort the process and lose the report.
+pub fn record_panic(info: &PanicHookInfo<'_>, role: &str) {
+    let location = info
+        .location()
+        .map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    let thread = thread::current();
+    let report = format!(
+        "kind: panic\n\
+         {}\
+         thread: {}\n\
+         location: {location}\n\
+         message: {}\n\
+         backtrace:\n{}\n",
+        report_preamble(role),
+        thread.name().unwrap_or("unnamed"),
+        panic_payload_message(info.payload()),
+        std::backtrace::Backtrace::force_capture(),
+    );
+    write_report("panic", role, &report);
+}
+
+/// Record a non-zero exit so a failed startup or teardown leaves a trail too.
+pub fn record_error_exit(role: &str, error: &anyhow::Error) {
+    let report = format!(
+        "kind: error-exit\n{}error: {error:#}\n",
+        report_preamble(role)
+    );
+    write_report("error", role, &report);
+}
+
+/// Record a failure the process survived.
+///
+/// Recovered failures never reach the user's terminal, so without this they
+/// would leave no trace at all beyond a status-bar line that scrolls away.
+pub fn record_recovered(role: &str, context: &str, detail: &str) {
+    let report = format!(
+        "kind: recovered\n{}context: {context}\ndetail: {detail}\n",
+        report_preamble(role)
+    );
+    write_report("recovered", role, &report);
+}
+
+fn report_preamble(role: &str) -> String {
+    format!(
+        "role: {role}\nversion: {}\npid: {}\ntimestamp_ms: {}\n",
+        env!("CARGO_PKG_VERSION"),
+        std::process::id(),
+        now_millis(),
+    )
+}
+
+/// Best-effort text of a panic payload, for reports and status messages.
+///
+/// A panic payload is `Any`, so anything other than the two shapes `panic!`
+/// produces has to be described rather than read.
+pub fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis())
+        .unwrap_or_default()
+}
+
+fn write_report(kind: &str, role: &str, report: &str) {
+    let Some(directory) = logs_dir() else {
+        return;
+    };
+    if fs::create_dir_all(&directory).is_err() {
+        return;
+    }
+    let path = directory.join(format!(
+        "{kind}-{role}-{}-{}.log",
+        now_millis(),
+        std::process::id()
+    ));
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+        let _ = file.write_all(report.as_bytes());
+        let _ = file.flush();
+    }
+    prune_reports(&directory);
+}
+
+fn prune_reports(directory: &Path) {
+    let Ok(entries) = fs::read_dir(directory) else {
+        return;
+    };
+    let mut reports = entries
+        .flatten()
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    let Some(excess) = reports
+        .len()
+        .checked_sub(MAX_REPORTS)
+        .filter(|count| *count > 0)
+    else {
+        return;
+    };
+    reports.sort_by_key(|(modified, _)| *modified);
+    for (_, path) in reports.into_iter().take(excess) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_reports_name_the_role_and_location() {
+        let report = format!(
+            "kind: panic\n{}location: src/ui.rs:1:2\n",
+            report_preamble("tui")
+        );
+        assert!(report.contains("role: tui"));
+        assert!(report.contains(concat!("version: ", env!("CARGO_PKG_VERSION"))));
+        assert!(report.contains("location: src/ui.rs:1:2"));
+    }
+
+    /// End-to-end: a real panic must leave a readable report behind, because
+    /// this is the only evidence that survives the process.
+    #[test]
+    fn a_real_panic_writes_a_report_naming_the_message_and_location() {
+        let directory = logs_dir().expect("log directory");
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|info| record_panic(info, "smoketest")));
+        let result = std::panic::catch_unwind(|| panic!("gridbash crash log smoke test"));
+        std::panic::set_hook(previous);
+        assert!(result.is_err(), "the test panic must have unwound");
+
+        let reports = fs::read_dir(&directory)
+            .expect("read log directory")
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("panic-smoketest-"))
+            })
+            .collect::<Vec<_>>();
+        assert!(!reports.is_empty(), "panic must produce a report");
+
+        let body = fs::read_to_string(&reports[0]).expect("read report");
+        assert!(body.contains("kind: panic"), "report body: {body}");
+        assert!(body.contains("role: smoketest"), "report body: {body}");
+        assert!(
+            body.contains("gridbash crash log smoke test"),
+            "report body: {body}"
+        );
+        assert!(
+            body.contains("src\\diagnostics.rs") || body.contains("src/diagnostics.rs"),
+            "report must name the panicking file: {body}"
+        );
+
+        for report in reports {
+            let _ = fs::remove_file(report);
+        }
+    }
+
+    /// The shield decides whether a panic tears down the alternate screen and
+    /// prints to stderr. Leaving it stuck on would hide a genuinely fatal panic;
+    /// leaving it stuck off would let a recovered one garble the interface.
+    #[test]
+    fn the_panic_shield_lifts_on_both_the_happy_path_and_an_unwind() {
+        assert!(!panics_are_shielded());
+
+        {
+            let _outer = PanicShield::new();
+            assert!(panics_are_shielded());
+            {
+                let _inner = PanicShield::new();
+                assert!(panics_are_shielded());
+            }
+            assert!(
+                panics_are_shielded(),
+                "a nested guard must not lift the outer shield"
+            );
+        }
+        assert!(!panics_are_shielded());
+
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(|| {
+            let _shield = PanicShield::new();
+            assert!(panics_are_shielded());
+            panic!("unwind past the shield");
+        });
+        std::panic::set_hook(previous);
+
+        assert!(result.is_err(), "the test panic must have unwound");
+        assert!(
+            !panics_are_shielded(),
+            "unwinding out of the guard must lift the shield"
+        );
+    }
+
+    #[test]
+    fn pruning_keeps_the_newest_reports() {
+        let directory = std::env::temp_dir().join(format!("gridbash-logs-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&directory);
+        fs::create_dir_all(&directory).expect("create log directory");
+        for index in 0..MAX_REPORTS + 10 {
+            fs::write(directory.join(format!("panic-tui-{index:04}.log")), b"x")
+                .expect("write report");
+        }
+
+        prune_reports(&directory);
+
+        let remaining = fs::read_dir(&directory)
+            .expect("read log directory")
+            .flatten()
+            .count();
+        assert_eq!(remaining, MAX_REPORTS);
+        let _ = fs::remove_dir_all(&directory);
+    }
+}

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -12,11 +12,13 @@ pub enum Action {
     FocusUp,
     FocusDown,
     ToggleSelection,
+    ToggleGridSelection,
     SelectAll,
     SleepPanes,
     RestartPanes,
     NextTab,
     NewTab,
+    CloseGrid,
     ResizeGrid,
     SwapPanes,
     ZoomPane,
@@ -31,6 +33,7 @@ pub enum Action {
     Settings,
     PreviousPanes,
     PaneActivity,
+    Ports,
     CopyMode,
     BackgroundPanes,
     BackgroundJobs,
@@ -45,9 +48,11 @@ const ACTIONS: &[Action] = &[
     Action::FocusUp,
     Action::FocusDown,
     Action::ToggleSelection,
+    Action::ToggleGridSelection,
     Action::SelectAll,
     Action::NewTab,
     Action::NextTab,
+    Action::CloseGrid,
     Action::RenameTab,
     Action::CommandLine,
     Action::CommandPalette,
@@ -55,6 +60,7 @@ const ACTIONS: &[Action] = &[
     Action::CaptureOutput,
     Action::ToggleOutputLogging,
     Action::PaneActivity,
+    Action::Ports,
     Action::PreviousPanes,
     Action::CopyMode,
     Action::BackgroundPanes,
@@ -88,11 +94,13 @@ impl Action {
             Self::FocusUp => "focus-up",
             Self::FocusDown => "focus-down",
             Self::ToggleSelection => "toggle-selection",
+            Self::ToggleGridSelection => "toggle-grid-selection",
             Self::SelectAll => "select-all",
             Self::SleepPanes => "sleep-panes",
             Self::RestartPanes => "restart-panes",
             Self::NextTab => "next-tab",
             Self::NewTab => "new-tab",
+            Self::CloseGrid => "close-grid",
             Self::ResizeGrid => "resize-grid",
             Self::SwapPanes => "swap-panes",
             Self::ZoomPane => "zoom-pane",
@@ -107,6 +115,7 @@ impl Action {
             Self::Settings => "settings",
             Self::PreviousPanes => "previous-panes",
             Self::PaneActivity => "pane-activity",
+            Self::Ports => "ports",
             Self::CopyMode => "copy-mode",
             Self::BackgroundPanes => "background-panes",
             Self::BackgroundJobs => "background-jobs",
@@ -125,13 +134,15 @@ impl Action {
             Self::FocusUp => "focus pane above",
             Self::FocusDown => "focus pane below",
             Self::ToggleSelection => "toggle pane selection",
+            Self::ToggleGridSelection => "toggle current grid selection",
             Self::SelectAll => "select or clear all panes",
             Self::SleepPanes => "sleep or wake panes",
             Self::RestartPanes => "restart exited panes",
             Self::NextTab => "switch to next tab",
             Self::NewTab => "open a new tab",
+            Self::CloseGrid => "close current grid",
             Self::ResizeGrid => "resize the grid",
-            Self::SwapPanes => "swap selected panes",
+            Self::SwapPanes => "swap selected panes or grids",
             Self::ZoomPane => "zoom or restore focused pane",
             Self::CommandLine => "expand or close command line",
             Self::CommandPalette => "open searchable command palette",
@@ -144,6 +155,7 @@ impl Action {
             Self::Settings => "open settings and profiles",
             Self::PreviousPanes => "show previous panes",
             Self::PaneActivity => "show focused-pane activity",
+            Self::Ports => "show ports used by coding agents",
             Self::CopyMode => "search and copy pane scrollback",
             Self::BackgroundPanes => "background selected or focused panes",
             Self::BackgroundJobs => "show background agents",
@@ -166,11 +178,13 @@ impl Action {
             Self::FocusUp => "alt+up",
             Self::FocusDown => "alt+down",
             Self::ToggleSelection => "alt+s",
+            Self::ToggleGridSelection => "alt+shift+s",
             Self::SelectAll => "alt+a",
             Self::SleepPanes => "alt+z",
             Self::RestartPanes => "alt+shift+t",
             Self::NextTab => "alt+t",
             Self::NewTab => "alt+n",
+            Self::CloseGrid => "alt+w",
             Self::ResizeGrid => "alt+l",
             Self::SwapPanes => "alt+x",
             Self::ZoomPane => "alt+f",
@@ -185,6 +199,7 @@ impl Action {
             Self::Settings => "alt+o",
             Self::PreviousPanes => "alt+shift+p",
             Self::PaneActivity => "alt+p",
+            Self::Ports => "ctrl+alt+p",
             Self::CopyMode => "alt+b",
             Self::BackgroundPanes => "alt+shift+b",
             Self::BackgroundJobs => "ctrl+alt+b",
@@ -308,9 +323,11 @@ fn parse_key(value: &str) -> Result<ShortcutKey> {
         "right" => Ok(ShortcutKey::Right),
         "up" => Ok(ShortcutKey::Up),
         "down" => Ok(ShortcutKey::Down),
-        value if value.len() == 1 => Ok(ShortcutKey::Char(
-            value.chars().next().expect("one-character shortcut"),
-        )),
+        value if value.len() == 1 => value
+            .chars()
+            .next()
+            .map(ShortcutKey::Char)
+            .ok_or_else(|| anyhow!("unknown shortcut key '{value}'")),
         value if value.starts_with('f') => {
             let number = value[1..]
                 .parse::<u8>()
@@ -388,13 +405,17 @@ impl KeyBindings {
             .iter()
             .copied()
             .map(|action| {
-                let shortcut = self.bindings[&action];
-                let label = match action {
-                    Action::Quit if shortcut != fallback_quit_shortcut() => {
-                        format!("{} / Alt+Q", shortcut.label())
-                    }
-                    Action::Help => format!("{} / F1", shortcut.label()),
-                    _ => shortcut.label(),
+                // `from_overrides` seeds every action, but indexing a map that
+                // is one action short would panic instead of degrading.
+                let label = match self.shortcut_for(action) {
+                    None => "unbound".to_string(),
+                    Some(shortcut) => match action {
+                        Action::Quit if shortcut != fallback_quit_shortcut() => {
+                            format!("{} / Alt+Q", shortcut.label())
+                        }
+                        Action::Help => format!("{} / F1", shortcut.label()),
+                        _ => shortcut.label(),
+                    },
                 };
                 (label, action.description())
             })
@@ -402,7 +423,15 @@ impl KeyBindings {
     }
 
     pub fn label_for(&self, action: Action) -> String {
-        self.bindings[&action].label()
+        self.shortcut_for(action)
+            .map_or_else(|| "unbound".to_string(), Shortcut::label)
+    }
+
+    fn shortcut_for(&self, action: Action) -> Option<Shortcut> {
+        self.bindings
+            .get(&action)
+            .copied()
+            .or_else(|| Shortcut::parse(action.default_chord()).ok())
     }
 }
 
@@ -442,6 +471,24 @@ mod tests {
             .iter()
             .map(|(name, value)| (name.to_string(), value.to_string()))
             .collect()
+    }
+
+    /// The help overlay and every shortcut label used to index the binding map
+    /// directly, which panics for an action the map is missing.
+    #[test]
+    fn labels_survive_a_binding_map_that_is_missing_an_action() {
+        let mut bindings = KeyBindings::from_overrides(&overrides(&[])).expect("default bindings");
+        bindings.bindings.clear();
+
+        assert_eq!(
+            bindings.label_for(Action::ZoomPane),
+            Shortcut::parse(Action::ZoomPane.default_chord())
+                .expect("default chord")
+                .label(),
+            "a missing binding falls back to the action's default chord"
+        );
+        assert_eq!(bindings.help_entries().len(), ACTIONS.len());
+        assert!(bindings.action_for(&KeyEvent::new(KeyCode::Char('q'), KeyModifiers::ALT)).is_none());
     }
 
     #[test]
@@ -509,5 +556,38 @@ mod tests {
             .map(|action| action.name())
             .collect::<BTreeSet<_>>();
         assert_eq!(names.len(), ACTIONS.len());
+    }
+
+    #[test]
+    fn grid_selection_has_a_pane_selection_companion_shortcut() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(
+                KeyCode::Char('S'),
+                KeyModifiers::ALT | KeyModifiers::SHIFT,
+            )),
+            Some(Action::ToggleGridSelection)
+        );
+    }
+
+    #[test]
+    fn close_grid_has_a_modeless_default_shortcut() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT)),
+            Some(Action::CloseGrid)
+        );
+    }
+
+    #[test]
+    fn agent_ports_has_a_modeless_default_shortcut() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.action_for(&KeyEvent::new(
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            )),
+            Some(Action::Ports)
+        );
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -185,19 +185,28 @@ fn weighted_grid_rects(
     let column_widths = weighted_lengths(area.width, column_weights);
     let row_heights = weighted_lengths(area.height, row_weights);
 
+    let row_count = row_heights.len();
+    let column_count = column_widths.len();
     let mut y = area.y;
-    for row_height in row_heights {
+    for (row, row_height) in row_heights.into_iter().enumerate() {
         let mut x = area.x;
-        for column_width in column_widths.iter().copied() {
+        for (column, column_width) in column_widths.iter().copied().enumerate() {
             if rects.len() >= count {
                 break;
             }
 
+            // Neighbours share the line that divides them: a pane reaches one
+            // cell into the next so both draw the same border row or column, and
+            // ratatui's border merging collapses the overlap into a single line.
+            // Two abutting frames would otherwise spend two cells on what reads
+            // as one divider, and the pair of parallel lines makes a grid look
+            // like a spreadsheet instead of a workspace. The last row and column
+            // have nothing to reach into, so they stay inside `area`.
             rects.push(Rect {
                 x,
                 y,
-                width: column_width,
-                height: row_height,
+                width: column_width.saturating_add(u16::from(column + 1 < column_count)),
+                height: row_height.saturating_add(u16::from(row + 1 < row_count)),
             });
             x = x.saturating_add(column_width);
         }
@@ -391,6 +400,30 @@ mod tests {
 
     #[test]
     fn grid_rects_cover_area() {
+        let area = Rect::new(0, 0, 100, 40);
+        let rects = grid_rects(
+            area,
+            GridSize {
+                rows: 2,
+                columns: 3,
+            },
+            6,
+        );
+
+        assert_eq!(rects.len(), 6);
+        // The grid fills the area exactly: the first pane starts at its origin
+        // and the last pane in each direction ends on its far edge.
+        assert_eq!(rects[0].x, area.x);
+        assert_eq!(rects[0].y, area.y);
+        assert_eq!(rects[2].right(), area.right());
+        assert_eq!(rects[3].bottom(), area.bottom());
+    }
+
+    /// Adjacent panes are meant to land on the same divider cell so the two
+    /// borders merge into one line. Losing the overlap costs a cell per boundary
+    /// and puts two parallel lines between every pair of panes.
+    #[test]
+    fn neighbouring_panes_share_one_dividing_line() {
         let rects = grid_rects(
             Rect::new(0, 0, 100, 40),
             GridSize {
@@ -399,9 +432,27 @@ mod tests {
             },
             6,
         );
-        assert_eq!(rects.len(), 6);
-        assert_eq!(rects[0].height + rects[3].height, 40);
-        assert_eq!(rects[0].width + rects[1].width + rects[2].width, 100);
+
+        assert_eq!(rects[1].x, rects[0].right() - 1, "columns must overlap by 1");
+        assert_eq!(rects[2].x, rects[1].right() - 1, "columns must overlap by 1");
+        assert_eq!(rects[3].y, rects[0].bottom() - 1, "rows must overlap by 1");
+    }
+
+    /// The overlap only exists to be shared. A single pane has no neighbour to
+    /// share with, so it must not reach outside the area it was given.
+    #[test]
+    fn a_lone_pane_stays_inside_its_area() {
+        let area = Rect::new(2, 3, 40, 12);
+        let rects = grid_rects(
+            area,
+            GridSize {
+                rows: 1,
+                columns: 1,
+            },
+            1,
+        );
+
+        assert_eq!(rects, vec![area]);
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,5 +1,10 @@
 use ratatui::layout::Rect;
 
+/// Upper bound on panes in a single grid. Every path that turns a number into
+/// per-pane allocations clamps to this, so an out-of-range grid size can never
+/// become an allocation the process cannot satisfy.
+pub const MAX_PANES: usize = 100;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PaneId(pub usize);
 
@@ -36,25 +41,30 @@ impl GridSize {
     }
 
     pub fn from_count(count: usize) -> Self {
-        let count = count.clamp(1, 100);
-        let columns = (count as f64).sqrt().ceil() as usize;
+        let count = count.clamp(1, MAX_PANES);
+        let columns = ((count as f64).sqrt().ceil() as usize).clamp(1, MAX_PANES);
         let rows = count.div_ceil(columns);
         Self { rows, columns }
     }
 
     pub fn new(rows: usize, columns: usize) -> Option<Self> {
-        if rows == 0 || columns == 0 || rows * columns > 100 {
+        // `rows * columns` would overflow for values parsed straight out of a
+        // `--grid` argument, and a wrapped product can slip past the cap and
+        // reach `vec![1000; rows]`.
+        if rows == 0 || columns == 0 || rows.checked_mul(columns)? > MAX_PANES {
             return None;
         }
         Some(Self { rows, columns })
     }
 
     pub fn count(self) -> usize {
-        self.rows * self.columns
+        self.rows.saturating_mul(self.columns)
     }
 
     pub fn compact_for_count(self, count: usize) -> Self {
-        let count = count.clamp(1, self.count());
+        // A caller-built `GridSize` can hold zero rows or columns, and
+        // `clamp(1, 0)` panics.
+        let count = count.clamp(1, self.count().max(1));
         let mut compact = self;
 
         while compact.columns > 1 && compact.rows * (compact.columns - 1) >= count {
@@ -72,8 +82,8 @@ impl GridLayout {
     pub fn new(size: GridSize) -> Self {
         Self {
             size,
-            row_weights: vec![1000; size.rows],
-            column_weights: vec![1000; size.columns],
+            row_weights: vec![1000; size.rows.min(MAX_PANES)],
+            column_weights: vec![1000; size.columns.min(MAX_PANES)],
         }
     }
 
@@ -83,8 +93,8 @@ impl GridLayout {
 
     pub fn set_size(&mut self, size: GridSize) {
         self.size = size;
-        resize_weights(&mut self.row_weights, size.rows);
-        resize_weights(&mut self.column_weights, size.columns);
+        resize_weights(&mut self.row_weights, size.rows.min(MAX_PANES));
+        resize_weights(&mut self.column_weights, size.columns.min(MAX_PANES));
     }
 
     pub fn rects(&self, area: Rect, count: usize) -> Vec<Rect> {
@@ -162,6 +172,11 @@ fn weighted_grid_rects(
     column_weights: &[u16],
     count: usize,
 ) -> Vec<Rect> {
+    // `count` reaches here from pane bookkeeping; honouring it verbatim would
+    // turn a bad number into an allocation failure rather than an empty grid.
+    // `GridSize::new` already caps a valid grid at `MAX_PANES`, so this only
+    // bites a size a caller built by hand.
+    let count = count.min(MAX_PANES);
     let mut rects = Vec::with_capacity(count);
     if grid.rows == 0 || grid.columns == 0 {
         return rects;
@@ -277,6 +292,51 @@ mod tests {
     fn auto_grid_caps_at_hundred() {
         let grid = GridSize::from_count(100);
         assert_eq!(grid.count(), 100);
+    }
+
+    /// `rows * columns` overflows for numbers a `--grid` argument can carry, and
+    /// a wrapped product used to slip past the pane cap and reach an allocation
+    /// the process cannot satisfy.
+    #[test]
+    fn grid_dimensions_that_overflow_are_rejected() {
+        assert_eq!(GridSize::new(usize::MAX, usize::MAX), None);
+        assert_eq!(GridSize::new(usize::MAX, 2), None);
+        assert_eq!(GridSize::parse("18446744073709551615x2"), None);
+        let huge = (1_usize << 40).to_string();
+        assert_eq!(GridSize::parse(&format!("{huge}x{huge}")), None);
+    }
+
+    /// A caller-built `GridSize` can hold zero rows, and the old
+    /// `clamp(1, self.count())` panicked on the crossed bounds.
+    #[test]
+    fn compacting_an_empty_grid_does_not_panic() {
+        let empty = GridSize {
+            rows: 0,
+            columns: 0,
+        };
+
+        assert_eq!(empty.count(), 0);
+        assert_eq!(empty.compact_for_count(4), empty);
+        assert_eq!(empty.compact_for_count(0), empty);
+    }
+
+    /// An out-of-range `GridSize` must not turn into a huge per-row allocation.
+    #[test]
+    fn layout_weights_stay_bounded_for_an_absurd_grid() {
+        let absurd = GridSize {
+            rows: usize::MAX,
+            columns: usize::MAX,
+        };
+
+        let mut layout = GridLayout::new(absurd);
+        assert!(layout.rects(Rect::new(0, 0, 40, 10), 4).len() <= 4);
+        layout.set_size(absurd);
+        assert!(
+            layout
+                .rects(Rect::new(0, 0, 40, 10), usize::MAX)
+                .len()
+                <= MAX_PANES
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,18 @@ mod config;
 mod control;
 mod control_discovery;
 mod copy_mode;
+mod diagnostics;
 mod image_preview;
 mod keybindings;
 mod layout;
 mod manager;
 mod output_capture;
 mod pane_host;
+mod ports;
 mod process_priority;
 mod profiles;
 mod pty;
+mod resume_picker;
 mod session;
 mod setup;
 mod ui;
@@ -40,6 +43,19 @@ use crate::{
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Installed before anything else can fail so the crash report survives the
+    // terminal. App::run chains its terminal-restoring hook onto this one.
+    let role = if cli.pane_host.is_some() {
+        "pane-host"
+    } else {
+        "tui"
+    };
+    diagnostics::install_panic_logger(role);
+
+    run(cli).inspect_err(|error| diagnostics::record_error_exit(role, error))
+}
+
+fn run(cli: Cli) -> Result<()> {
     if let Some(spec_path) = cli.pane_host.as_deref() {
         return pane_host::run_pane_host(spec_path);
     }

--- a/src/output_capture.rs
+++ b/src/output_capture.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{BufWriter, Write},
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -12,6 +12,8 @@ use directories::ProjectDirs;
 use crate::layout::PaneId;
 
 const OUTPUT_FILE_ATTEMPTS: usize = 1_000;
+const PANE_LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const PANE_LOG_FLUSH_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PaneLogKey {
@@ -58,6 +60,8 @@ pub fn capture_output(directory: &Path, pane_number: usize, plain_text: &str) ->
 struct PaneLogger {
     path: PathBuf,
     writer: Box<dyn Write + Send>,
+    pending_bytes: usize,
+    last_flush: Instant,
 }
 
 impl std::fmt::Debug for PaneLogger {
@@ -75,6 +79,8 @@ impl PaneLogger {
         Ok(Self {
             path,
             writer: Box::new(BufWriter::new(file)),
+            pending_bytes: 0,
+            last_flush: Instant::now(),
         })
     }
 
@@ -83,6 +89,8 @@ impl PaneLogger {
         Self {
             path,
             writer: Box::new(writer),
+            pending_bytes: 0,
+            last_flush: Instant::now(),
         }
     }
 
@@ -93,15 +101,33 @@ impl PaneLogger {
         self.writer
             .write_all(plain_text.as_bytes())
             .with_context(|| format!("failed to append log {}", self.path.display()))?;
+        self.pending_bytes = self.pending_bytes.saturating_add(plain_text.len());
+        if self.pending_bytes >= PANE_LOG_FLUSH_BYTES {
+            self.flush()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn flush_if_due(&mut self, now: Instant) -> Result<()> {
+        if self.pending_bytes == 0 || now.duration_since(self.last_flush) < PANE_LOG_FLUSH_INTERVAL
+        {
+            return Ok(());
+        }
+        self.flush()
+    }
+
+    fn flush(&mut self) -> Result<()> {
         self.writer
             .flush()
-            .with_context(|| format!("failed to flush log {}", self.path.display()))
+            .with_context(|| format!("failed to flush log {}", self.path.display()))?;
+        self.pending_bytes = 0;
+        self.last_flush = Instant::now();
+        Ok(())
     }
 
     fn finish(&mut self) -> Result<()> {
-        self.writer
-            .flush()
-            .with_context(|| format!("failed to flush log {}", self.path.display()))
+        self.flush()
     }
 }
 
@@ -147,6 +173,22 @@ impl OutputLogs {
             self.active.remove(&key);
         }
         result
+    }
+
+    pub fn flush_due(&mut self) -> Result<()> {
+        let now = Instant::now();
+        let mut failure = None;
+        for (key, logger) in &mut self.active {
+            if let Err(error) = logger.flush_if_due(now) {
+                failure = Some((*key, error));
+                break;
+            }
+        }
+        if let Some((key, error)) = failure {
+            self.active.remove(&key);
+            return Err(error);
+        }
+        Ok(())
     }
 
     pub fn is_active(&self, key: PaneLogKey) -> bool {
@@ -251,6 +293,31 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct CountingWriterState {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    #[derive(Clone)]
+    struct CountingWriter(Arc<Mutex<CountingWriterState>>);
+
+    impl Write for CountingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("counting writer lock")
+                .bytes
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().expect("counting writer lock").flushes += 1;
+            Ok(())
+        }
+    }
+
     struct FailingWriter;
 
     impl Write for FailingWriter {
@@ -305,6 +372,29 @@ mod tests {
             String::from_utf8(bytes.lock().expect("bytes lock").clone()).expect("utf8"),
             "first\nsecond\n"
         );
+    }
+
+    #[test]
+    fn logger_batches_small_flushes_and_flushes_large_batches_immediately() {
+        let state = Arc::new(Mutex::new(CountingWriterState::default()));
+        let writer = CountingWriter(state.clone());
+        let mut logger = PaneLogger::with_writer(PathBuf::from("batched.log"), writer);
+
+        logger.append("first\n").expect("first append");
+        logger.append("second\n").expect("second append");
+        assert_eq!(state.lock().expect("state lock").flushes, 0);
+
+        logger
+            .append(&"x".repeat(PANE_LOG_FLUSH_BYTES))
+            .expect("large append");
+        assert_eq!(state.lock().expect("state lock").flushes, 1);
+
+        logger.append("tail\n").expect("tail append");
+        logger.finish().expect("finish");
+        let state = state.lock().expect("state lock");
+        assert_eq!(state.flushes, 2);
+        assert!(state.bytes.starts_with(b"first\nsecond\n"));
+        assert!(state.bytes.ends_with(b"tail\n"));
     }
 
     #[test]

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -1,14 +1,15 @@
 use std::{
+    cell::RefCell,
     collections::BTreeMap,
     ffi::{OsString, OsString as PlatformString},
     fs::{self, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::{self, BufRead, BufReader, Write},
     net::{Shutdown, SocketAddr, TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{Arc, Mutex, mpsc as std_mpsc},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use std::{error::Error as StdError, fmt};
 
@@ -28,19 +29,36 @@ use crate::{
     layout::PaneId,
     process_priority::PaneWorkloadClass,
     pty::{PtyEvent, PtyPane as LocalPtyPane, PtyView, PtyWriteToken},
+    session::process_is_running,
 };
 
 const HOST_START_TIMEOUT: Duration = Duration::from_secs(8);
-const HOST_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const HOST_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const HOST_EVENT_QUEUE_CAPACITY: usize = 256;
+const HOST_EVENT_DRAIN_LIMIT: usize = 256;
+const HOST_WORKER_STACK_BYTES: usize = 256 * 1024;
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long a keep-running host waits for a replacement GridBash to reattach
+/// after the process that owned it disappeared. Long enough to survive a crash
+/// and relaunch, short enough that nothing lingers for hours.
+const ORPHAN_REATTACH_GRACE: Duration = Duration::from_secs(600);
 const BACKGROUND_OUTPUT_LIMIT: usize = 2 * 1024 * 1024;
 const PANE_HOST_PROTOCOL_VERSION: u16 = 1;
+/// A PTY read is capped at 32 KiB, which base64-encodes and JSON-escapes into
+/// roughly 44 KiB. Scratch buffers keep that much capacity between messages and
+/// release anything larger so one oversized burst is not pinned forever.
+const WIRE_SCRATCH_KEEP_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PtyHostRef {
     pub endpoint: String,
     pub token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub process_id: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_sqlite_home: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -73,6 +91,8 @@ enum HostCommand {
         protocol_version: u16,
         token: String,
         keep_running: bool,
+        #[serde(default)]
+        client_pid: Option<u32>,
     },
     Write {
         data: String,
@@ -102,9 +122,15 @@ enum HostEvent {
     Ready {
         #[serde(default)]
         protocol_version: u16,
+        #[serde(default)]
+        host_process_id: Option<u32>,
         background_output: String,
         cwd: PathBuf,
         exited: bool,
+        #[serde(default)]
+        codex_sqlite_home: Option<PathBuf>,
+        #[serde(default)]
+        started_at_ms: Option<u64>,
     },
     Output {
         data: String,
@@ -125,6 +151,17 @@ enum HostEvent {
         host_version: u16,
     },
     Busy,
+}
+
+/// Wire-identical to [`HostEvent::Output`], but borrows its payload.
+///
+/// The output event is the only message on the hot path, so encoding into a
+/// reused buffer avoids one allocation per PTY read for the life of the pane.
+#[derive(Serialize)]
+struct HostOutputEvent<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    data: &'a str,
 }
 
 #[derive(Debug)]
@@ -177,6 +214,7 @@ pub struct PtyPane {
     generation: u64,
     connection: Arc<Mutex<TcpStream>>,
     host: PtyHostRef,
+    host_process_id: Option<u32>,
     view: PtyView,
     keep_running: bool,
     pub active: bool,
@@ -270,6 +308,7 @@ impl PtyPane {
             thread::sleep(Duration::from_millis(20));
         };
         let _ = fs::remove_file(&ready_path);
+        let host_process_id = child.id();
         thread::spawn(move || {
             let _ = child.wait();
         });
@@ -277,6 +316,9 @@ impl PtyPane {
         let host = PtyHostRef {
             endpoint: ready.endpoint,
             token,
+            process_id: Some(host_process_id),
+            codex_sqlite_home: None,
+            started_at_ms: None,
         };
         Self::connect(
             host,
@@ -318,7 +360,7 @@ impl PtyPane {
 
     #[allow(clippy::too_many_arguments)]
     fn connect(
-        host: PtyHostRef,
+        mut host: PtyHostRef,
         id: PaneId,
         generation: u64,
         fallback_cwd: &Path,
@@ -334,6 +376,8 @@ impl PtyPane {
             .with_context(|| format!("invalid pane host endpoint {}", host.endpoint))?;
         let mut stream = TcpStream::connect_timeout(&endpoint, HANDSHAKE_TIMEOUT)
             .with_context(|| format!("failed to connect to pane host {}", host.endpoint))?;
+        prevent_stream_inheritance(&stream)
+            .context("failed to protect pane host connection from child-process inheritance")?;
         stream.set_nodelay(true).ok();
         stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT)).ok();
         send_json(
@@ -342,12 +386,15 @@ impl PtyPane {
                 protocol_version: PANE_HOST_PROTOCOL_VERSION,
                 token: host.token.clone(),
                 keep_running,
+                client_pid: Some(std::process::id()),
             },
         )?;
 
         let reader_stream = stream
             .try_clone()
             .context("failed to clone pane host connection")?;
+        prevent_stream_inheritance(&reader_stream)
+            .context("failed to protect pane host reader from child-process inheritance")?;
         let mut reader = BufReader::new(reader_stream);
         let mut line = String::new();
         reader
@@ -358,13 +405,32 @@ impl PtyPane {
         }
         let ready = serde_json::from_str::<HostEvent>(&line)
             .context("failed to parse pane host handshake")?;
-        let (protocol_version, background_output, cwd, exited) = match ready {
+        let (
+            protocol_version,
+            host_process_id,
+            background_output,
+            cwd,
+            exited,
+            codex_sqlite_home,
+            started_at_ms,
+        ) = match ready {
             HostEvent::Ready {
                 protocol_version,
+                host_process_id,
                 background_output,
                 cwd,
                 exited,
-            } => (protocol_version, background_output, cwd, exited),
+                codex_sqlite_home,
+                started_at_ms,
+            } => (
+                protocol_version,
+                host_process_id,
+                background_output,
+                cwd,
+                exited,
+                codex_sqlite_home,
+                started_at_ms,
+            ),
             HostEvent::Error { error } => {
                 return Err(PaneHostRejected { reason: error }.into());
             }
@@ -392,12 +458,22 @@ impl PtyPane {
             view.process_output(&background_output);
         }
 
+        if host_process_id.is_some() {
+            host.process_id = host_process_id;
+        }
+        if codex_sqlite_home.is_some() {
+            host.codex_sqlite_home = codex_sqlite_home;
+        }
+        if started_at_ms.is_some() {
+            host.started_at_ms = started_at_ms;
+        }
         spawn_client_reader(reader, id, generation, event_tx);
         Ok(Self {
             id,
             generation,
             connection: Arc::new(Mutex::new(stream)),
             host,
+            host_process_id,
             view,
             keep_running,
             active: !background_output.is_empty(),
@@ -415,6 +491,18 @@ impl PtyPane {
 
     pub fn host_ref(&self) -> PtyHostRef {
         self.host.clone()
+    }
+
+    pub fn host_process_id(&self) -> Option<u32> {
+        self.host_process_id
+    }
+
+    pub fn codex_thread_id(&self, cwd: &Path) -> Option<String> {
+        let home = self.host.codex_sqlite_home.as_deref()?;
+        let started_at_ms = self.host.started_at_ms?;
+        crate::codex_sqlite::latest_thread_id(home, cwd, started_at_ms)
+            .ok()
+            .flatten()
     }
 
     pub fn cwd(&self) -> &Path {
@@ -487,6 +575,10 @@ impl PtyPane {
             .restore_history_display(output_tail, input_history);
     }
 
+    pub fn restore_history_state(&mut self, output_tail: &str, input_history: &[String]) {
+        self.view.restore_history_state(output_tail, input_history);
+    }
+
     pub fn write(&self, bytes: &[u8]) -> Result<()> {
         self.send(&HostCommand::Write {
             data: BASE64.encode(bytes),
@@ -540,6 +632,73 @@ impl PtyPane {
     }
 }
 
+pub fn terminate_saved_host(host: &PtyHostRef) -> Result<()> {
+    let endpoint = host
+        .endpoint
+        .parse::<SocketAddr>()
+        .with_context(|| format!("invalid pane host endpoint {}", host.endpoint))?;
+    let mut stream = match TcpStream::connect_timeout(&endpoint, HANDSHAKE_TIMEOUT) {
+        Ok(stream) => stream,
+        Err(error) if pane_host_is_gone(&error) => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to connect to pane host {}", host.endpoint));
+        }
+    };
+    prevent_stream_inheritance(&stream)
+        .context("failed to protect pane host connection from child-process inheritance")?;
+    stream.set_nodelay(true).ok();
+    stream.set_read_timeout(Some(HANDSHAKE_TIMEOUT)).ok();
+    send_json(
+        &mut stream,
+        &HostCommand::Hello {
+            protocol_version: PANE_HOST_PROTOCOL_VERSION,
+            token: host.token.clone(),
+            keep_running: false,
+            client_pid: Some(std::process::id()),
+        },
+    )?;
+
+    let reader_stream = stream
+        .try_clone()
+        .context("failed to clone pane host connection")?;
+    prevent_stream_inheritance(&reader_stream)
+        .context("failed to protect pane host reader from child-process inheritance")?;
+    let mut reader = BufReader::new(reader_stream);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .context("failed to read pane host handshake")?;
+    if line.is_empty() {
+        return Ok(());
+    }
+
+    match serde_json::from_str::<HostEvent>(&line).context("failed to parse pane host handshake")? {
+        HostEvent::Ready { .. } => {
+            send_json(&mut stream, &HostCommand::Terminate)?;
+            let _ = stream.shutdown(Shutdown::Both);
+            Ok(())
+        }
+        HostEvent::Busy => Err(PaneHostBusy.into()),
+        HostEvent::Incompatible { host_version } => {
+            Err(PaneHostIncompatible { host_version }.into())
+        }
+        HostEvent::Error { error } => Err(PaneHostRejected { reason: error }.into()),
+        _ => bail!("pane host rejected the termination request"),
+    }
+}
+
+fn pane_host_is_gone(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::NotConnected
+            | io::ErrorKind::NotFound
+            | io::ErrorKind::AddrNotAvailable
+    )
+}
+
 impl Drop for PtyPane {
     fn drop(&mut self) {
         let command = if self.exited {
@@ -564,9 +723,8 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
     let _ = fs::remove_file(spec_path);
 
     let listener = TcpListener::bind(("127.0.0.1", 0)).context("failed to bind pane host")?;
-    listener
-        .set_nonblocking(true)
-        .context("failed to make pane host listener nonblocking")?;
+    prevent_listener_inheritance(&listener)
+        .context("failed to protect pane host listener from child-process inheritance")?;
     let endpoint = listener
         .local_addr()
         .context("failed to read pane host endpoint")?;
@@ -583,15 +741,17 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
 
     let PaneCodexSqlite {
         env: codex_env,
+        home: codex_sqlite_home,
         lease,
     } = CodexSqlitePool::new()?.for_pane(&spec.env)?;
+    let started_at_ms = now_millis();
     let mut extra_env = spec
         .extra_env
         .iter()
         .map(|(name, value)| (PlatformString::from(name), PlatformString::from(value)))
         .collect::<Vec<_>>();
     extra_env.extend(codex_env);
-    let (event_tx, mut event_rx) = mpsc::channel(256);
+    let (event_tx, event_rx) = mpsc::channel(256);
     let mut pane = LocalPtyPane::spawn(
         &spec.profile_name,
         PaneId(spec.pane_id),
@@ -602,187 +762,261 @@ pub fn run_pane_host(spec_path: &Path) -> Result<()> {
         &spec.cwd,
         &extra_env,
         lease,
-        spec.scrollback_rows,
         spec.process_priority,
         spec.workload_policy,
         event_tx,
     )?;
 
-    let (command_tx, command_rx) = std_mpsc::channel::<HostInput>();
+    let (loop_tx, loop_rx) = std_mpsc::sync_channel::<HostLoopEvent>(HOST_EVENT_QUEUE_CAPACITY);
+    spawn_host_acceptor(listener, loop_tx.clone())?;
+    spawn_pty_event_forwarder(event_rx, loop_tx.clone())?;
     let mut client = None::<HostClient>;
+    let mut active_client_id = None::<u64>;
     let mut next_client_id = 1_u64;
     let mut keep_running = spec.keep_running;
+    // Survives disconnection so an abruptly-dead owner can still be detected.
+    let mut last_owner_pid = None::<u32>;
+    let mut client_lost_at = None::<Instant>;
     let mut background_output = Vec::new();
+    let mut output_scratch = String::new();
     let mut last_exit_poll = Instant::now();
 
     loop {
-        match listener.accept() {
-            Ok((mut stream, _)) => {
-                if client.is_none() {
-                    if let Some(connected) = accept_client(
-                        stream,
-                        next_client_id,
-                        &spec.token,
-                        &pane,
-                        &mut background_output,
-                        command_tx.clone(),
-                    )? {
-                        keep_running = connected.keep_running;
-                        client = Some(connected.client);
-                        next_client_id = next_client_id.wrapping_add(1);
-                    }
-                } else {
-                    stream.set_nonblocking(false).ok();
-                    stream
-                        .set_read_timeout(Some(Duration::from_millis(250)))
-                        .ok();
-                    if let Ok(reader_stream) = stream.try_clone() {
-                        let mut reader = BufReader::new(reader_stream);
-                        let mut hello = String::new();
-                        let _ = reader.read_line(&mut hello);
-                    }
-                    let _ = send_json(&mut stream, &HostEvent::Busy);
-                    let _ = stream.shutdown(Shutdown::Both);
-                }
+        let wait = HOST_EXIT_POLL_INTERVAL.saturating_sub(last_exit_poll.elapsed());
+        let mut next_event = match loop_rx.recv_timeout(wait) {
+            Ok(event) => Some(event),
+            Err(std_mpsc::RecvTimeoutError::Timeout) => None,
+            Err(std_mpsc::RecvTimeoutError::Disconnected) => {
+                bail!("pane host event loop stopped unexpectedly")
             }
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
-            Err(error) => return Err(error).context("failed to accept pane host client"),
-        }
+        };
 
-        while let Ok(input) = command_rx.try_recv() {
-            if client.as_ref().map(|value| value.id) != Some(input.client_id) {
-                continue;
-            }
-            match input.message {
-                HostInputMessage::Command(command) => match command {
-                    HostCommand::Hello { .. } => {}
-                    HostCommand::Write { data, token } => {
-                        let decoded = BASE64.decode(data).context("invalid pane input payload")?;
-                        let tracked_token = token
-                            .map(|token| {
-                                token
-                                    .parse::<u128>()
-                                    .context("invalid tracked pane input token")
-                            })
-                            .transpose()?;
-                        let write_result = if let Some(token) = tracked_token {
-                            pane.write_tracked(&decoded, PtyWriteToken(token))
-                        } else {
-                            pane.write(&decoded)
-                        };
-                        if let Err(error) = write_result {
-                            send_to_client(
-                                &mut client,
-                                &HostEvent::WriteFailed {
-                                    token: tracked_token.map(|token| token.to_string()),
-                                    error: error.to_string(),
-                                },
-                            );
-                        }
-                    }
-                    HostCommand::Resize { rows, cols } => {
-                        if let Err(error) = pane.resize(rows, cols) {
-                            send_to_client(
-                                &mut client,
-                                &HostEvent::Error {
-                                    error: error.to_string(),
-                                },
-                            );
-                        }
-                    }
-                    HostCommand::ApplyWorkload { policy, class } => {
-                        if let Err(error) = pane.apply_workload(policy, class) {
-                            send_to_client(
-                                &mut client,
-                                &HostEvent::Error {
-                                    error: error.to_string(),
-                                },
-                            );
-                        }
-                    }
-                    HostCommand::SetKeepRunning {
-                        keep_running: value,
-                    } => keep_running = value,
-                    HostCommand::Disconnect {
-                        keep_running: value,
-                    } => {
-                        keep_running = value;
-                        disconnect_client(&mut client);
-                        if !keep_running {
-                            pane.terminate();
-                            return Ok(());
-                        }
-                    }
-                    HostCommand::Terminate => {
-                        pane.terminate();
-                        send_to_client(&mut client, &HostEvent::Exited);
-                        return Ok(());
-                    }
+        for _ in 0..HOST_EVENT_DRAIN_LIMIT {
+            let event = match next_event.take() {
+                Some(event) => event,
+                None => match loop_rx.try_recv() {
+                    Ok(event) => event,
+                    Err(_) => break,
                 },
-                HostInputMessage::Closed => {
-                    disconnect_client(&mut client);
-                    if !keep_running {
-                        pane.terminate();
-                        return Ok(());
-                    }
-                }
-            }
-        }
+            };
 
-        while let Ok(event) = event_rx.try_recv() {
             match event {
-                PtyEvent::Output { bytes, .. } => {
-                    pane.process_output(&bytes);
-                    if client.is_some() {
-                        send_to_client(
-                            &mut client,
-                            &HostEvent::Output {
-                                data: BASE64.encode(&bytes),
-                            },
-                        );
+                HostLoopEvent::Connection(mut stream) => {
+                    prevent_stream_inheritance(&stream).context(
+                    "failed to protect accepted pane host connection from child-process inheritance",
+                )?;
+                    if client
+                        .as_ref()
+                        .is_some_and(|client| client_process_is_gone(client.owner_pid))
+                    {
+                        disconnect_client(&mut client);
                     }
                     if client.is_none() {
-                        append_background_output(&mut background_output, &bytes);
+                        if let Some(connected) = accept_client(
+                            stream,
+                            next_client_id,
+                            &spec.token,
+                            &pane,
+                            codex_sqlite_home.as_deref(),
+                            started_at_ms,
+                            &mut background_output,
+                            loop_tx.clone(),
+                        )? {
+                            keep_running = connected.keep_running;
+                            active_client_id = Some(connected.client.id);
+                            last_owner_pid = connected.client.owner_pid;
+                            client_lost_at = None;
+                            client = Some(connected.client);
+                            next_client_id = next_client_id.wrapping_add(1);
+                        }
+                    } else {
+                        stream.set_nonblocking(false).ok();
+                        stream
+                            .set_read_timeout(Some(Duration::from_millis(250)))
+                            .ok();
+                        if let Ok(reader_stream) = stream.try_clone() {
+                            let mut reader = BufReader::new(reader_stream);
+                            let mut hello = String::new();
+                            let _ = reader.read_line(&mut hello);
+                        }
+                        let _ = send_json(&mut stream, &HostEvent::Busy);
+                        let _ = stream.shutdown(Shutdown::Both);
                     }
                 }
-                PtyEvent::Exited { .. } => {
-                    pane.exited = true;
-                    send_to_client(&mut client, &HostEvent::Exited);
+                HostLoopEvent::Input(input) => {
+                    if active_client_id != Some(input.client_id) {
+                        continue;
+                    }
+                    match input.message {
+                        HostInputMessage::Command(command) => match command {
+                            HostCommand::Hello { .. } => {}
+                            HostCommand::Write { data, token } => {
+                                let decoded =
+                                    BASE64.decode(data).context("invalid pane input payload")?;
+                                let tracked_token = token
+                                    .map(|token| {
+                                        token
+                                            .parse::<u128>()
+                                            .context("invalid tracked pane input token")
+                                    })
+                                    .transpose()?;
+                                let write_result = if let Some(token) = tracked_token {
+                                    pane.write_tracked(&decoded, PtyWriteToken(token))
+                                } else {
+                                    pane.write(&decoded)
+                                };
+                                if let Err(error) = write_result {
+                                    send_to_client(
+                                        &mut client,
+                                        &HostEvent::WriteFailed {
+                                            token: tracked_token.map(|token| token.to_string()),
+                                            error: error.to_string(),
+                                        },
+                                    );
+                                }
+                            }
+                            HostCommand::Resize { rows, cols } => {
+                                if let Err(error) = pane.resize(rows, cols) {
+                                    send_to_client(
+                                        &mut client,
+                                        &HostEvent::Error {
+                                            error: error.to_string(),
+                                        },
+                                    );
+                                }
+                            }
+                            HostCommand::ApplyWorkload { policy, class } => {
+                                if let Err(error) = pane.apply_workload(policy, class) {
+                                    send_to_client(
+                                        &mut client,
+                                        &HostEvent::Error {
+                                            error: error.to_string(),
+                                        },
+                                    );
+                                }
+                            }
+                            HostCommand::SetKeepRunning {
+                                keep_running: value,
+                            } => keep_running = value,
+                            HostCommand::Disconnect {
+                                keep_running: value,
+                            } => {
+                                keep_running = value;
+                                disconnect_client(&mut client);
+                                active_client_id = None;
+                                client_lost_at = Some(Instant::now());
+                                if !keep_running {
+                                    pane.terminate();
+                                    return Ok(());
+                                }
+                            }
+                            HostCommand::Terminate => {
+                                pane.terminate();
+                                send_to_client(&mut client, &HostEvent::Exited);
+                                return Ok(());
+                            }
+                        },
+                        HostInputMessage::Closed => {
+                            disconnect_client(&mut client);
+                            active_client_id = None;
+                            client_lost_at = Some(Instant::now());
+                            if !keep_running {
+                                pane.terminate();
+                                return Ok(());
+                            }
+                        }
+                    }
                 }
-                PtyEvent::WriteFailed { token, error, .. } => send_to_client(
-                    &mut client,
-                    &HostEvent::WriteFailed {
-                        token: token.map(|token| token.0.to_string()),
-                        error,
-                    },
-                ),
-                PtyEvent::WriteSucceeded { token, .. } => send_to_client(
-                    &mut client,
-                    &HostEvent::WriteSucceeded {
-                        token: token.0.to_string(),
-                    },
-                ),
+                HostLoopEvent::Pty(event) => match event {
+                    PtyEvent::Output { bytes, .. } => {
+                        pane.process_output(&bytes);
+                        if client.is_some() {
+                            // Reuse one encode buffer: this runs for every PTY
+                            // read for the life of the pane.
+                            output_scratch.clear();
+                            BASE64.encode_string(&bytes, &mut output_scratch);
+                            send_to_client(
+                                &mut client,
+                                &HostOutputEvent {
+                                    kind: "output",
+                                    data: &output_scratch,
+                                },
+                            );
+                            release_line_slack(&mut output_scratch);
+                        }
+                        if client.is_none() {
+                            append_background_output(&mut background_output, &bytes);
+                        }
+                    }
+                    PtyEvent::Exited { .. } => {
+                        pane.exited = true;
+                        send_to_client(&mut client, &HostEvent::Exited);
+                    }
+                    PtyEvent::WriteFailed { token, error, .. } => send_to_client(
+                        &mut client,
+                        &HostEvent::WriteFailed {
+                            token: token.map(|token| token.0.to_string()),
+                            error,
+                        },
+                    ),
+                    PtyEvent::WriteSucceeded { token, .. } => send_to_client(
+                        &mut client,
+                        &HostEvent::WriteSucceeded {
+                            token: token.0.to_string(),
+                        },
+                    ),
+                },
+                HostLoopEvent::ListenerFailed(error) => {
+                    return Err(error).context("failed to accept pane host client");
+                }
             }
         }
 
         if last_exit_poll.elapsed() >= HOST_EXIT_POLL_INTERVAL {
             if pane.poll_exit() {
+                pane.exited = true;
                 send_to_client(&mut client, &HostEvent::Exited);
             }
             last_exit_poll = Instant::now();
         }
 
-        if client.is_none() && !keep_running {
+        if client.is_none()
+            && should_shut_down_detached_host(
+                keep_running,
+                pane.exited,
+                client_process_is_gone(last_owner_pid),
+                client_lost_at.map(|at| at.elapsed()),
+            )
+        {
             pane.terminate();
             return Ok(());
         }
-        thread::sleep(HOST_POLL_INTERVAL);
     }
+}
+
+/// Decide whether a host with no attached client should exit.
+///
+/// A keep-running host deliberately outlives a clean disconnect so a later
+/// GridBash can reattach to it. It must still exit once nothing is left to
+/// reattach to: a dead PTY child has no session to resume, and an owner that
+/// vanished without a replacement would otherwise leave the host — and its
+/// pseudoconsole — running indefinitely.
+fn should_shut_down_detached_host(
+    keep_running: bool,
+    child_exited: bool,
+    owner_gone: bool,
+    detached_for: Option<Duration>,
+) -> bool {
+    if !keep_running || child_exited {
+        return true;
+    }
+    owner_gone && detached_for.is_some_and(|elapsed| elapsed >= ORPHAN_REATTACH_GRACE)
 }
 
 struct HostClient {
     id: u64,
     stream: TcpStream,
+    owner_pid: Option<u32>,
 }
 
 struct AcceptedClient {
@@ -800,13 +1034,66 @@ enum HostInputMessage {
     Closed,
 }
 
+enum HostLoopEvent {
+    Connection(TcpStream),
+    Input(HostInput),
+    Pty(PtyEvent),
+    ListenerFailed(io::Error),
+}
+
+fn spawn_host_acceptor(
+    listener: TcpListener,
+    sender: std_mpsc::SyncSender<HostLoopEvent>,
+) -> Result<()> {
+    thread::Builder::new()
+        .name("gridbash-host-accept".into())
+        .stack_size(HOST_WORKER_STACK_BYTES)
+        .spawn(move || {
+            loop {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        if sender.send(HostLoopEvent::Connection(stream)).is_err() {
+                            return;
+                        }
+                    }
+                    Err(error) => {
+                        let _ = sender.send(HostLoopEvent::ListenerFailed(error));
+                        return;
+                    }
+                }
+            }
+        })
+        .context("failed to start pane host accept worker")?;
+    Ok(())
+}
+
+fn spawn_pty_event_forwarder(
+    mut receiver: mpsc::Receiver<PtyEvent>,
+    sender: std_mpsc::SyncSender<HostLoopEvent>,
+) -> Result<()> {
+    thread::Builder::new()
+        .name("gridbash-host-pty".into())
+        .stack_size(HOST_WORKER_STACK_BYTES)
+        .spawn(move || {
+            while let Some(event) = receiver.blocking_recv() {
+                if sender.send(HostLoopEvent::Pty(event)).is_err() {
+                    return;
+                }
+            }
+        })
+        .context("failed to start pane host PTY event worker")?;
+    Ok(())
+}
+
 fn accept_client(
     mut stream: TcpStream,
     client_id: u64,
     expected_token: &str,
     pane: &LocalPtyPane,
+    codex_sqlite_home: Option<&Path>,
+    started_at_ms: u64,
     background_output: &mut Vec<u8>,
-    command_tx: std_mpsc::Sender<HostInput>,
+    command_tx: std_mpsc::SyncSender<HostLoopEvent>,
 ) -> Result<Option<AcceptedClient>> {
     stream
         .set_nonblocking(false)
@@ -816,6 +1103,8 @@ fn accept_client(
     let reader_stream = stream
         .try_clone()
         .context("failed to clone pane host client")?;
+    prevent_stream_inheritance(&reader_stream)
+        .context("failed to protect pane host client reader from child-process inheritance")?;
     let mut reader = BufReader::new(reader_stream);
     let mut line = String::new();
     reader
@@ -825,6 +1114,7 @@ fn accept_client(
         protocol_version,
         token,
         keep_running,
+        client_pid,
     }) = serde_json::from_str::<HostCommand>(&line)
     else {
         let _ = send_json(
@@ -858,52 +1148,67 @@ fn accept_client(
         &mut stream,
         &HostEvent::Ready {
             protocol_version: PANE_HOST_PROTOCOL_VERSION,
+            host_process_id: Some(std::process::id()),
             background_output: BASE64.encode(&*background_output),
             cwd: pane.cwd().to_path_buf(),
             exited: pane.exited,
+            codex_sqlite_home: codex_sqlite_home.map(Path::to_path_buf),
+            started_at_ms: Some(started_at_ms),
         },
     )?;
-    background_output.clear();
+    release_background_output(background_output);
     reader.get_mut().set_read_timeout(None).ok();
     spawn_host_reader(reader, client_id, command_tx);
     Ok(Some(AcceptedClient {
         client: HostClient {
             id: client_id,
             stream,
+            owner_pid: client_pid,
         },
         keep_running,
     }))
 }
 
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
 fn spawn_host_reader(
     mut reader: BufReader<TcpStream>,
     client_id: u64,
-    sender: std_mpsc::Sender<HostInput>,
+    sender: std_mpsc::SyncSender<HostLoopEvent>,
 ) {
     thread::spawn(move || {
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
+            line.clear();
+            release_line_slack(&mut line);
             match reader.read_line(&mut line) {
                 Ok(0) => break,
                 Ok(_) => match serde_json::from_str::<HostCommand>(&line) {
                     Ok(command) => {
                         if sender
-                            .send(HostInput {
+                            .send(HostLoopEvent::Input(HostInput {
                                 client_id,
                                 message: HostInputMessage::Command(command),
-                            })
+                            }))
                             .is_err()
                         {
                             return;
                         }
                     }
                     Err(error) => {
-                        let _ = sender.send(HostInput {
+                        let _ = sender.send(HostLoopEvent::Input(HostInput {
                             client_id,
                             message: HostInputMessage::Command(HostCommand::Disconnect {
                                 keep_running: false,
                             }),
-                        });
+                        }));
                         let _ = error;
                         return;
                     }
@@ -911,10 +1216,10 @@ fn spawn_host_reader(
                 Err(_) => break,
             }
         }
-        let _ = sender.send(HostInput {
+        let _ = sender.send(HostLoopEvent::Input(HostInput {
             client_id,
             message: HostInputMessage::Closed,
-        });
+        }));
     });
 }
 
@@ -925,8 +1230,10 @@ fn spawn_client_reader(
     event_tx: mpsc::Sender<PtyEvent>,
 ) {
     thread::spawn(move || {
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
+            line.clear();
+            release_line_slack(&mut line);
             let event = match reader.read_line(&mut line) {
                 Ok(0) => break,
                 Ok(_) => serde_json::from_str::<HostEvent>(&line),
@@ -986,7 +1293,7 @@ fn spawn_client_reader(
     });
 }
 
-fn send_to_client(client: &mut Option<HostClient>, event: &HostEvent) {
+fn send_to_client(client: &mut Option<HostClient>, event: &impl Serialize) {
     let failed = client
         .as_mut()
         .is_some_and(|client| send_json(&mut client.stream, event).is_err());
@@ -1001,6 +1308,53 @@ fn disconnect_client(client: &mut Option<HostClient>) {
     }
 }
 
+fn client_process_is_gone(owner_pid: Option<u32>) -> bool {
+    owner_pid.is_some_and(|owner_pid| !process_is_running(owner_pid))
+}
+
+#[cfg(windows)]
+fn prevent_stream_inheritance(stream: &TcpStream) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    prevent_socket_inheritance(stream.as_raw_socket())
+}
+
+#[cfg(not(windows))]
+fn prevent_stream_inheritance(_stream: &TcpStream) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prevent_listener_inheritance(listener: &TcpListener) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    prevent_socket_inheritance(listener.as_raw_socket())
+}
+
+#[cfg(not(windows))]
+fn prevent_listener_inheritance(_listener: &TcpListener) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prevent_socket_inheritance(socket: std::os::windows::io::RawSocket) -> io::Result<()> {
+    use windows_sys::Win32::Foundation::{HANDLE, HANDLE_FLAG_INHERIT, SetHandleInformation};
+
+    let result = unsafe { SetHandleInformation(socket as HANDLE, HANDLE_FLAG_INHERIT, 0) };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// Hand back the detached-mode backlog buffer once a client has taken it.
+///
+/// Clearing in place would keep `BACKGROUND_OUTPUT_LIMIT` bytes of dead
+/// capacity for the rest of the host's life. It reallocates only if the pane
+/// detaches again.
+fn release_background_output(buffer: &mut Vec<u8>) {
+    *buffer = Vec::new();
+}
+
 fn append_background_output(buffer: &mut Vec<u8>, bytes: &[u8]) {
     buffer.extend_from_slice(bytes);
     if buffer.len() > BACKGROUND_OUTPUT_LIMIT {
@@ -1010,11 +1364,38 @@ fn append_background_output(buffer: &mut Vec<u8>, bytes: &[u8]) {
 }
 
 fn send_json(stream: &mut TcpStream, value: &impl Serialize) -> Result<()> {
-    serde_json::to_writer(&mut *stream, value).context("failed to encode pane host message")?;
-    stream
-        .write_all(b"\n")
-        .context("failed to write pane host message")?;
+    thread_local! {
+        static SEND_SCRATCH: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    }
+
+    // Serializing straight into the socket issues a syscall per JSON token, so
+    // encode into a reused buffer and send the framed line in one write.
+    SEND_SCRATCH.with(|scratch| {
+        let mut buffer = scratch.borrow_mut();
+        buffer.clear();
+        serde_json::to_writer(&mut *buffer, value).context("failed to encode pane host message")?;
+        buffer.push(b'\n');
+        let result = stream
+            .write_all(&buffer)
+            .context("failed to write pane host message");
+        release_vec_slack(&mut buffer);
+        result
+    })?;
     stream.flush().context("failed to flush pane host message")
+}
+
+/// Return capacity a reused wire buffer grew past its steady-state size.
+fn release_vec_slack(buffer: &mut Vec<u8>) {
+    if buffer.capacity() > WIRE_SCRATCH_KEEP_BYTES {
+        buffer.shrink_to(WIRE_SCRATCH_KEEP_BYTES);
+    }
+}
+
+/// Return capacity a reused line buffer grew past its steady-state size.
+fn release_line_slack(line: &mut String) {
+    if line.capacity() > WIRE_SCRATCH_KEEP_BYTES {
+        line.shrink_to(WIRE_SCRATCH_KEEP_BYTES);
+    }
 }
 
 fn random_token() -> Result<String> {
@@ -1093,6 +1474,48 @@ fn spawn_detached_host(spec_path: &Path) -> Result<std::process::Child> {
 mod tests {
     use super::*;
 
+    static PANE_HOST_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn detached_hosts_without_keep_running_exit_immediately() {
+        assert!(should_shut_down_detached_host(false, false, false, None));
+    }
+
+    #[test]
+    fn keep_running_hosts_stay_for_a_live_owner() {
+        assert!(!should_shut_down_detached_host(true, false, false, None));
+        assert!(!should_shut_down_detached_host(
+            true,
+            false,
+            false,
+            Some(ORPHAN_REATTACH_GRACE * 2)
+        ));
+    }
+
+    #[test]
+    fn keep_running_hosts_exit_once_their_child_is_gone() {
+        // The leak that stranded pane hosts for hours: the child had exited and
+        // the owning GridBash was gone, but keep_running held the host open.
+        assert!(should_shut_down_detached_host(true, true, false, None));
+        assert!(should_shut_down_detached_host(true, true, true, None));
+    }
+
+    #[test]
+    fn keep_running_hosts_outlive_a_dead_owner_only_for_the_reattach_grace() {
+        assert!(!should_shut_down_detached_host(
+            true,
+            false,
+            true,
+            Some(ORPHAN_REATTACH_GRACE / 2)
+        ));
+        assert!(should_shut_down_detached_host(
+            true,
+            false,
+            true,
+            Some(ORPHAN_REATTACH_GRACE)
+        ));
+    }
+
     struct TestHostFiles {
         directory: PathBuf,
         spec: PathBuf,
@@ -1136,6 +1559,62 @@ mod tests {
     }
 
     #[test]
+    fn borrowed_output_event_is_wire_identical_to_the_owned_variant() {
+        let encoded = BASE64.encode(b"hello\0\x1b[31m");
+        let owned = serde_json::to_string(&HostEvent::Output {
+            data: encoded.clone(),
+        })
+        .expect("serialize owned event");
+        let borrowed = serde_json::to_string(&HostOutputEvent {
+            kind: "output",
+            data: &encoded,
+        })
+        .expect("serialize borrowed event");
+
+        assert_eq!(owned, borrowed);
+        // Clients built against the released protocol must still parse it.
+        let HostEvent::Output { data } =
+            serde_json::from_str::<HostEvent>(&borrowed).expect("parse borrowed event")
+        else {
+            panic!("wrong event kind");
+        };
+        assert_eq!(BASE64.decode(data).expect("decode"), b"hello\0\x1b[31m");
+    }
+
+    #[test]
+    fn wire_scratch_buffers_release_oversized_bursts() {
+        let mut buffer = Vec::with_capacity(WIRE_SCRATCH_KEEP_BYTES * 8);
+        release_vec_slack(&mut buffer);
+        assert!(buffer.capacity() <= WIRE_SCRATCH_KEEP_BYTES);
+
+        let mut line = String::with_capacity(WIRE_SCRATCH_KEEP_BYTES * 8);
+        release_line_slack(&mut line);
+        assert!(line.capacity() <= WIRE_SCRATCH_KEEP_BYTES);
+
+        // Steady-state buffers are left alone so appends do not reallocate.
+        let mut steady = Vec::with_capacity(WIRE_SCRATCH_KEEP_BYTES);
+        release_vec_slack(&mut steady);
+        assert_eq!(steady.capacity(), WIRE_SCRATCH_KEEP_BYTES);
+    }
+
+    #[test]
+    fn hello_protocol_accepts_clients_without_owner_pid() {
+        let raw = r#"{"type":"hello","protocol_version":1,"token":"secret","keep_running":true}"#;
+        let command = serde_json::from_str::<HostCommand>(raw).expect("parse legacy hello");
+        let HostCommand::Hello { client_pid, .. } = command else {
+            panic!("wrong command kind");
+        };
+        assert_eq!(client_pid, None);
+    }
+
+    #[test]
+    fn stale_client_detection_requires_a_known_dead_owner() {
+        assert!(!client_process_is_gone(None));
+        assert!(!client_process_is_gone(Some(std::process::id())));
+        assert!(client_process_is_gone(Some(u32::MAX)));
+    }
+
+    #[test]
     fn background_output_keeps_a_bounded_tail() {
         let mut output = vec![b'a'; BACKGROUND_OUTPUT_LIMIT];
         append_background_output(&mut output, b"latest");
@@ -1144,7 +1623,20 @@ mod tests {
     }
 
     #[test]
+    fn reattaching_releases_the_background_output_buffer() {
+        let mut output = vec![b'a'; BACKGROUND_OUTPUT_LIMIT];
+
+        release_background_output(&mut output);
+
+        assert_eq!(output.capacity(), 0);
+        // A later detach still buffers normally.
+        append_background_output(&mut output, b"after reattach");
+        assert_eq!(output, b"after reattach");
+    }
+
+    #[test]
     fn pane_host_survives_disconnect_and_accepts_reattach() {
+        let _guard = PANE_HOST_TEST_LOCK.lock().expect("lock pane host test");
         let files = TestHostFiles::new();
         let host_token = random_token().expect("host token");
         #[cfg(windows)]
@@ -1185,6 +1677,9 @@ mod tests {
         let host = PtyHostRef {
             endpoint: ready.endpoint,
             token: host_token,
+            process_id: None,
+            codex_sqlite_home: None,
+            started_at_ms: None,
         };
         let (first_tx, mut first_rx) = mpsc::channel(32);
         let first = PtyPane::attach(
@@ -1254,6 +1749,104 @@ mod tests {
             .expect("pane host exits cleanly");
     }
 
+    #[test]
+    fn pane_host_replaces_a_client_owned_by_a_dead_process() {
+        let _guard = PANE_HOST_TEST_LOCK.lock().expect("lock pane host test");
+        let files = TestHostFiles::new();
+        let host_token = random_token().expect("host token");
+        #[cfg(windows)]
+        let (profile_name, command, args, line_ending) = (
+            "cmd",
+            PathBuf::from("cmd.exe"),
+            vec!["/d".to_string(), "/q".to_string()],
+            "\r",
+        );
+        #[cfg(unix)]
+        let (profile_name, command, args, line_ending) =
+            ("sh", PathBuf::from("/bin/sh"), vec!["-i".to_string()], "\n");
+        let spec = HostLaunchSpec {
+            token: host_token.clone(),
+            ready_path: files.ready.clone(),
+            profile_name: profile_name.into(),
+            pane_id: 8,
+            generation: 0,
+            command,
+            args,
+            env: BTreeMap::new(),
+            cwd: std::env::current_dir().expect("current directory"),
+            extra_env: Vec::new(),
+            scrollback_rows: 1_000,
+            process_priority: PaneProcessPriority::Normal,
+            workload_policy: PaneWorkloadPolicy::Unrestricted,
+            keep_running: true,
+        };
+        fs::write(
+            &files.spec,
+            serde_json::to_vec(&spec).expect("serialize host spec"),
+        )
+        .expect("write host spec");
+        let spec_path = files.spec.clone();
+        let host_thread = thread::spawn(move || run_pane_host(&spec_path));
+
+        let ready = wait_for_ready(&files.ready);
+        let mut stale = TcpStream::connect(&ready.endpoint).expect("connect stale client");
+        send_json(
+            &mut stale,
+            &HostCommand::Hello {
+                protocol_version: PANE_HOST_PROTOCOL_VERSION,
+                token: host_token.clone(),
+                keep_running: true,
+                client_pid: Some(u32::MAX),
+            },
+        )
+        .expect("send stale hello");
+        let mut stale_reader = BufReader::new(stale.try_clone().expect("clone stale client"));
+        let mut hello = String::new();
+        stale_reader
+            .read_line(&mut hello)
+            .expect("read stale client handshake");
+        assert!(matches!(
+            serde_json::from_str::<HostEvent>(&hello).expect("parse stale handshake"),
+            HostEvent::Ready { .. }
+        ));
+
+        let host = PtyHostRef {
+            endpoint: ready.endpoint,
+            token: host_token,
+            process_id: None,
+            codex_sqlite_home: None,
+            started_at_ms: None,
+        };
+        let (replacement_tx, mut replacement_rx) = mpsc::channel(8);
+        let mut replacement = PtyPane::attach(
+            host,
+            PaneId(8),
+            0,
+            &spec.cwd,
+            1_000,
+            true,
+            "",
+            &[],
+            replacement_tx,
+        )
+        .expect("replacement client takes over");
+        replacement
+            .write(format!("exit{line_ending}").as_bytes())
+            .expect("exit replacement shell");
+        assert_pane_exits(&mut replacement_rx);
+        replacement
+            .set_keep_running(false)
+            .expect("disable host persistence");
+        drop(replacement);
+        drop(stale_reader);
+        drop(stale);
+
+        host_thread
+            .join()
+            .expect("join pane host")
+            .expect("pane host exits cleanly");
+    }
+
     fn wait_for_ready(path: &Path) -> HostReadyFile {
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
@@ -1286,5 +1879,20 @@ mod tests {
             }
         }
         panic!("expected output {expected:?}, got {output:?}");
+    }
+
+    fn assert_pane_exits(receiver: &mut mpsc::Receiver<PtyEvent>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            match receiver.try_recv() {
+                Ok(PtyEvent::Exited { .. }) => return,
+                Ok(PtyEvent::WriteFailed { error, .. }) => panic!("pane write failed: {error}"),
+                Ok(_) | Err(mpsc::error::TryRecvError::Empty) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => break,
+            }
+        }
+        panic!("expected pane to exit");
     }
 }

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -1,0 +1,660 @@
+use std::{
+    collections::{HashMap, HashSet},
+    io::{self, Read},
+    process::{Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+const INSPECTOR_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const INSPECTOR_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentProcessRoot {
+    pub pid: u32,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentPort {
+    pub port: u16,
+    pub pid: u32,
+    pub process: String,
+    pub owner: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessInfo {
+    parent_pid: u32,
+    name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ListeningSocket {
+    port: u16,
+    pid: u32,
+    process: Option<String>,
+}
+
+pub fn discover_agent_ports(roots: &[AgentProcessRoot]) -> io::Result<Vec<AgentPort>> {
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let processes = process_snapshot()?;
+    let listeners = listening_sockets()?;
+    Ok(associate_agent_ports(roots, &processes, listeners))
+}
+
+pub fn terminate_process(pid: u32) -> io::Result<()> {
+    if pid == 0 || pid == std::process::id() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "refusing to terminate an invalid or current process",
+        ));
+    }
+
+    terminate_process_platform(pid)
+}
+
+pub fn roots_with_descendant_named(roots: &[u32], expected_name: &str) -> io::Result<HashSet<u32>> {
+    if roots.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let processes = process_snapshot()?;
+    let roots = roots.iter().copied().collect::<HashSet<_>>();
+    let expected_name = expected_name.trim_end_matches(".exe").to_ascii_lowercase();
+    Ok(processes
+        .iter()
+        .filter(|(_, process)| {
+            let name = process
+                .name
+                .rsplit(['/', '\\'])
+                .next()
+                .unwrap_or(&process.name)
+                .to_ascii_lowercase();
+            name.trim_end_matches(".exe") == expected_name
+        })
+        .filter_map(|(pid, _)| descendant_root(*pid, &processes, &roots))
+        .collect())
+}
+
+fn descendant_root(
+    pid: u32,
+    processes: &HashMap<u32, ProcessInfo>,
+    roots: &HashSet<u32>,
+) -> Option<u32> {
+    let mut current = pid;
+    let mut visited = HashSet::new();
+    for _ in 0..64 {
+        if !visited.insert(current) {
+            return None;
+        }
+        let parent = processes.get(&current)?.parent_pid;
+        if roots.contains(&parent) {
+            return Some(parent);
+        }
+        if parent == 0 || parent == current {
+            return None;
+        }
+        current = parent;
+    }
+    None
+}
+
+fn associate_agent_ports(
+    roots: &[AgentProcessRoot],
+    processes: &HashMap<u32, ProcessInfo>,
+    listeners: Vec<ListeningSocket>,
+) -> Vec<AgentPort> {
+    let roots = roots
+        .iter()
+        .filter(|root| {
+            processes
+                .get(&root.pid)
+                .is_some_and(|process| is_gridbash_host(&process.name))
+        })
+        .map(|root| (root.pid, root.label.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut seen = HashSet::new();
+    let mut ports = listeners
+        .into_iter()
+        .filter_map(|listener| {
+            let owner = process_root(listener.pid, processes, &roots)?;
+            seen.insert((listener.port, listener.pid))
+                .then(|| AgentPort {
+                    port: listener.port,
+                    pid: listener.pid,
+                    process: listener
+                        .process
+                        .filter(|name| !name.is_empty())
+                        .or_else(|| {
+                            processes
+                                .get(&listener.pid)
+                                .map(|process| process.name.clone())
+                        })
+                        .unwrap_or_else(|| "unknown".into()),
+                    owner: owner.to_string(),
+                })
+        })
+        .collect::<Vec<_>>();
+    ports.sort_by(|left, right| {
+        left.port
+            .cmp(&right.port)
+            .then_with(|| left.pid.cmp(&right.pid))
+    });
+    ports
+}
+
+fn is_gridbash_host(process_name: &str) -> bool {
+    process_name
+        .rsplit(['/', '\\'])
+        .next()
+        .is_some_and(|name| name.to_ascii_lowercase().starts_with("gridbash"))
+}
+
+fn process_root<'a>(
+    pid: u32,
+    processes: &HashMap<u32, ProcessInfo>,
+    roots: &HashMap<u32, &'a str>,
+) -> Option<&'a str> {
+    let mut current = pid;
+    let mut visited = HashSet::new();
+    for _ in 0..64 {
+        if !visited.insert(current) {
+            return None;
+        }
+        let parent = processes.get(&current)?.parent_pid;
+        if let Some(label) = roots.get(&parent) {
+            return Some(*label);
+        }
+        if parent == 0 || parent == current {
+            return None;
+        }
+        current = parent;
+    }
+    None
+}
+
+fn endpoint_port(endpoint: &str) -> Option<u16> {
+    endpoint
+        .trim()
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.trim_end_matches(']').parse().ok())
+}
+
+#[cfg(windows)]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    let mut command = Command::new("netstat");
+    command.args(["-ano", "-p", "tcp"]);
+    let output = command_output_with_timeout(&mut command)?;
+    if !output.status.success() {
+        return Err(io::Error::other("netstat failed while listing TCP ports"));
+    }
+    Ok(parse_windows_netstat(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+#[cfg(windows)]
+fn parse_windows_netstat(output: &str) -> Vec<ListeningSocket> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            if fields.len() < 5
+                || !fields[0].eq_ignore_ascii_case("TCP")
+                || !fields[3].eq_ignore_ascii_case("LISTENING")
+            {
+                return None;
+            }
+            Some(ListeningSocket {
+                port: endpoint_port(fields[1])?,
+                pid: fields[4].parse().ok()?,
+                process: None,
+            })
+        })
+        .collect()
+}
+
+#[cfg(windows)]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    use std::mem;
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW,
+            TH32CS_SNAPPROCESS,
+        },
+    };
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut entry = unsafe { mem::zeroed::<PROCESSENTRY32W>() };
+    entry.dwSize = mem::size_of::<PROCESSENTRY32W>() as u32;
+    let mut processes = HashMap::new();
+    let mut success = unsafe { Process32FirstW(snapshot, &mut entry) };
+    while success != 0 {
+        let length = entry
+            .szExeFile
+            .iter()
+            .position(|unit| *unit == 0)
+            .unwrap_or(entry.szExeFile.len());
+        let name = String::from_utf16_lossy(&entry.szExeFile[..length]);
+        processes.insert(
+            entry.th32ProcessID,
+            ProcessInfo {
+                parent_pid: entry.th32ParentProcessID,
+                name,
+            },
+        );
+        success = unsafe { Process32NextW(snapshot, &mut entry) };
+    }
+    unsafe { CloseHandle(snapshot) };
+    Ok(processes)
+}
+
+#[cfg(windows)]
+fn terminate_process_platform(pid: u32) -> io::Result<()> {
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{OpenProcess, PROCESS_TERMINATE, TerminateProcess},
+    };
+
+    let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if process.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let result = unsafe { TerminateProcess(process, 1) };
+    let error = (result == 0).then(io::Error::last_os_error);
+    unsafe { CloseHandle(process) };
+    error.map_or(Ok(()), Err)
+}
+
+#[cfg(unix)]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    let lsof = if cfg!(target_os = "macos") {
+        "/usr/sbin/lsof"
+    } else {
+        "lsof"
+    };
+    let mut command = Command::new(lsof);
+    command.args(["-nP", "-iTCP", "-sTCP:LISTEN", "-Fpcn"]);
+    match command_output_with_timeout(&mut command) {
+        Ok(output) if output.status.success() || !output.stdout.is_empty() => {
+            return Ok(parse_lsof(&String::from_utf8_lossy(&output.stdout)));
+        }
+        _ => {}
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut command = Command::new("ss");
+        command.args(["-H", "-ltnp"]);
+        let output = command_output_with_timeout(&mut command)?;
+        if output.status.success() {
+            return Ok(parse_linux_ss(&String::from_utf8_lossy(&output.stdout)));
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "neither lsof nor a supported socket inspector is available",
+    ))
+}
+
+#[cfg(unix)]
+fn parse_lsof(output: &str) -> Vec<ListeningSocket> {
+    let mut pid = None;
+    let mut process = None::<String>;
+    let mut listeners = Vec::new();
+    for line in output.lines() {
+        let Some(tag) = line.get(..1) else {
+            continue;
+        };
+        let value = &line[1..];
+        match tag {
+            "p" => {
+                pid = value.parse().ok();
+                process = None;
+            }
+            "c" => process = Some(value.to_string()),
+            "n" => {
+                if let (Some(pid), Some(port)) = (pid, endpoint_port(value)) {
+                    listeners.push(ListeningSocket {
+                        port,
+                        pid,
+                        process: process.clone(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    listeners
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_ss(output: &str) -> Vec<ListeningSocket> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let fields = line.split_whitespace().collect::<Vec<_>>();
+            let local = *fields.get(3)?;
+            let details = fields.get(5..)?.join(" ");
+            let pid_start = details.find("pid=")? + 4;
+            let pid_end = details[pid_start..]
+                .find(|ch: char| !ch.is_ascii_digit())
+                .map(|offset| pid_start + offset)
+                .unwrap_or(details.len());
+            let pid = details[pid_start..pid_end].parse().ok()?;
+            let process = details
+                .split_once("((\"")
+                .and_then(|(_, tail)| tail.split_once('"'))
+                .map(|(name, _)| name.to_string());
+            Some(ListeningSocket {
+                port: endpoint_port(local)?,
+                pid,
+                process,
+            })
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    let mut processes = HashMap::new();
+    for entry in std::fs::read_dir("/proc")? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let Some(name_start) = stat.find('(') else {
+            continue;
+        };
+        let Some(name_end) = stat.rfind(')') else {
+            continue;
+        };
+        let Some(parent_pid) = stat[name_end + 1..]
+            .split_whitespace()
+            .nth(1)
+            .and_then(|value| value.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        processes.insert(
+            pid,
+            ProcessInfo {
+                parent_pid,
+                name: stat[name_start + 1..name_end].to_string(),
+            },
+        );
+    }
+    Ok(processes)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    let mut command = Command::new("ps");
+    command.args(["-axo", "pid=,ppid=,comm="]);
+    let output = command_output_with_timeout(&mut command)?;
+    if !output.status.success() {
+        return Err(io::Error::other("ps failed while listing processes"));
+    }
+    Ok(parse_ps(&String::from_utf8_lossy(&output.stdout)))
+}
+
+fn command_output_with_timeout(command: &mut Command) -> io::Result<Output> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("failed to capture inspector stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("failed to capture inspector stderr"))?;
+    let stdout_reader = thread::spawn(move || read_all(stdout));
+    let stderr_reader = thread::spawn(move || read_all(stderr));
+    let deadline = Instant::now() + INSPECTOR_COMMAND_TIMEOUT;
+
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "port inspection command timed out",
+            ));
+        }
+        thread::sleep(INSPECTOR_COMMAND_POLL_INTERVAL);
+    };
+
+    Ok(Output {
+        status,
+        stdout: join_reader(stdout_reader)?,
+        stderr: join_reader(stderr_reader)?,
+    })
+}
+
+fn read_all(mut reader: impl Read) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+fn join_reader(reader: thread::JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u8>> {
+    reader
+        .join()
+        .map_err(|_| io::Error::other("port inspection output reader panicked"))?
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn parse_ps(output: &str) -> HashMap<u32, ProcessInfo> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields.next()?.parse().ok()?;
+            let parent_pid = fields.next()?.parse().ok()?;
+            let name = fields.next()?.rsplit('/').next()?.to_string();
+            Some((pid, ProcessInfo { parent_pid, name }))
+        })
+        .collect()
+}
+
+#[cfg(unix)]
+fn terminate_process_platform(pid: u32) -> io::Result<()> {
+    let pid = i32::try_from(pid)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "process ID is too large"))?;
+    let result = unsafe { libc::kill(pid, libc::SIGTERM) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+fn listening_sockets() -> io::Result<Vec<ListeningSocket>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "port discovery is not supported on this platform",
+    ))
+}
+
+#[cfg(not(any(windows, unix)))]
+fn process_snapshot() -> io::Result<HashMap<u32, ProcessInfo>> {
+    Ok(HashMap::new())
+}
+
+#[cfg(not(any(windows, unix)))]
+fn terminate_process_platform(_pid: u32) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "process termination is not supported on this platform",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn associates_only_descendants_of_agent_roots() {
+        let roots = vec![AgentProcessRoot {
+            pid: 10,
+            label: "Grid 1 / Pane 2".into(),
+        }];
+        let processes = HashMap::from([
+            (
+                10,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "gridbash".into(),
+                },
+            ),
+            (
+                20,
+                ProcessInfo {
+                    parent_pid: 10,
+                    name: "codex".into(),
+                },
+            ),
+            (
+                30,
+                ProcessInfo {
+                    parent_pid: 20,
+                    name: "node".into(),
+                },
+            ),
+            (
+                40,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "postgres".into(),
+                },
+            ),
+        ]);
+        let listeners = vec![
+            ListeningSocket {
+                port: 41_000,
+                pid: 10,
+                process: None,
+            },
+            ListeningSocket {
+                port: 3000,
+                pid: 30,
+                process: None,
+            },
+            ListeningSocket {
+                port: 5432,
+                pid: 40,
+                process: None,
+            },
+        ];
+
+        assert_eq!(
+            associate_agent_ports(&roots, &processes, listeners),
+            vec![AgentPort {
+                port: 3000,
+                pid: 30,
+                process: "node".into(),
+                owner: "Grid 1 / Pane 2".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn finds_the_owning_root_for_nested_processes() {
+        let processes = HashMap::from([
+            (
+                10,
+                ProcessInfo {
+                    parent_pid: 1,
+                    name: "gridbash".into(),
+                },
+            ),
+            (
+                20,
+                ProcessInfo {
+                    parent_pid: 10,
+                    name: "bash".into(),
+                },
+            ),
+            (
+                30,
+                ProcessInfo {
+                    parent_pid: 20,
+                    name: "codex".into(),
+                },
+            ),
+        ]);
+        let roots = HashSet::from([10]);
+
+        assert_eq!(descendant_root(30, &processes, &roots), Some(10));
+        assert_eq!(descendant_root(10, &processes, &roots), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parses_windows_tcp_listeners() {
+        let output = r#"
+  TCP    0.0.0.0:3000           0.0.0.0:0              LISTENING       1234
+  TCP    [::1]:8080             [::]:0                 LISTENING       4321
+  TCP    127.0.0.1:5000         127.0.0.1:6000         ESTABLISHED     9999
+"#;
+        assert_eq!(
+            parse_windows_netstat(output),
+            vec![
+                ListeningSocket {
+                    port: 3000,
+                    pid: 1234,
+                    process: None,
+                },
+                ListeningSocket {
+                    port: 8080,
+                    pid: 4321,
+                    process: None,
+                },
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_lsof_machine_output() {
+        let output = "p1234\ncnode\nf19\nPIPv4\nn*:3000\nn127.0.0.1:3001\n";
+        assert_eq!(
+            parse_lsof(output),
+            vec![
+                ListeningSocket {
+                    port: 3000,
+                    pid: 1234,
+                    process: Some("node".into()),
+                },
+                ListeningSocket {
+                    port: 3001,
+                    pid: 1234,
+                    process: Some("node".into()),
+                },
+            ]
+        );
+    }
+}

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -39,6 +39,10 @@ const MAX_REPLAY_OUTPUT_CHARS: usize = 18_000;
 const MAX_OSC_SCAN: usize = 4096;
 const PTY_READ_BUFFER_BYTES: usize = 32 * 1024;
 const PTY_WRITE_QUEUE_MESSAGES: usize = 256;
+/// PTY reader/writer threads only shuttle bytes between a pipe and a channel,
+/// so the platform default stack (1 MiB on Windows, 8 MiB on glibc) is reserved
+/// for nothing. The reader keeps a `PTY_READ_BUFFER_BYTES` array on its stack.
+const PTY_WORKER_STACK_BYTES: usize = 128 * 1024;
 const CHILD_REAP_GRACE: Duration = Duration::from_millis(100);
 const CHILD_REAP_AFTER_FORCE: Duration = Duration::from_millis(400);
 const CHILD_REAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -255,12 +259,28 @@ pub(crate) struct PtyView {
     input_revision: u64,
     output_tail: String,
     output_tail_chars: usize,
+    tracks_history: bool,
 }
 
 impl PtyView {
     pub(crate) fn new(cwd: PathBuf, scrollback_rows: usize) -> Self {
+        Self::with_history(cwd, scrollback_rows.clamp(1_000, 50_000), true)
+    }
+
+    /// View for a process that never renders the pane: the pane host.
+    ///
+    /// The host answers cursor-position queries and tracks the working
+    /// directory, so it still needs a parser for the visible grid, but the
+    /// GridBash client keeps the only copy of the scrollback and the plain-text
+    /// tail that anything actually reads. Keeping a second copy per pane host
+    /// costs `scrollback_rows * cols * 32` bytes for nothing.
+    pub(crate) fn headless(cwd: PathBuf) -> Self {
+        Self::with_history(cwd, 0, false)
+    }
+
+    fn with_history(cwd: PathBuf, scrollback_rows: usize, tracks_history: bool) -> Self {
         Self {
-            parser: Parser::new(24, 80, scrollback_rows.clamp(1_000, 50_000)),
+            parser: Parser::new(24, 80, scrollback_rows),
             screen_revision: 0,
             cwd,
             rows: 24,
@@ -273,6 +293,7 @@ impl PtyView {
             input_revision: 0,
             output_tail: String::new(),
             output_tail_chars: 0,
+            tracks_history,
         }
     }
 
@@ -317,10 +338,13 @@ impl PtyView {
     pub(crate) fn process_output(&mut self, bytes: &[u8]) -> String {
         self.update_cwd_from_osc7(bytes);
         self.parser.process(bytes);
-        let (plain, plain_chars) = plain_terminal_text_with_char_count(bytes);
-        self.append_plain_output(&plain, plain_chars);
         self.screen_revision = self.screen_revision.wrapping_add(1);
         self.output_activity.record_output(Instant::now());
+        if !self.tracks_history {
+            return String::new();
+        }
+        let (plain, plain_chars) = plain_terminal_text_with_char_count(bytes);
+        self.append_plain_output(&plain, plain_chars);
         plain
     }
 
@@ -334,6 +358,9 @@ impl PtyView {
 
     pub(crate) fn record_input(&mut self, bytes: &[u8]) {
         self.record_input_activity(bytes);
+        if !self.tracks_history {
+            return;
+        }
         record_input_bytes(bytes, &mut self.pending_input, &mut self.input_history);
     }
 
@@ -358,9 +385,20 @@ impl PtyView {
     }
 
     pub(crate) fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
+        self.restore_history_state(output_tail, input_history);
+
+        let replay = history_replay_text(&self.output_tail, &self.input_history);
+        if !replay.is_empty() {
+            self.parser.process(replay.as_bytes());
+            self.screen_revision = self.screen_revision.wrapping_add(1);
+        }
+    }
+
+    pub(crate) fn restore_history_state(&mut self, output_tail: &str, input_history: &[String]) {
         self.output_tail = output_tail.to_string();
         trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
         self.output_tail_chars = self.output_tail.chars().count();
+        release_string_slack(&mut self.output_tail);
         self.input_history = input_history
             .iter()
             .filter(|line| !line.trim().is_empty())
@@ -369,12 +407,6 @@ impl PtyView {
             .cloned()
             .collect::<Vec<_>>();
         self.input_history.reverse();
-
-        let replay = history_replay_text(&self.output_tail, &self.input_history);
-        if !replay.is_empty() {
-            self.parser.process(replay.as_bytes());
-            self.screen_revision = self.screen_revision.wrapping_add(1);
-        }
     }
 
     pub(crate) fn resize_view(&mut self, rows: u16, cols: u16) -> bool {
@@ -392,17 +424,24 @@ impl PtyView {
         if self.osc_scan_tail.is_empty() && !bytes.contains(&0x1b) {
             return;
         }
-        let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
-        scan.extend_from_slice(&self.osc_scan_tail);
-        scan.extend_from_slice(bytes);
+        // Most chunks carry no partial OSC sequence from the previous read, so
+        // borrow them instead of copying every read buffer onto the heap.
+        let scan = if self.osc_scan_tail.is_empty() {
+            Cow::Borrowed(bytes)
+        } else {
+            let mut scan = Vec::with_capacity(self.osc_scan_tail.len() + bytes.len());
+            scan.extend_from_slice(&self.osc_scan_tail);
+            scan.extend_from_slice(bytes);
+            Cow::Owned(scan)
+        };
 
-        for payload in osc_payloads(&scan) {
+        for payload in osc_payloads(scan.as_ref()) {
             if let Some(path) = cwd_from_osc7_payload(payload) {
                 self.cwd = path;
             }
         }
 
-        self.osc_scan_tail = incomplete_osc_tail(&scan);
+        self.osc_scan_tail = incomplete_osc_tail(scan.as_ref());
     }
 
     fn append_plain_output(&mut self, plain: &str, plain_chars: usize) {
@@ -415,6 +454,7 @@ impl PtyView {
         if self.output_tail_chars > OUTPUT_TAIL_TRIM_AT_CHARS {
             trim_string_tail(&mut self.output_tail, MAX_OUTPUT_TAIL_CHARS);
             self.output_tail_chars = self.output_tail.chars().count();
+            release_string_slack(&mut self.output_tail);
         }
     }
 }
@@ -432,7 +472,6 @@ impl PtyPane {
         cwd: &Path,
         extra_env: &[(OsString, OsString)],
         codex_sqlite_lease: Option<CodexSqliteLease>,
-        scrollback_rows: usize,
         process_priority: PaneProcessPriority,
         workload_policy: PaneWorkloadPolicy,
         event_tx: mpsc::Sender<PtyEvent>,
@@ -491,8 +530,8 @@ impl PtyPane {
             .master
             .take_writer()
             .context("failed to open PTY writer")?;
-        let writer = spawn_writer(id, generation, event_tx.clone(), writer);
-        spawn_reader(id, generation, event_tx, reader);
+        let writer = spawn_writer(id, generation, event_tx.clone(), writer)?;
+        spawn_reader(id, generation, event_tx, reader)?;
 
         let mut pane = Self {
             id,
@@ -502,7 +541,7 @@ impl PtyPane {
             writer,
             workload,
             workload_error,
-            view: PtyView::new(cwd.to_path_buf(), scrollback_rows),
+            view: PtyView::headless(cwd.to_path_buf()),
             active: false,
             exited: false,
             child_reaped: false,
@@ -589,6 +628,10 @@ impl PtyPane {
     pub fn restore_history_display(&mut self, output_tail: &str, input_history: &[String]) {
         self.view
             .restore_history_display(output_tail, input_history);
+    }
+
+    pub fn restore_history_state(&mut self, output_tail: &str, input_history: &[String]) {
+        self.view.restore_history_state(output_tail, input_history);
     }
 
     pub fn write(&self, bytes: &[u8]) -> Result<()> {
@@ -754,10 +797,10 @@ fn screen_history_lines(screen: &mut Screen) -> Vec<String> {
     let original_scrollback = screen.scrollback();
     let (rows, columns) = screen.size();
     let page_rows = usize::from(rows).max(1);
-    let mut lines = Vec::new();
 
     screen.set_scrollback(usize::MAX);
     let history_rows = screen.scrollback();
+    let mut lines = Vec::with_capacity(history_rows + page_rows);
     let mut history_start = 0;
     while history_start < history_rows {
         screen.set_scrollback(history_rows - history_start);
@@ -773,7 +816,13 @@ fn screen_history_lines(screen: &mut Screen) -> Vec<String> {
     let first_content = lines.iter().position(|line| !line.is_empty());
     let last_content = lines.iter().rposition(|line| !line.is_empty());
     match (first_content, last_content) {
-        (Some(first), Some(last)) => lines[first..=last].to_vec(),
+        // Trim in place: cloning the slice would briefly hold two copies of the
+        // whole scrollback, which for a full 50 000-row pane is tens of MB.
+        (Some(first), Some(last)) => {
+            lines.truncate(last + 1);
+            lines.drain(..first);
+            lines
+        }
         _ => vec![String::new()],
     }
 }
@@ -862,29 +911,34 @@ fn spawn_reader(
     generation: u64,
     event_tx: mpsc::Sender<PtyEvent>,
     mut reader: Box<dyn Read + Send>,
-) {
-    thread::spawn(move || {
-        let mut buffer = [0_u8; PTY_READ_BUFFER_BYTES];
-        loop {
-            match reader.read(&mut buffer) {
-                Ok(0) => {
-                    let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
-                    break;
-                }
-                Ok(n) => {
-                    let _ = event_tx.blocking_send(PtyEvent::Output {
-                        pane,
-                        generation,
-                        bytes: buffer[..n].to_vec(),
-                    });
-                }
-                Err(_) => {
-                    let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
-                    break;
+) -> Result<()> {
+    thread::Builder::new()
+        .name("gridbash-pty-read".into())
+        .stack_size(PTY_WORKER_STACK_BYTES)
+        .spawn(move || {
+            let mut buffer = vec![0_u8; PTY_READ_BUFFER_BYTES];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => {
+                        let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
+                        break;
+                    }
+                    Ok(n) => {
+                        let _ = event_tx.blocking_send(PtyEvent::Output {
+                            pane,
+                            generation,
+                            bytes: buffer[..n].to_vec(),
+                        });
+                    }
+                    Err(_) => {
+                        let _ = event_tx.blocking_send(PtyEvent::Exited { pane, generation });
+                        break;
+                    }
                 }
             }
-        }
-    });
+        })
+        .context("failed to start PTY reader")?;
+    Ok(())
 }
 
 fn spawn_writer(
@@ -892,51 +946,55 @@ fn spawn_writer(
     generation: u64,
     event_tx: mpsc::Sender<PtyEvent>,
     mut writer: Box<dyn Write + Send>,
-) -> PtyWriterQueue {
+) -> Result<PtyWriterQueue> {
     let (tx, rx) = sync_channel::<PtyWrite>(PTY_WRITE_QUEUE_MESSAGES);
     let status = Arc::new(Mutex::new(PtyWriterStatus::Open));
     let worker_status = status.clone();
-    thread::spawn(move || {
-        while let Ok(write) = rx.recv() {
-            let result = writer
-                .write_all(&write.bytes)
-                .and_then(|()| writer.flush())
-                .context("failed to write to PTY");
-            match result {
-                Ok(()) => {
-                    if let Some(token) = write.token {
-                        let _ = event_tx.blocking_send(PtyEvent::WriteSucceeded {
-                            pane,
-                            generation,
-                            token,
-                        });
+    thread::Builder::new()
+        .name("gridbash-pty-write".into())
+        .stack_size(PTY_WORKER_STACK_BYTES)
+        .spawn(move || {
+            while let Ok(write) = rx.recv() {
+                let result = writer
+                    .write_all(&write.bytes)
+                    .and_then(|()| writer.flush())
+                    .context("failed to write to PTY");
+                match result {
+                    Ok(()) => {
+                        if let Some(token) = write.token {
+                            let _ = event_tx.blocking_send(PtyEvent::WriteSucceeded {
+                                pane,
+                                generation,
+                                token,
+                            });
+                        }
                     }
-                }
-                Err(error) => {
-                    let error = format!("{error:#}");
-                    let queued = fail_writer_queue(&worker_status, &rx);
-                    let _ = event_tx.blocking_send(PtyEvent::WriteFailed {
-                        pane,
-                        generation,
-                        token: write.token,
-                        error: error.clone(),
-                    });
-                    for queued in queued.into_iter().filter(|queued| queued.token.is_some()) {
+                    Err(error) => {
+                        let error = format!("{error:#}");
+                        let queued = fail_writer_queue(&worker_status, &rx);
                         let _ = event_tx.blocking_send(PtyEvent::WriteFailed {
                             pane,
                             generation,
-                            token: queued.token,
-                            error: format!(
-                                "PTY writer stopped before queued input was written: {error}"
-                            ),
+                            token: write.token,
+                            error: error.clone(),
                         });
+                        for queued in queued.into_iter().filter(|queued| queued.token.is_some()) {
+                            let _ = event_tx.blocking_send(PtyEvent::WriteFailed {
+                                pane,
+                                generation,
+                                token: queued.token,
+                                error: format!(
+                                    "PTY writer stopped before queued input was written: {error}"
+                                ),
+                            });
+                        }
+                        break;
                     }
-                    break;
                 }
             }
-        }
-    });
-    PtyWriterQueue { sender: tx, status }
+        })
+        .context("failed to start PTY writer")?;
+    Ok(PtyWriterQueue { sender: tx, status })
 }
 
 fn fail_writer_queue(
@@ -1187,7 +1245,7 @@ fn plain_terminal_text_with_char_count(bytes: &[u8]) -> (String, usize) {
     let raw = String::from_utf8_lossy(bytes);
     let bytes = raw.as_bytes();
     let mut plain = String::with_capacity(bytes.len());
-    let mut plain_chars = 0;
+    let mut plain_chars = 0_usize;
     let mut index = 0;
 
     while index < bytes.len() {
@@ -1207,7 +1265,7 @@ fn plain_terminal_text_with_char_count(bytes: &[u8]) -> (String, usize) {
             }
             0x08 => {
                 if plain.pop().is_some() {
-                    plain_chars -= 1;
+                    plain_chars = plain_chars.saturating_sub(1);
                 }
                 index += 1;
             }
@@ -1221,14 +1279,21 @@ fn plain_terminal_text_with_char_count(bytes: &[u8]) -> (String, usize) {
                 {
                     index += 1;
                 }
-                plain.push_str(&raw[start..index]);
-                plain_chars += index - start;
+                // Every byte in this run is ASCII, so both ends are character
+                // boundaries; `get` keeps a desynced index from panicking.
+                if let Some(run) = raw.get(start..index) {
+                    plain.push_str(run);
+                    plain_chars += run.chars().count();
+                }
             }
             _ => {
-                let ch = raw[index..]
-                    .chars()
-                    .next()
-                    .expect("index remains on a UTF-8 character boundary");
+                // The arms above only ever stop on ASCII bytes, so `index` is on
+                // a character boundary. Skipping a byte beats panicking here:
+                // this runs on every chunk of pane output.
+                let Some(ch) = raw.get(index..).and_then(|rest| rest.chars().next()) else {
+                    index += 1;
+                    continue;
+                };
                 if !ch.is_control() {
                     plain.push(ch);
                     plain_chars += 1;
@@ -1307,6 +1372,19 @@ fn incomplete_osc_tail(buffer: &[u8]) -> Vec<u8> {
         };
     }
     Vec::new()
+}
+
+/// Drop capacity a `String` no longer needs.
+///
+/// `String::drain` keeps the buffer it grew into, so a pane that once printed a
+/// burst of wide output would pin that peak allocation for the rest of the
+/// session. Half the buffer is kept as headroom so steady-state appends do not
+/// reallocate on every trim.
+fn release_string_slack(value: &mut String) {
+    let target = value.len().saturating_add(value.len() / 2);
+    if value.capacity() > target {
+        value.shrink_to(target);
+    }
 }
 
 fn trim_string_tail(value: &mut String, max_chars: usize) {
@@ -1537,7 +1615,8 @@ mod tests {
             7,
             event_tx,
             Box::new(SharedWriter(output.clone())),
-        );
+        )
+        .expect("spawn writer");
         writer
             .try_send(PtyWrite::untracked(b"first"))
             .expect("first write");
@@ -1555,7 +1634,8 @@ mod tests {
     #[test]
     fn writer_worker_reports_asynchronous_failures() {
         let (event_tx, mut event_rx) = mpsc::channel(4);
-        let writer = spawn_writer(PaneId(4), 2, event_tx, Box::new(FailingWriter));
+        let writer =
+            spawn_writer(PaneId(4), 2, event_tx, Box::new(FailingWriter)).expect("spawn writer");
         let token = PtyWriteToken(42);
         writer
             .try_send(PtyWrite::tracked(b"input", token))
@@ -1586,7 +1666,8 @@ mod tests {
                 entered: entered_tx,
                 release: release_rx,
             }),
-        );
+        )
+        .expect("spawn writer");
         let first = PtyWriteToken(101);
         let queued = PtyWriteToken(102);
         writer
@@ -1633,7 +1714,8 @@ mod tests {
             3,
             event_tx,
             Box::new(SharedWriter(output.clone())),
-        );
+        )
+        .expect("spawn writer");
         let token = PtyWriteToken(99);
         writer
             .try_send(PtyWrite::tracked(b"tracked", token))
@@ -1813,6 +1895,104 @@ mod tests {
     }
 
     #[test]
+    fn restoring_history_state_does_not_repaint_plain_text_into_the_terminal() {
+        let mut view = PtyView::new(PathBuf::from("workspace"), 1_000);
+
+        view.restore_history_state("old agent output", &["previous command".into()]);
+
+        assert_eq!(view.output_tail(), "old agent output");
+        assert_eq!(view.input_history(), ["previous command"]);
+        assert!(!view.screen().contents().contains("old agent output"));
+        assert!(
+            !view
+                .screen()
+                .contents()
+                .contains("GridBash resumed pane history")
+        );
+    }
+
+    #[test]
+    fn headless_view_keeps_no_scrollback_and_no_plain_text_history() {
+        let mut view = PtyView::headless(PathBuf::from("workspace"));
+        view.resize_view(4, 20);
+
+        for index in 0..500 {
+            assert!(
+                view.process_output(format!("line {index}\r\n").as_bytes())
+                    .is_empty()
+            );
+        }
+        view.record_input(b"cargo test\r");
+
+        // Nothing scrolled off is retained, so `set_scrollback` clamps to zero.
+        assert!(!view.scroll_view(100));
+        assert_eq!(view.screen().scrollback(), 0);
+        assert!(view.output_tail().is_empty());
+        assert!(view.input_history().is_empty());
+        // The visible grid still tracks the pane so cursor queries stay correct.
+        assert!(view.screen().contents().contains("line 499"));
+    }
+
+    #[test]
+    fn headless_view_still_tracks_the_working_directory() {
+        let mut view = PtyView::headless(PathBuf::from("workspace"));
+
+        #[cfg(windows)]
+        let (report, expected) = (
+            "\x1b]7;file://localhost/C:/Users/Jason/repo\x07",
+            PathBuf::from("C:/Users/Jason/repo"),
+        );
+        #[cfg(not(windows))]
+        let (report, expected) = (
+            "\x1b]7;file://localhost/home/jason/repo\x07",
+            PathBuf::from("/home/jason/repo"),
+        );
+
+        view.process_output(report.as_bytes());
+
+        assert_eq!(view.cwd(), expected);
+    }
+
+    #[test]
+    fn split_osc_reports_survive_the_borrowed_scan_fast_path() {
+        let mut view = PtyView::headless(PathBuf::from("workspace"));
+
+        #[cfg(windows)]
+        let (head, tail, expected) = (
+            "\x1b]7;file://localhost/C:/Users/Jason/spl",
+            "it\x07",
+            PathBuf::from("C:/Users/Jason/split"),
+        );
+        #[cfg(not(windows))]
+        let (head, tail, expected) = (
+            "\x1b]7;file://localhost/home/jason/spl",
+            "it\x07",
+            PathBuf::from("/home/jason/split"),
+        );
+
+        view.process_output(head.as_bytes());
+        view.process_output(tail.as_bytes());
+
+        assert_eq!(view.cwd(), expected);
+    }
+
+    #[test]
+    fn trimming_the_output_tail_releases_the_peak_allocation() {
+        let mut view = PtyView::new(PathBuf::from("workspace"), 1_000);
+        let wide = "x".repeat(OUTPUT_TAIL_TRIM_AT_CHARS * 4);
+
+        view.process_output(wide.as_bytes());
+
+        assert!(view.output_tail().chars().count() <= MAX_OUTPUT_TAIL_CHARS);
+        assert!(
+            view.output_tail.capacity() < wide.len(),
+            "trimmed tail kept {} bytes of capacity for {} bytes of text",
+            view.output_tail.capacity(),
+            view.output_tail.len()
+        );
+    }
+
+    #[test]
     fn plain_output_character_count_matches_filtered_unicode() {
         for input in [
             "plain ASCII output",
@@ -1848,7 +2028,6 @@ mod tests {
             &cwd,
             &[],
             None,
-            10_000,
             PaneProcessPriority::BelowNormal,
             PaneWorkloadPolicy::Adaptive,
             event_tx,
@@ -1912,7 +2091,6 @@ mod tests {
             &cwd,
             &[],
             None,
-            10_000,
             PaneProcessPriority::BelowNormal,
             PaneWorkloadPolicy::Adaptive,
             event_tx,

--- a/src/resume_picker.rs
+++ b/src/resume_picker.rs
@@ -1,0 +1,803 @@
+use std::{
+    collections::BTreeSet,
+    io::{self, Stdout, Write},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow};
+use crossterm::{
+    cursor::Show,
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::session::{SessionRecord, delete_saved_session, process_is_running};
+
+type ResumeTerminal = Terminal<CrosstermBackend<Stdout>>;
+
+const CANVAS_BG: Color = Color::Rgb(0, 5, 2);
+const PANEL_BG: Color = Color::Rgb(1, 10, 5);
+const RAISED_BG: Color = Color::Rgb(2, 16, 8);
+const SELECTED_BG: Color = Color::Rgb(5, 35, 18);
+const HAIRLINE: Color = Color::Rgb(18, 76, 40);
+const MUTED: Color = Color::Rgb(72, 128, 88);
+const DIM_GREEN: Color = Color::Rgb(50, 176, 92);
+const TERMINAL_GREEN: Color = Color::Rgb(91, 255, 139);
+const SOFT_GREEN: Color = Color::Rgb(159, 255, 183);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionState {
+    Open(u32),
+    Interrupted,
+    Detached,
+    Saved,
+}
+
+impl SessionState {
+    fn for_record(record: &SessionRecord) -> Self {
+        let session = &record.session;
+        if session.running {
+            if let Some(owner_pid) = session.owner_pid
+                && process_is_running(owner_pid)
+            {
+                return Self::Open(owner_pid);
+            }
+            return Self::Interrupted;
+        }
+
+        if all_panes(record).any(|pane| pane.host.is_some()) {
+            Self::Detached
+        } else {
+            Self::Saved
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Open(_) => "OPEN",
+            Self::Interrupted => "RECOVER",
+            Self::Detached => "DETACHED",
+            Self::Saved => "SAVED",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::Open(_) => DIM_GREEN,
+            Self::Interrupted => TERMINAL_GREEN,
+            Self::Detached => SOFT_GREEN,
+            Self::Saved => MUTED,
+        }
+    }
+
+    fn description(self) -> String {
+        match self {
+            Self::Open(owner_pid) => {
+                format!("Already attached to a live GridBash client (PID {owner_pid}).")
+            }
+            Self::Interrupted => {
+                "The previous client stopped. GridBash will recover this workspace.".into()
+            }
+            Self::Detached => "Saved pane hosts are ready to reconnect.".into(),
+            Self::Saved => "Recreates terminals from the saved layout and history.".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PickerAction {
+    Continue,
+    Select(usize),
+    Delete(usize),
+    Cancel,
+}
+
+struct ResumePicker {
+    sessions: Vec<SessionRecord>,
+    list_state: ListState,
+    page_size: usize,
+    notice: Option<String>,
+    pending_delete: Option<String>,
+}
+
+pub fn select_session(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
+    let mut restore_guard = ResumeTerminalRestoreGuard::new();
+    let mut terminal = setup_terminal()?;
+    let mut picker = ResumePicker::new(sessions);
+    let result = picker.run(&mut terminal);
+    let teardown_result = teardown_terminal(&mut terminal);
+
+    if teardown_result.is_ok() {
+        restore_guard.disarm();
+    }
+    match (result, teardown_result) {
+        (Err(error), Err(cleanup_error)) => Err(error.context(format!(
+            "resume picker terminal cleanup also failed: {cleanup_error:#}"
+        ))),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(selection), Ok(())) => Ok(selection),
+    }
+}
+
+impl ResumePicker {
+    fn new(sessions: &[SessionRecord]) -> Self {
+        let mut list_state = ListState::default();
+        list_state.select((!sessions.is_empty()).then_some(0));
+        Self {
+            sessions: sessions.to_vec(),
+            list_state,
+            page_size: 1,
+            notice: None,
+            pending_delete: None,
+        }
+    }
+
+    fn run(&mut self, terminal: &mut ResumeTerminal) -> Result<Option<SessionRecord>> {
+        loop {
+            terminal.draw(|frame| self.draw(frame))?;
+            if !event::poll(Duration::from_millis(100))? {
+                continue;
+            }
+
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            match self.handle_key(key) {
+                PickerAction::Continue => {}
+                PickerAction::Cancel => return Ok(None),
+                PickerAction::Select(index) => return Ok(Some(self.sessions[index].clone())),
+                PickerAction::Delete(index) => {
+                    let title = session_title(&self.sessions[index]);
+                    match delete_saved_session(&self.sessions[index]) {
+                        Ok(()) => {
+                            self.sessions.remove(index);
+                            self.pending_delete = None;
+                            if self.sessions.is_empty() {
+                                return Ok(None);
+                            }
+                            self.list_state
+                                .select(Some(index.min(self.sessions.len().saturating_sub(1))));
+                            self.notice = Some(format!("Deleted saved session {title}."));
+                        }
+                        Err(error) => {
+                            self.pending_delete = None;
+                            self.notice = Some(format!("Could not delete session: {error:#}"));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> PickerAction {
+        let Some(selected) = self.list_state.selected() else {
+            return PickerAction::Cancel;
+        };
+        if self.pending_delete.is_some() && !matches!(key.code, KeyCode::Delete | KeyCode::Esc) {
+            self.pending_delete = None;
+        }
+        match key.code {
+            KeyCode::Esc if self.pending_delete.take().is_some() => {
+                self.notice = Some("Session deletion canceled.".into());
+                PickerAction::Continue
+            }
+            KeyCode::Esc | KeyCode::Char('q') => PickerAction::Cancel,
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.select(selected.saturating_sub(1));
+                PickerAction::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.select((selected + 1).min(self.sessions.len().saturating_sub(1)));
+                PickerAction::Continue
+            }
+            KeyCode::Home => {
+                self.select(0);
+                PickerAction::Continue
+            }
+            KeyCode::End => {
+                self.select(self.sessions.len().saturating_sub(1));
+                PickerAction::Continue
+            }
+            KeyCode::PageUp => {
+                self.select(selected.saturating_sub(self.page_size));
+                PickerAction::Continue
+            }
+            KeyCode::PageDown => {
+                self.select((selected + self.page_size).min(self.sessions.len().saturating_sub(1)));
+                PickerAction::Continue
+            }
+            KeyCode::Delete => self.request_delete(selected),
+            KeyCode::Enter => {
+                if let SessionState::Open(owner_pid) =
+                    SessionState::for_record(&self.sessions[selected])
+                {
+                    self.notice = Some(format!(
+                        "Session is already open in PID {owner_pid}. Switch to that GridBash window or close it before resuming."
+                    ));
+                    PickerAction::Continue
+                } else {
+                    PickerAction::Select(selected)
+                }
+            }
+            _ => PickerAction::Continue,
+        }
+    }
+
+    fn select(&mut self, index: usize) {
+        self.list_state.select(Some(index));
+        self.notice = None;
+        self.pending_delete = None;
+    }
+
+    fn request_delete(&mut self, selected: usize) -> PickerAction {
+        let record = &self.sessions[selected];
+        if let SessionState::Open(owner_pid) = SessionState::for_record(record) {
+            self.pending_delete = None;
+            self.notice = Some(format!(
+                "Session is open in PID {owner_pid}. Close that GridBash window before deleting it."
+            ));
+            return PickerAction::Continue;
+        }
+
+        if self.pending_delete.as_deref() == Some(record.session.id.as_str()) {
+            return PickerAction::Delete(selected);
+        }
+
+        self.pending_delete = Some(record.session.id.clone());
+        let detached = all_panes(record).any(|pane| pane.host.is_some());
+        self.notice = Some(if detached {
+            "Press Delete again to stop detached terminals and permanently delete this session."
+                .into()
+        } else {
+            "Press Delete again to permanently delete this saved session.".into()
+        });
+        PickerAction::Continue
+    }
+
+    fn draw(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(CANVAS_BG)),
+            area,
+        );
+
+        let panel = if area.width >= 84 && area.height >= 20 {
+            inset(area, 1, 1)
+        } else {
+            area
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .title(Line::from(vec![
+                Span::styled(" $ ", Style::default().fg(TERMINAL_GREEN)),
+                Span::styled(
+                    "gridbash resume",
+                    Style::default()
+                        .fg(TERMINAL_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" ", Style::default()),
+            ]))
+            .border_style(Style::default().fg(TERMINAL_GREEN))
+            .style(Style::default().fg(SOFT_GREEN).bg(PANEL_BG));
+        let inner = inset(block.inner(panel), 1, 0);
+        frame.render_widget(block, panel);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let (header_height, detail_height, controls_height) = if inner.height >= 22 {
+            (3, 9, 3)
+        } else {
+            (2, 7, 2)
+        };
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(header_height),
+                Constraint::Length(detail_height),
+                Constraint::Min(4),
+                Constraint::Length(controls_height),
+            ])
+            .split(inner);
+        self.draw_header(frame, chunks[0]);
+        self.draw_details(frame, chunks[1]);
+        self.draw_sessions(frame, chunks[2]);
+        self.draw_controls(frame, chunks[3]);
+    }
+
+    fn draw_header(&self, frame: &mut Frame<'_>, area: Rect) {
+        let selected = self.list_state.selected().unwrap_or(0) + 1;
+        let selected_state = self
+            .list_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+            .map(SessionState::for_record)
+            .unwrap_or(SessionState::Saved);
+        let right_width = area.width.min(24);
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(20), Constraint::Length(right_width)])
+            .split(area);
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "SELECT A WORKSPACE TO RESUME",
+                    Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(Span::styled(
+                    "Saved terminals, layout, and working context.",
+                    Style::default().fg(MUTED),
+                )),
+            ])
+            .style(Style::default().bg(PANEL_BG)),
+            columns[0],
+        );
+
+        if columns[1].width > 0 {
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(state_badge(selected_state)),
+                    Line::from(Span::styled(
+                        format!("{selected:02} / {:02}", self.sessions.len()),
+                        Style::default().fg(MUTED),
+                    )),
+                ])
+                .alignment(Alignment::Right)
+                .style(Style::default().bg(PANEL_BG)),
+                columns[1],
+            );
+        }
+    }
+
+    fn draw_details(&self, frame: &mut Frame<'_>, area: Rect) {
+        let block = panel_block("SELECTED SESSION");
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        let Some(record) = self
+            .list_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+        else {
+            return;
+        };
+
+        let state = SessionState::for_record(record);
+        let session = &record.session;
+        let panes = all_panes(record).count();
+        let tabs = session.tabs.len() + 1;
+        let folders = compact_labels(all_panes(record).map(|pane| pane.folder_name.as_str()));
+        let profiles = compact_labels(all_panes(record).map(|pane| pane.profile_name.as_str()));
+        let host_count = all_panes(record).filter(|pane| pane.host.is_some()).count();
+        let resume_mode = if host_count > 0 {
+            format!(
+                "reconnect {host_count} PTY host{}",
+                if host_count == 1 { "" } else { "s" }
+            )
+        } else {
+            "recreate from snapshot".into()
+        };
+        let lines = vec![
+            Line::from(vec![
+                Span::styled(
+                    session_title(record),
+                    Style::default()
+                        .fg(TERMINAL_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                state_badge(state),
+            ]),
+            Line::from(Span::styled(
+                state.description(),
+                Style::default().fg(MUTED),
+            )),
+            detail_row("SESSION ID", session.id.clone()),
+            detail_row(
+                "WORKSPACE",
+                format!(
+                    "{}x{} | {panes} pane{} | {tabs} tab{} | {resume_mode}",
+                    session.grid.rows,
+                    session.grid.columns,
+                    if panes == 1 { "" } else { "s" },
+                    if tabs == 1 { "" } else { "s" },
+                ),
+            ),
+            detail_row("FOLDERS", folders.unwrap_or_else(|| "Unknown".into())),
+            detail_row("PROFILES", profiles.unwrap_or_else(|| "Unknown".into())),
+        ];
+        frame.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: true })
+                .style(Style::default().bg(RAISED_BG)),
+            inner,
+        );
+    }
+
+    fn draw_sessions(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let block = panel_block("RECENT SESSIONS");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        self.page_size = usize::from((inner.height / 2).max(1));
+
+        let items = self
+            .sessions
+            .iter()
+            .map(|record| {
+                let state = SessionState::for_record(record);
+                ListItem::new(vec![
+                    Line::from(vec![
+                        state_badge(state),
+                        Span::raw(" "),
+                        Span::styled(
+                            session_title(record),
+                            Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("           ", Style::default().fg(MUTED)),
+                        Span::styled(record.summary(), Style::default().fg(MUTED)),
+                    ]),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let list = List::new(items)
+            .highlight_symbol("> ")
+            .highlight_style(Style::default().fg(TERMINAL_GREEN).bg(SELECTED_BG))
+            .style(Style::default().bg(RAISED_BG));
+        frame.render_stateful_widget(list, inner, &mut self.list_state);
+    }
+
+    fn draw_controls(&self, frame: &mut Frame<'_>, area: Rect) {
+        let line = if let Some(notice) = &self.notice {
+            Line::from(vec![
+                Span::styled("[!]", Style::default().fg(TERMINAL_GREEN)),
+                Span::raw("  "),
+                Span::styled(notice.clone(), Style::default().fg(SOFT_GREEN)),
+            ])
+        } else {
+            Line::from(vec![
+                keycap("UP/DOWN or J/K"),
+                Span::styled(" NAVIGATE   ", Style::default().fg(MUTED)),
+                launch_keycap("ENTER"),
+                Span::styled(" RESUME   ", Style::default().fg(MUTED)),
+                keycap("DELETE x2"),
+                Span::styled(" REMOVE   ", Style::default().fg(MUTED)),
+                keycap("Q or ESC"),
+                Span::styled(" CANCEL", Style::default().fg(MUTED)),
+            ])
+        };
+        frame.render_widget(
+            Paragraph::new(line)
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true })
+                .style(Style::default().bg(PANEL_BG)),
+            area,
+        );
+    }
+}
+
+fn all_panes(record: &SessionRecord) -> impl Iterator<Item = &crate::session::SavedPane> {
+    record
+        .session
+        .panes
+        .iter()
+        .chain(record.session.tabs.iter().flat_map(|tab| tab.panes.iter()))
+        .chain(record.session.background_panes.iter().map(|job| &job.pane))
+}
+
+fn session_title(record: &SessionRecord) -> String {
+    if record.session.title.trim().is_empty() {
+        record
+            .session
+            .panes
+            .first()
+            .map(|pane| pane.folder_name.clone())
+            .filter(|title| !title.is_empty())
+            .unwrap_or_else(|| "Untitled workspace".into())
+    } else {
+        record.session.title.clone()
+    }
+}
+
+fn compact_labels<'a>(labels: impl Iterator<Item = &'a str>) -> Option<String> {
+    let unique = labels
+        .filter(|label| !label.is_empty())
+        .collect::<BTreeSet<_>>();
+    if unique.is_empty() {
+        return None;
+    }
+    let shown = unique.iter().take(3).copied().collect::<Vec<_>>();
+    let extra = unique.len().saturating_sub(shown.len());
+    let mut label = shown.join(", ");
+    if extra > 0 {
+        label.push_str(&format!(" +{extra}"));
+    }
+    Some(label)
+}
+
+fn detail_row(label: &'static str, value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<12}"),
+            Style::default().fg(MUTED).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(value, Style::default().fg(SOFT_GREEN)),
+    ])
+}
+
+fn state_badge(state: SessionState) -> Span<'static> {
+    Span::styled(
+        format!("[{:<8}]", state.label()),
+        Style::default()
+            .fg(state.color())
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn panel_block(label: &'static str) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .title(Line::from(Span::styled(
+            format!(" {label} "),
+            Style::default()
+                .fg(TERMINAL_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )))
+        .border_style(Style::default().fg(HAIRLINE))
+        .style(Style::default().bg(RAISED_BG))
+}
+
+fn keycap(label: &'static str) -> Span<'static> {
+    Span::styled(
+        format!("[{label}]"),
+        Style::default()
+            .fg(TERMINAL_GREEN)
+            .bg(RAISED_BG)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn launch_keycap(label: &'static str) -> Span<'static> {
+    Span::styled(
+        format!(" {label} "),
+        Style::default()
+            .fg(Color::Black)
+            .bg(TERMINAL_GREEN)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn inset(area: Rect, x: u16, y: u16) -> Rect {
+    Rect {
+        x: area.x.saturating_add(x.min(area.width)),
+        y: area.y.saturating_add(y.min(area.height)),
+        width: area.width.saturating_sub(x.saturating_mul(2)),
+        height: area.height.saturating_sub(y.saturating_mul(2)),
+    }
+}
+
+fn setup_terminal() -> Result<ResumeTerminal> {
+    enable_raw_mode().context("failed to enable raw terminal mode")?;
+    let mut stdout = io::stdout();
+    if let Err(error) = execute!(stdout, EnterAlternateScreen) {
+        let _ = restore_terminal_output(&mut stdout);
+        return Err(error).context("failed to enter alternate screen");
+    }
+    let backend = CrosstermBackend::new(stdout);
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(error) => {
+            let mut stdout = io::stdout();
+            let _ = restore_terminal_output(&mut stdout);
+            Err(error).context("failed to create resume terminal")
+        }
+    }
+}
+
+fn teardown_terminal(terminal: &mut ResumeTerminal) -> Result<()> {
+    restore_terminal_output(terminal.backend_mut())
+}
+
+fn restore_terminal_output(output: &mut impl Write) -> Result<()> {
+    let mut first_error = disable_raw_mode()
+        .err()
+        .map(|error| anyhow!(error).context("failed to disable raw terminal mode"));
+    if let Err(error) = execute!(output, LeaveAlternateScreen)
+        && first_error.is_none()
+    {
+        first_error = Some(anyhow!(error).context("failed to leave alternate screen"));
+    }
+    if let Err(error) = execute!(output, Show)
+        && first_error.is_none()
+    {
+        first_error = Some(anyhow!(error).context("failed to restore cursor"));
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+struct ResumeTerminalRestoreGuard {
+    armed: bool,
+}
+
+impl ResumeTerminalRestoreGuard {
+    fn new() -> Self {
+        Self { armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ResumeTerminalRestoreGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = restore_terminal_output(&mut io::stdout());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use ratatui::{Terminal, backend::TestBackend};
+
+    use super::*;
+    use crate::{
+        profiles::Profile,
+        session::{SavedGrid, SavedPane, SavedPaneHistory, SavedSession},
+    };
+
+    #[test]
+    fn marks_live_and_interrupted_sessions() {
+        let mut record = record("active", true, Some(std::process::id()), false);
+        assert_eq!(
+            SessionState::for_record(&record),
+            SessionState::Open(std::process::id())
+        );
+
+        record.session.owner_pid = Some(u32::MAX);
+        assert_eq!(SessionState::for_record(&record), SessionState::Interrupted);
+    }
+
+    #[test]
+    fn marks_detached_sessions_with_saved_hosts() {
+        let record = record("detached", false, None, true);
+        assert_eq!(SessionState::for_record(&record), SessionState::Detached);
+    }
+
+    #[test]
+    fn renders_terminal_green_stacked_resume_picker() {
+        let sessions = vec![record("Fluent workspace", false, None, true)];
+        let mut picker = ResumePicker::new(&sessions);
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame))
+            .expect("draw resume picker");
+
+        let buffer = terminal.backend().buffer();
+        let rendered = buffer
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        let details_at = rendered.find("SELECTED SESSION").expect("details panel");
+        let sessions_at = rendered.find("RECENT SESSIONS").expect("sessions panel");
+        assert!(
+            details_at < sessions_at,
+            "details should render above sessions"
+        );
+        assert!(rendered.contains("gridbash resume"));
+        assert!(rendered.contains("Fluent workspace"));
+        assert!(rendered.contains("DETACHED"));
+        assert!(rendered.contains("DELETE x2"));
+        assert!(!rendered.contains("01 /"));
+        assert!(!rendered.contains("02 /"));
+        assert!(
+            buffer
+                .content()
+                .iter()
+                .any(|cell| cell.fg == TERMINAL_GREEN)
+        );
+    }
+
+    #[test]
+    fn session_deletion_requires_a_second_delete_press() {
+        let sessions = vec![record("Saved workspace", false, None, false)];
+        let mut picker = ResumePicker::new(&sessions);
+        let delete = KeyEvent::new(KeyCode::Delete, crossterm::event::KeyModifiers::NONE);
+
+        assert_eq!(picker.handle_key(delete), PickerAction::Continue);
+        assert!(picker.pending_delete.is_some());
+        assert_eq!(picker.handle_key(delete), PickerAction::Delete(0));
+    }
+
+    #[test]
+    fn open_sessions_cannot_be_deleted_from_the_picker() {
+        let sessions = vec![record(
+            "Open workspace",
+            true,
+            Some(std::process::id()),
+            false,
+        )];
+        let mut picker = ResumePicker::new(&sessions);
+        let delete = KeyEvent::new(KeyCode::Delete, crossterm::event::KeyModifiers::NONE);
+
+        assert_eq!(picker.handle_key(delete), PickerAction::Continue);
+        assert!(picker.pending_delete.is_none());
+        assert!(
+            picker
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice.contains("Close that GridBash window"))
+        );
+    }
+
+    fn record(title: &str, running: bool, owner_pid: Option<u32>, host: bool) -> SessionRecord {
+        let pane = SavedPane {
+            index: 0,
+            profile_name: "codex".into(),
+            command: Profile {
+                command: "codex".into(),
+                args: Vec::new(),
+                title: Some("Codex".into()),
+                agent_kind: None,
+            },
+            cwd: PathBuf::from("fluent"),
+            folder_name: "fluent".into(),
+            worktree_name: None,
+            auth_name: None,
+            auth_kind: None,
+            history: SavedPaneHistory::default(),
+            codex_thread_id: None,
+            host: host.then(|| crate::pane_host::PtyHostRef {
+                endpoint: "127.0.0.1:12345".into(),
+                token: "token".into(),
+                process_id: None,
+                codex_sqlite_home: None,
+                started_at_ms: None,
+            }),
+        };
+        SessionRecord {
+            path: PathBuf::from("session.toml"),
+            session: SavedSession {
+                version: 1,
+                id: "session-id".into(),
+                started_at: 1,
+                updated_at: 1,
+                title: title.into(),
+                grid: SavedGrid {
+                    rows: 1,
+                    columns: 1,
+                },
+                panes: vec![pane],
+                background_panes: Vec::new(),
+                tabs: Vec::new(),
+                running,
+                owner_pid,
+                recovered_at: None,
+            },
+        }
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
-    io::{self, Write},
+    io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -17,8 +17,9 @@ use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 use crate::{
     auth::AgentKind,
     cli::ResumeArgs,
-    layout::GridSize,
-    pane_host::{PtyHostRef, PtyPane},
+    layout::{GridSize, MAX_PANES},
+    pane_host::{PtyHostRef, PtyPane, terminate_saved_host},
+    ports::roots_with_descendant_named,
     profiles::Profile,
     setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
 };
@@ -78,6 +79,8 @@ pub struct SavedPane {
     #[serde(default)]
     pub history: SavedPaneHistory,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<PtyHostRef>,
 }
 
@@ -111,11 +114,29 @@ pub struct InterruptedRecovery {
     pub tabs: Vec<SavedTab>,
     pub session_count: usize,
     pub pane_count: usize,
+    pub claim: InterruptedRecoveryClaim,
+}
+
+#[derive(Debug, Clone)]
+pub struct InterruptedRecoveryClaim {
+    sources: Vec<RecoverySource>,
+}
+
+#[derive(Debug, Clone)]
+struct RecoverySource {
+    path: PathBuf,
+    id: String,
 }
 
 pub struct SessionRecorder {
     path: PathBuf,
     session: SavedSession,
+    /// Digest of the last session written to disk.
+    ///
+    /// The serialized session embeds every pane's output tail, so keeping the
+    /// text itself pinned a multi-megabyte copy for the life of the process.
+    /// Only the change check needs it, and a digest answers that in 8 bytes.
+    last_saved_digest: Option<u64>,
 }
 
 impl SessionRecord {
@@ -151,7 +172,7 @@ impl SavedSession {
                 .iter()
                 .enumerate()
                 .map(|(index, spec)| {
-                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None)
+                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None, None)
                 })
                 .collect(),
             background_panes: Vec::new(),
@@ -179,6 +200,7 @@ impl SavedSession {
         self.running = false;
         self.owner_pid = None;
         self.recovered_at = Some(now_seconds());
+        self.updated_at = now_seconds();
     }
 
     fn has_agent_pane(&self) -> bool {
@@ -198,7 +220,6 @@ impl SavedSession {
         background_panes: Vec<SavedBackgroundPane>,
     ) {
         self.version = SESSION_VERSION;
-        self.updated_at = now_seconds();
         self.title = title.to_string();
         self.grid = plan.grid.into();
         self.panes = saved_panes_from_live(plan, panes);
@@ -285,27 +306,28 @@ fn launch_plan_from_saved(
             saved_grid.columns
         )
     })?;
-    let panes = panes
-        .iter()
-        .map(|pane| PaneLaunchSpec {
-            profile_name: pane.profile_name.clone(),
-            command: pane.command.clone(),
-            env: BTreeMap::new(),
-            cwd: pane.cwd.clone(),
-            folder_name: pane.folder_name.clone(),
-            worktree_name: pane.worktree_name.clone(),
-            auth_name: pane.auth_name.clone(),
-            auth_kind: pane.auth_kind,
-            auth_dir: None,
-        })
-        .collect::<Vec<_>>();
+    let panes = panes.iter().map(SavedPane::launch_spec).collect::<Vec<_>>();
     if panes.is_empty() {
         bail!("saved session {id} has no panes");
+    }
+    // A grid can never hold more than `MAX_PANES`, so a file claiming more is
+    // damaged. Refusing it here keeps the count from becoming per-pane
+    // allocations and PTY spawns.
+    if panes.len() > MAX_PANES {
+        bail!(
+            "saved session {id} claims {} panes; the maximum is {MAX_PANES}",
+            panes.len()
+        );
     }
     Ok(LaunchPlan { panes, grid })
 }
 
 fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane> {
+    let host_processes = panes
+        .iter()
+        .filter_map(PtyPane::host_process_id)
+        .collect::<Vec<_>>();
+    let codex_roots = roots_with_descendant_named(&host_processes, "codex").ok();
     plan.panes
         .iter()
         .enumerate()
@@ -313,7 +335,20 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
             let live = panes.get(index);
             let history = live.map(SavedPaneHistory::from_pane).unwrap_or_default();
             let host = live.map(PtyPane::host_ref);
-            let mut saved = SavedPane::from_spec(index, spec, history, host);
+            let codex_running = live.is_some_and(|pane| {
+                pane.host_process_id().is_some_and(|process_id| {
+                    codex_roots
+                        .as_ref()
+                        .is_some_and(|roots| roots.contains(&process_id))
+                }) || (spec.command.agent_kind == Some(AgentKind::Codex) && !pane.exited)
+            });
+            let codex_thread_id = codex_running
+                .then(|| {
+                    codex_resume_id(&spec.command, &history.input_history)
+                        .or_else(|| live.and_then(|pane| pane.codex_thread_id(pane.cwd())))
+                })
+                .flatten();
+            let mut saved = SavedPane::from_spec(index, spec, history, codex_thread_id, host);
             if let Some(live) = live {
                 saved.cwd = live.cwd().to_path_buf();
                 saved.folder_name = folder_display_name(&saved.cwd);
@@ -325,9 +360,14 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
 
 impl SavedPane {
     pub fn launch_spec(&self) -> PaneLaunchSpec {
+        let (profile_name, command) = self
+            .codex_thread_id
+            .as_deref()
+            .map(|thread_id| codex_resume_profile(&self.profile_name, &self.command, thread_id))
+            .unwrap_or_else(|| (self.profile_name.clone(), self.command.clone()));
         PaneLaunchSpec {
-            profile_name: self.profile_name.clone(),
-            command: self.command.clone(),
+            profile_name,
+            command,
             env: BTreeMap::new(),
             cwd: self.cwd.clone(),
             folder_name: self.folder_name.clone(),
@@ -343,13 +383,14 @@ impl SavedPane {
         history: SavedPaneHistory,
         host: Option<PtyHostRef>,
     ) -> Self {
-        Self::from_spec(0, spec, history, host)
+        Self::from_spec(0, spec, history, None, host)
     }
 
     fn from_spec(
         index: usize,
         spec: &PaneLaunchSpec,
         history: SavedPaneHistory,
+        codex_thread_id: Option<String>,
         host: Option<PtyHostRef>,
     ) -> Self {
         Self {
@@ -362,9 +403,101 @@ impl SavedPane {
             auth_name: spec.auth_name.clone(),
             auth_kind: spec.auth_kind,
             history,
+            codex_thread_id,
             host,
         }
     }
+}
+
+fn codex_resume_profile(
+    profile_name: &str,
+    command: &Profile,
+    thread_id: &str,
+) -> (String, Profile) {
+    if command.agent_kind == Some(AgentKind::Codex) && is_direct_codex_command(&command.command) {
+        let mut command = command.clone();
+        if let Some(resume_index) = command
+            .args
+            .iter()
+            .position(|argument| argument == "resume")
+        {
+            if command
+                .args
+                .get(resume_index + 1)
+                .is_some_and(|argument| looks_like_thread_id(argument))
+            {
+                command.args[resume_index + 1] = thread_id.to_string();
+            } else {
+                command.args.insert(resume_index + 1, thread_id.to_string());
+            }
+        } else {
+            command.args.extend(["resume".into(), thread_id.into()]);
+        }
+        return (profile_name.to_string(), command);
+    }
+    if codex_resume_id(command, &[]).as_deref() == Some(thread_id) {
+        return (profile_name.to_string(), command.clone());
+    }
+
+    (
+        "codex".into(),
+        Profile {
+            command: "codex".into(),
+            args: vec!["resume".into(), thread_id.into()],
+            title: Some("Codex".into()),
+            agent_kind: Some(AgentKind::Codex),
+        },
+    )
+}
+
+fn codex_resume_id(command: &Profile, input_history: &[String]) -> Option<String> {
+    command
+        .args
+        .windows(2)
+        .find_map(|arguments| {
+            (arguments[0] == "resume" && looks_like_thread_id(&arguments[1]))
+                .then(|| arguments[1].clone())
+        })
+        .or_else(|| {
+            command
+                .args
+                .iter()
+                .rev()
+                .find_map(|argument| resume_id_in_text(argument))
+        })
+        .or_else(|| {
+            input_history
+                .iter()
+                .rev()
+                .find_map(|input| resume_id_in_text(input))
+        })
+}
+
+fn resume_id_in_text(value: &str) -> Option<String> {
+    let tokens = value
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|character: char| matches!(character, '"' | '\'' | ';' | ','))
+        })
+        .collect::<Vec<_>>();
+    tokens.windows(2).find_map(|tokens| {
+        (tokens[0] == "resume" && looks_like_thread_id(tokens[1])).then(|| tokens[1].to_string())
+    })
+}
+
+fn is_direct_codex_command(command: &str) -> bool {
+    Path::new(command)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("codex"))
+}
+
+fn looks_like_thread_id(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
 }
 
 impl SavedPaneHistory {
@@ -389,9 +522,10 @@ impl SessionRecorder {
     pub fn start_new(title: &str, plan: &LaunchPlan) -> Result<Self> {
         let id = new_session_id();
         let path = session_file_path(&id)?;
-        let recorder = Self {
+        let mut recorder = Self {
             path,
             session: SavedSession::new(id, title, plan),
+            last_saved_digest: None,
         };
         recorder.save()?;
         prune_old_sessions()?;
@@ -399,10 +533,14 @@ impl SessionRecorder {
     }
 
     pub fn continue_record(mut record: SessionRecord) -> Self {
+        let last_saved_digest = toml::to_string_pretty(&record.session)
+            .ok()
+            .map(|raw| session_digest(&raw));
         record.session.begin_run();
         Self {
             path: record.path,
             session: record.session,
+            last_saved_digest,
         }
     }
 
@@ -418,8 +556,29 @@ impl SessionRecorder {
             .update_from_live(title, plan, panes, tabs, background_panes);
     }
 
-    pub fn save(&self) -> Result<()> {
-        save_session_to_path(&self.path, &self.session)
+    pub fn save(&mut self) -> Result<()> {
+        self.save_if_changed().map(|_| ())
+    }
+
+    pub fn save_if_changed(&mut self) -> Result<bool> {
+        let raw = toml::to_string_pretty(&self.session).context("failed to serialize session")?;
+        let unchanged = self.last_saved_digest == Some(session_digest(&raw));
+        // Release the probe before serializing again; the two copies of a
+        // session carrying every pane's output tail are the peak of this path.
+        drop(raw);
+        if unchanged {
+            return Ok(false);
+        }
+
+        self.session.updated_at = now_seconds();
+        let raw = toml::to_string_pretty(&self.session).context("failed to serialize session")?;
+        write_session_raw(&self.path, raw.as_bytes())?;
+        self.last_saved_digest = Some(session_digest(&raw));
+        Ok(true)
+    }
+
+    pub fn resume_command(&self) -> String {
+        format!("gridbash resume {}", self.session.id)
     }
 
     pub fn finish(&mut self) -> Result<()> {
@@ -429,23 +588,49 @@ impl SessionRecorder {
 }
 
 pub fn claim_interrupted_recovery() -> Result<Option<InterruptedRecovery>> {
+    with_session_state_lock(claim_interrupted_recovery_locked)
+}
+
+pub fn complete_interrupted_recovery(claim: &InterruptedRecoveryClaim) -> Result<()> {
+    with_session_state_lock(|| {
+        for source in &claim.sources {
+            let mut record = load_session_record(&source.path)?;
+            if record.session.id != source.id {
+                bail!(
+                    "saved recovery session {} changed identity while it was claimed",
+                    source.id
+                );
+            }
+            if record.session.running
+                && record.session.owner_pid == Some(std::process::id())
+                && record.session.recovered_at.is_none()
+            {
+                record.session.mark_recovered();
+                save_session_to_path(&record.path, &record.session)?;
+            }
+        }
+        Ok(())
+    })
+}
+
+fn with_session_state_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
     let directory = sessions_dir()?;
     create_private_dir_all(&directory)
         .with_context(|| format!("failed to create session directory {}", directory.display()))?;
-    let lock_path = directory.join(".recovery.lock");
+    let lock_path = directory.join(".sessions.lock");
     let mut options = OpenOptions::new();
     options.create(true).read(true).write(true);
     #[cfg(unix)]
     options.mode(0o600);
     let lock = options
         .open(&lock_path)
-        .with_context(|| format!("failed to open recovery lock {}", lock_path.display()))?;
+        .with_context(|| format!("failed to open session lock {}", lock_path.display()))?;
     FileExt::lock(&lock)
-        .with_context(|| format!("failed to lock recovery state {}", lock_path.display()))?;
+        .with_context(|| format!("failed to lock session state {}", lock_path.display()))?;
 
-    let result = claim_interrupted_recovery_locked();
+    let result = operation();
     let unlock_result = FileExt::unlock(&lock)
-        .with_context(|| format!("failed to unlock recovery state {}", lock_path.display()));
+        .with_context(|| format!("failed to unlock session state {}", lock_path.display()));
     match (result, unlock_result) {
         (Err(error), _) => Err(error),
         (Ok(_), Err(error)) => Err(error),
@@ -463,7 +648,7 @@ fn claim_interrupted_recovery_locked() -> Result<Option<InterruptedRecovery>> {
     };
 
     for record in &mut records {
-        record.session.mark_recovered();
+        record.session.begin_run();
         save_session_to_path(&record.path, &record.session)?;
     }
     Ok(Some(recovery))
@@ -531,6 +716,15 @@ fn build_interrupted_recovery(records: &[SessionRecord]) -> Option<InterruptedRe
         tabs,
         session_count: records.len(),
         pane_count,
+        claim: InterruptedRecoveryClaim {
+            sources: records
+                .iter()
+                .map(|record| RecoverySource {
+                    path: record.path.clone(),
+                    id: record.session.id.clone(),
+                })
+                .collect(),
+        },
     })
 }
 
@@ -554,15 +748,106 @@ pub fn select_resume_session(args: &ResumeArgs) -> Result<Option<SessionRecord>>
         return Ok(None);
     }
 
-    if let Some(query) = args.session.as_deref() {
-        return find_session(&sessions, query).map(Some);
+    if args.delete {
+        let query = args
+            .session
+            .as_deref()
+            .ok_or_else(|| anyhow!("--delete requires a session id or unique id prefix"))?;
+        let record = find_session(&sessions, query)?;
+        let id = record.session.id.clone();
+        delete_saved_session(&record)?;
+        println!("gridbash: deleted saved session {id}");
+        return Ok(None);
     }
 
-    if args.latest || sessions.len() == 1 {
-        return Ok(sessions.into_iter().next());
+    let selected = if let Some(query) = args.session.as_deref() {
+        Some(find_session(&sessions, query)?)
+    } else if args.latest {
+        sessions
+            .iter()
+            .find(|record| live_owner_pid(record).is_none())
+            .cloned()
+            .or_else(|| sessions.first().cloned())
+    } else {
+        prompt_for_session(&sessions)?
+    };
+
+    selected.map(claim_resume_session).transpose()
+}
+
+fn claim_resume_session(record: SessionRecord) -> Result<SessionRecord> {
+    with_session_state_lock(|| claim_resume_session_locked(record))
+}
+
+fn claim_resume_session_locked(record: SessionRecord) -> Result<SessionRecord> {
+    let mut current = load_session_record(&record.path)?;
+    if current.session.id != record.session.id {
+        bail!(
+            "saved session {} changed identity while it was selected",
+            record.session.id
+        );
+    }
+    current = ensure_session_is_resumable(current)?;
+    current.session.begin_run();
+    save_session_to_path(&current.path, &current.session)?;
+    Ok(current)
+}
+
+pub fn delete_saved_session(record: &SessionRecord) -> Result<()> {
+    with_session_state_lock(|| {
+        let current = match load_session_record(&record.path) {
+            Ok(current) => current,
+            Err(_) if !record.path.exists() => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if current.session.id != record.session.id {
+            bail!(
+                "saved session {} changed identity while it was selected for deletion",
+                record.session.id
+            );
+        }
+        delete_saved_session_locked(&current)
+    })
+}
+
+fn delete_saved_session_locked(record: &SessionRecord) -> Result<()> {
+    if let Some(owner_pid) = live_owner_pid(record) {
+        bail!(
+            "session {} is open in GridBash (PID {owner_pid}); close that client before deleting it",
+            record.session.id
+        );
     }
 
-    prompt_for_session(&sessions)
+    let mut hosts = BTreeMap::<String, PtyHostRef>::new();
+    for pane in record
+        .session
+        .panes
+        .iter()
+        .chain(record.session.tabs.iter().flat_map(|tab| tab.panes.iter()))
+        .chain(record.session.background_panes.iter().map(|job| &job.pane))
+    {
+        if let Some(host) = pane.host.as_ref() {
+            hosts
+                .entry(host.endpoint.clone())
+                .or_insert_with(|| host.clone());
+        }
+    }
+
+    for host in hosts.values() {
+        terminate_saved_host(host).with_context(|| {
+            format!(
+                "failed to stop a detached terminal for session {}",
+                record.session.id
+            )
+        })?;
+    }
+
+    match fs::remove_file(&record.path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to delete saved session {}", record.session.id)),
+    }
 }
 
 pub fn load_recent_sessions() -> Result<Vec<SessionRecord>> {
@@ -631,6 +916,33 @@ fn find_session(sessions: &[SessionRecord], query: &str) -> Result<SessionRecord
 }
 
 fn prompt_for_session(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
+    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+        return crate::resume_picker::select_session(sessions);
+    }
+
+    prompt_for_session_plain(sessions)
+}
+
+fn live_owner_pid(record: &SessionRecord) -> Option<u32> {
+    record
+        .session
+        .running
+        .then_some(record.session.owner_pid)
+        .flatten()
+        .filter(|owner_pid| process_is_running(*owner_pid))
+}
+
+fn ensure_session_is_resumable(record: SessionRecord) -> Result<SessionRecord> {
+    if let Some(owner_pid) = live_owner_pid(&record) {
+        bail!(
+            "session {} is already open in GridBash (PID {owner_pid}); switch to that client or close it before resuming",
+            record.session.id
+        );
+    }
+    Ok(record)
+}
+
+fn prompt_for_session_plain(sessions: &[SessionRecord]) -> Result<Option<SessionRecord>> {
     println!("Recent GridBash sessions:");
     for (index, record) in sessions.iter().take(20).enumerate() {
         println!(
@@ -669,11 +981,38 @@ fn prompt_for_session(sessions: &[SessionRecord]) -> Result<Option<SessionRecord
 }
 
 fn prune_old_sessions() -> Result<()> {
-    let sessions = load_recent_sessions()?;
-    for record in sessions.into_iter().skip(MAX_SAVED_SESSIONS) {
-        let _ = fs::remove_file(record.path);
-    }
-    Ok(())
+    with_session_state_lock(|| {
+        let sessions = load_recent_sessions()?;
+        let mut excess = sessions.len().saturating_sub(MAX_SAVED_SESSIONS);
+        if excess == 0 {
+            return Ok(());
+        }
+
+        for record in sessions.into_iter().rev() {
+            if excess == 0 {
+                break;
+            }
+            if live_owner_pid(&record).is_some() || session_has_live_host(&record.session) {
+                continue;
+            }
+            match fs::remove_file(&record.path) {
+                Ok(()) => excess -= 1,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => excess -= 1,
+                Err(_) => {}
+            }
+        }
+        Ok(())
+    })
+}
+
+fn session_has_live_host(session: &SavedSession) -> bool {
+    session
+        .panes
+        .iter()
+        .chain(session.tabs.iter().flat_map(|tab| tab.panes.iter()))
+        .chain(session.background_panes.iter().map(|job| &job.pane))
+        .filter_map(|pane| pane.host.as_ref())
+        .any(|host| host.process_id.map(process_is_running).unwrap_or(true))
 }
 
 fn sessions_dir() -> Result<PathBuf> {
@@ -726,15 +1065,42 @@ fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
     }
 }
 
+/// Fingerprint a serialized session so autosave can skip unchanged writes
+/// without keeping the serialized text around.
+fn session_digest(raw: &str) -> u64 {
+    use std::hash::{Hash as _, Hasher as _};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    raw.hash(&mut hasher);
+    hasher.finish()
+}
+
 fn save_session_to_path(path: &Path, session: &SavedSession) -> Result<()> {
+    let raw = toml::to_string_pretty(session).context("failed to serialize session")?;
+    write_session_raw(path, raw.as_bytes())
+}
+
+fn write_session_raw(path: &Path, raw: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         create_private_dir_all(parent)
             .with_context(|| format!("failed to create session directory {}", parent.display()))?;
     }
-
-    let raw = toml::to_string_pretty(session).context("failed to serialize session")?;
-    write_private_file(path, raw.as_bytes())
+    write_private_file(path, raw)
         .with_context(|| format!("failed to write session {}", path.display()))
+}
+
+fn load_session_record(path: &Path) -> Result<SessionRecord> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("failed to read saved session {}", path.display()))?;
+    let session = toml::from_str::<SavedSession>(&raw)
+        .with_context(|| format!("failed to parse saved session {}", path.display()))?;
+    if session.version != SESSION_VERSION || session.id.is_empty() {
+        bail!("saved session {} has an unsupported format", path.display());
+    }
+    Ok(SessionRecord {
+        path: path.to_path_buf(),
+        session,
+    })
 }
 
 fn session_file_path(id: &str) -> Result<PathBuf> {
@@ -761,7 +1127,7 @@ fn is_false(value: &bool) -> bool {
 }
 
 #[cfg(unix)]
-fn process_is_running(process_id: u32) -> bool {
+pub(crate) fn process_is_running(process_id: u32) -> bool {
     let Ok(process_id) = i32::try_from(process_id) else {
         return false;
     };
@@ -774,7 +1140,7 @@ fn process_is_running(process_id: u32) -> bool {
 }
 
 #[cfg(windows)]
-fn process_is_running(process_id: u32) -> bool {
+pub(crate) fn process_is_running(process_id: u32) -> bool {
     use windows_sys::Win32::{
         Foundation::{CloseHandle, ERROR_ACCESS_DENIED, STILL_ACTIVE},
         System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION},
@@ -795,7 +1161,7 @@ fn process_is_running(process_id: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn process_is_running(_process_id: u32) -> bool {
+pub(crate) fn process_is_running(_process_id: u32) -> bool {
     true
 }
 
@@ -874,6 +1240,80 @@ mod tests {
     }
 
     #[test]
+    fn saved_codex_thread_relaunches_with_resume() {
+        let mut pane = pane("fluent", "codex");
+        pane.command.agent_kind = Some(AgentKind::Codex);
+        pane.command.args = vec!["--dangerously-bypass-approvals-and-sandbox".into()];
+        pane.codex_thread_id = Some("019f7b81-de49-7782-8186-a3dc2c644c61".into());
+
+        let launch = pane.launch_spec();
+
+        assert_eq!(launch.profile_name, "codex");
+        assert_eq!(
+            launch.command.args,
+            [
+                "--dangerously-bypass-approvals-and-sandbox",
+                "resume",
+                "019f7b81-de49-7782-8186-a3dc2c644c61",
+            ]
+        );
+    }
+
+    #[test]
+    fn shell_running_codex_becomes_a_resumable_codex_pane() {
+        let mut pane = pane("fluent", "git-bash");
+        pane.codex_thread_id = Some("019f7b81-e026-7d12-a013-25f4763f4bce".into());
+
+        let launch = pane.launch_spec();
+
+        assert_eq!(launch.profile_name, "codex");
+        assert_eq!(launch.command.command, "codex");
+        assert_eq!(
+            launch.command.args,
+            ["resume", "019f7b81-e026-7d12-a013-25f4763f4bce"]
+        );
+        assert_eq!(launch.command.agent_kind, Some(AgentKind::Codex));
+    }
+
+    #[test]
+    fn extracts_codex_resume_id_from_shell_history() {
+        let command = Profile {
+            command: "bash".into(),
+            args: Vec::new(),
+            title: Some("Git Bash".into()),
+            agent_kind: None,
+        };
+
+        assert_eq!(
+            codex_resume_id(
+                &command,
+                &["codex resume 019f7b81-e2cd-71c1-84dd-9f09622cf74e".into()]
+            )
+            .as_deref(),
+            Some("019f7b81-e2cd-71c1-84dd-9f09622cf74e")
+        );
+    }
+
+    #[test]
+    fn preserves_a_wrapper_that_already_resumes_the_saved_thread() {
+        let thread_id = "019f7b81-de49-7782-8186-a3dc2c644c61";
+        let command = Profile {
+            command: "powershell.exe".into(),
+            args: vec![
+                "-Command".into(),
+                format!("& codex --dangerously-bypass-approvals-and-sandbox resume {thread_id}"),
+            ],
+            title: Some("Codex".into()),
+            agent_kind: Some(AgentKind::Codex),
+        };
+
+        let (profile_name, restored) = codex_resume_profile("codex", &command, thread_id);
+        assert_eq!(profile_name, "codex");
+        assert_eq!(restored.command, command.command);
+        assert_eq!(restored.args, command.args);
+    }
+
+    #[test]
     fn summarizes_unique_folders_and_profiles() {
         let session = SavedSession {
             version: SESSION_VERSION,
@@ -911,6 +1351,9 @@ mod tests {
         background_pane.host = Some(PtyHostRef {
             endpoint: "127.0.0.1:32123".into(),
             token: "secret".into(),
+            process_id: None,
+            codex_sqlite_home: None,
+            started_at_ms: None,
         });
         let mut session = SavedSession {
             version: SESSION_VERSION,
@@ -1048,6 +1491,87 @@ mod tests {
     }
 
     #[test]
+    fn resume_rejects_only_sessions_with_live_owners() {
+        let mut session = recovery_session("live", vec![pane("alpha", "codex")]);
+        session.running = true;
+        session.owner_pid = Some(std::process::id());
+        let record = SessionRecord {
+            path: PathBuf::from("live.toml"),
+            session,
+        };
+
+        let error = ensure_session_is_resumable(record.clone()).expect_err("live owner rejected");
+        assert!(error.to_string().contains("already open"));
+
+        let mut interrupted = record;
+        interrupted.session.owner_pid = Some(u32::MAX);
+        ensure_session_is_resumable(interrupted).expect("dead owner can be recovered");
+    }
+
+    #[test]
+    fn resume_claim_is_persisted_before_the_session_is_returned() {
+        let directory = env::temp_dir().join(format!(
+            "gridbash-resume-claim-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join("claim.toml");
+        let record = SessionRecord {
+            path: path.clone(),
+            session: recovery_session("claim", vec![pane("alpha", "codex")]),
+        };
+        save_session_to_path(&path, &record.session).expect("save unclaimed session");
+
+        let claimed = claim_resume_session_locked(record.clone()).expect("claim session");
+        assert!(claimed.session.running);
+        assert_eq!(claimed.session.owner_pid, Some(std::process::id()));
+
+        let error = claim_resume_session_locked(record).expect_err("second claim rejected");
+        assert!(error.to_string().contains("already open"));
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn deleting_a_saved_session_removes_its_snapshot() {
+        let directory = env::temp_dir().join(format!(
+            "gridbash-delete-session-test-{}-{}",
+            std::process::id(),
+            now_seconds()
+        ));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join("saved.toml");
+        let record = SessionRecord {
+            path: path.clone(),
+            session: recovery_session("saved", vec![pane("alpha", "codex")]),
+        };
+        save_session_to_path(&path, &record.session).expect("write session snapshot");
+
+        delete_saved_session(&record).expect("delete saved session");
+
+        assert!(!path.exists());
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn deleting_an_open_session_is_refused() {
+        let mut session = recovery_session("open", vec![pane("alpha", "codex")]);
+        session.running = true;
+        session.owner_pid = Some(std::process::id());
+        let record = SessionRecord {
+            path: PathBuf::from("open.toml"),
+            session,
+        };
+
+        let error = delete_saved_session(&record).expect_err("open session must be protected");
+
+        assert!(error.to_string().contains("close that client"));
+    }
+
+    #[test]
     fn interrupted_sessions_are_grouped_into_directory_named_tabs() {
         let alpha = PathBuf::from("workspaces").join("alpha");
         let beta = PathBuf::from("workspaces").join("beta");
@@ -1105,6 +1629,55 @@ mod tests {
             recovery.tabs[0].panes[0].history.output_tail,
             "first conversation"
         );
+        assert_eq!(recovery.claim.sources.len(), 2);
+    }
+
+    #[test]
+    fn session_recorder_skips_unchanged_snapshots() {
+        let directory = env::temp_dir().join(format!(
+            "gridbash-session-dirty-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join("session.toml");
+        let mut recorder = SessionRecorder {
+            path: path.clone(),
+            session: recovery_session("dirty", vec![pane("alpha", "codex")]),
+            last_saved_digest: None,
+        };
+
+        assert!(recorder.save_if_changed().expect("first save"));
+        let first = fs::read(&path).expect("first snapshot");
+        assert!(!recorder.save_if_changed().expect("unchanged save"));
+        assert_eq!(fs::read(&path).expect("unchanged snapshot"), first);
+
+        recorder.session.title = "Changed".into();
+        assert!(recorder.save_if_changed().expect("changed save"));
+        assert_ne!(fs::read(&path).expect("changed snapshot"), first);
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn live_and_legacy_hosts_are_protected_from_pruning() {
+        let mut session = recovery_session("host", vec![pane("alpha", "codex")]);
+        session.panes[0].host = Some(PtyHostRef {
+            endpoint: "127.0.0.1:12345".into(),
+            token: "token".into(),
+            process_id: Some(std::process::id()),
+            codex_sqlite_home: None,
+            started_at_ms: None,
+        });
+        assert!(session_has_live_host(&session));
+
+        session.panes[0].host.as_mut().expect("host").process_id = Some(u32::MAX);
+        assert!(!session_has_live_host(&session));
+
+        session.panes[0].host.as_mut().expect("host").process_id = None;
+        assert!(session_has_live_host(&session));
     }
 
     fn recovery_session(id: &str, panes: Vec<SavedPane>) -> SavedSession {
@@ -1140,6 +1713,7 @@ mod tests {
             auth_name: None,
             auth_kind: None,
             history: SavedPaneHistory::default(),
+            codex_thread_id: None,
             host: None,
         }
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -106,8 +106,18 @@ impl PaneLaunchSpec {
         self.command.resolved_command()
     }
 
+    pub fn is_agent(&self) -> bool {
+        command_basename(&self.command.command)
+            .is_some_and(|name| name.eq_ignore_ascii_case("vibe"))
+            || is_agent_like(&self.profile_name)
+            || self.command.title.as_deref().is_some_and(is_agent_like)
+            || command_basename(&self.command.command).is_some_and(is_agent_like)
+    }
+
     pub fn agent_label(&self) -> Option<String> {
-        if command_basename(&self.command.command).as_deref() == Some("vibe") {
+        if command_basename(&self.command.command)
+            .is_some_and(|name| name.eq_ignore_ascii_case("vibe"))
+        {
             return self
                 .command
                 .args
@@ -118,12 +128,7 @@ impl PaneLaunchSpec {
                 .map(clean_agent_label);
         }
 
-        if is_agent_like(&self.profile_name)
-            || self.command.title.as_deref().is_some_and(is_agent_like)
-            || command_basename(&self.command.command)
-                .as_deref()
-                .is_some_and(is_agent_like)
-        {
+        if self.is_agent() {
             return Some(clean_agent_label(
                 self.command
                     .title
@@ -164,36 +169,25 @@ fn run_git(path: &Path, args: &[&str]) -> Option<String> {
     (!value.is_empty()).then_some(value)
 }
 
-fn command_basename(command: &str) -> Option<String> {
+fn command_basename(command: &str) -> Option<&str> {
     let path = Path::new(command);
-    let file_name = path
-        .file_stem()
+    path.file_stem()
         .or_else(|| path.file_name())
-        .and_then(|value| value.to_str())?;
-    Some(file_name.to_ascii_lowercase())
+        .and_then(|value| value.to_str())
 }
 
 fn is_agent_like(value: &str) -> bool {
-    let normalized = value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
-    let parts = normalized
-        .split('-')
+    value
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
         .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>();
-
-    AGENT_PROFILE_NAMES.iter().any(|agent| {
-        parts
-            .iter()
-            .any(|part| *part == *agent || part.starts_with(agent))
-    })
+        .any(|part| {
+            AGENT_PROFILE_NAMES.iter().any(|agent| {
+                part.eq_ignore_ascii_case(agent)
+                    || part
+                        .get(..agent.len())
+                        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(agent))
+            })
+        })
 }
 
 fn clean_agent_label(value: String) -> String {
@@ -231,6 +225,7 @@ mod tests {
             auth_dir: None,
         };
 
+        assert!(spec.is_agent());
         assert_eq!(spec.agent_label().as_deref(), Some("claude-1"));
     }
 
@@ -254,6 +249,7 @@ mod tests {
             auth_dir: None,
         };
 
+        assert!(spec.is_agent());
         assert_eq!(spec.agent_label().as_deref(), Some("Codex Review"));
     }
 
@@ -277,6 +273,7 @@ mod tests {
             auth_dir: None,
         };
 
+        assert!(!spec.is_agent());
         assert_eq!(spec.agent_label(), None);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,23 +1,23 @@
 use ratatui::{
     Frame,
     buffer::Buffer,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget},
+    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
 };
 use vt100::Cell;
 
 use crate::{
     app::{
         App, AssistantMessageRole, BackgroundJobState, BackgroundJobView, BackgroundJobsView,
-        CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog, GoalEditorView, GridPalette,
-        PaneSelection, PaneSettingsTarget, PaneSettingsView, PreviousPaneView, PreviousPanesView,
+        CloseGridConfirmationView, CommandPaletteView, ExitedPaneRecoveryView, FollowUpDialog,
+        GoalEditorView, GridPalette, PaneSelection, PaneSettingsTarget, PaneSettingsView,
+        PortInspectorView, PreviousPaneView, PreviousPanesView, QuitConfirmationView,
         RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind,
         TabLabel, WorkspaceAssistantView,
     },
     auth::{AgentKind, AuthProfile},
-    composer::GridPickerMode,
     copy_mode::{CopyCellKind, CopyModeView, TextPoint},
     image_preview::ImagePreview,
 };
@@ -30,10 +30,12 @@ const SETTINGS_SHADOW: Color = Color::Rgb(4, 6, 10);
 const SETTINGS_BORDER: Color = Color::Rgb(58, 210, 210);
 const SETTINGS_MUTED: Color = Color::Rgb(118, 135, 149);
 const SETTINGS_TEXT: Color = Color::Rgb(230, 237, 243);
+const TAB_WAITING_BG: Color = Color::Green;
 
 pub struct DrawState {
     pub grid_area: Rect,
     pub pane_rects: Vec<Rect>,
+    pub tab_rects: Vec<(usize, Rect)>,
     pub previous_panes_button: Option<Rect>,
     pub previous_pane_rows: Vec<(usize, Rect)>,
     pub pane_settings_button: Option<Rect>,
@@ -45,6 +47,8 @@ pub struct DrawState {
     pub pane_settings_stop_goal_button: Option<Rect>,
     pub background_jobs_button: Option<Rect>,
     pub background_job_rows: Vec<(usize, Rect)>,
+    pub ports_button: Option<Rect>,
+    pub port_rows: Vec<(usize, Rect)>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -63,6 +67,7 @@ const PANE_SETTINGS_BUTTON: &str = " Summary ";
 
 pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let area = frame.area();
+    let command_height = command_line_height(app.command_focused());
     let output_height = if app.command_output_expanded() {
         command_output_height(area.height, app.command_output_lines().len())
     } else {
@@ -74,7 +79,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             Constraint::Length(1),
             Constraint::Min(1),
             Constraint::Length(output_height),
-            Constraint::Length(1),
+            Constraint::Length(command_height),
             Constraint::Length(1),
         ])
         .split(area);
@@ -90,6 +95,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let tab_rename_view = app.rename_tab_view();
     let previous_panes_view = app.previous_panes_view();
     let background_jobs_view = app.background_jobs_view();
+    let port_inspector_view = app.port_inspector_view();
     let follow_up_dialog = app.follow_up_dialog();
     let goal_editor_view = app.goal_editor_view();
     let pane_settings_view = app.pane_settings_view();
@@ -98,6 +104,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let assistant_view = app.workspace_assistant_view();
+    let quit_confirmation = app.quit_confirmation_view();
+    let close_grid_confirmation = app.close_grid_confirmation_view();
     let help_open = app.help_open();
     let copy_mode_open = app.copy_mode_open();
     let exited_recovery = if command_palette_view.is_some()
@@ -106,6 +114,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || app.settings_open()
         || previous_panes_view.is_some()
         || background_jobs_view.is_some()
+        || port_inspector_view.is_some()
         || pane_settings_open
         || rename_view.is_some()
         || tab_rename_view.is_some()
@@ -114,6 +123,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || goal_editor_view.is_some()
         || image_overlay.is_some()
         || assistant_view.is_some()
+        || quit_confirmation.is_some()
+        || close_grid_confirmation.is_some()
     {
         None
     } else {
@@ -125,6 +136,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || app.settings_open()
         || previous_panes_view.is_some()
         || background_jobs_view.is_some()
+        || port_inspector_view.is_some()
         || pane_settings_open
         || rename_view.is_some()
         || tab_rename_view.is_some()
@@ -133,6 +145,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         || goal_editor_view.is_some()
         || image_overlay.is_some()
         || assistant_view.is_some()
+        || quit_confirmation.is_some()
+        || close_grid_confirmation.is_some()
         || exited_recovery.is_some();
     let mut pane_settings_rename_button = None;
     let mut pane_settings_reload_button = None;
@@ -140,7 +154,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let mut pane_settings_deactivate_button = None;
     let mut pane_settings_goal_button = None;
     let mut pane_settings_stop_goal_button = None;
-    render_tabs(frame, tab_area, &app.tab_labels(), palette);
+    let tab_rects = render_tabs(frame, tab_area, &app.tab_labels(), palette);
 
     for (index, pane) in app.panes().iter().enumerate() {
         let Some(rect) = rects.get(index).copied() else {
@@ -213,6 +227,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let pane_settings_button = pane_settings_button_rect(status_area);
     let background_jobs_button =
         background_jobs_button_rect(status_area, app.background_job_count());
+    let ports_button = ports_button_rect(status_area, app.agent_port_count());
+    let selection_status = if app.selected_grid_count() == 0 {
+        format!("{} panes selected", app.selected().len())
+    } else {
+        format!(
+            "{} panes | {} grids selected",
+            app.selected().len(),
+            app.selected_grid_count()
+        )
+    };
     let status = Line::from(vec![
         Span::styled(
             STATUS_BRAND,
@@ -265,7 +289,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             }),
         ),
         Span::raw(" | "),
-        Span::raw(format!("{} selected", app.selected().len())),
+        Span::raw(selection_status),
         Span::raw(" | "),
         Span::raw(app.status().to_string()),
         Span::raw(" | F1 help | Alt+q quit fallback"),
@@ -274,6 +298,18 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         Paragraph::new(status).style(Style::default().bg(APP_BG)),
         status_area,
     );
+    if let Some(button) = ports_button {
+        frame.render_widget(
+            Paragraph::new(ports_button_label(app.agent_port_count()))
+                .alignment(Alignment::Center)
+                .style(ports_button_style(
+                    app.port_inspector_open(),
+                    app.agent_port_count(),
+                    palette,
+                )),
+            button,
+        );
+    }
 
     if app.settings_open() {
         render_settings(frame, area, app, palette);
@@ -298,6 +334,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     } else {
         Vec::new()
     };
+    let port_rows = if let Some(view) = port_inspector_view.as_ref() {
+        render_port_inspector(frame, area, view, palette)
+    } else {
+        Vec::new()
+    };
     if let Some(rename) = rename_view.as_ref() {
         render_rename_pane(frame, area, rename);
     }
@@ -314,7 +355,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         render_exited_recovery(frame, area, recovery, palette);
     }
     if let Some(picker) = grid_resizer {
-        picker.draw(frame, GridPickerMode::Resize, None);
+        picker.draw(frame, None);
     }
     if help_open {
         render_help(frame, area, app, palette);
@@ -325,10 +366,17 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     if let Some(view) = command_palette_view.as_ref() {
         render_command_palette(frame, area, view, palette);
     }
+    if let Some(confirmation) = quit_confirmation.as_ref() {
+        render_quit_confirmation(frame, area, confirmation, palette);
+    }
+    if let Some(confirmation) = close_grid_confirmation.as_ref() {
+        render_close_grid_confirmation(frame, area, confirmation, palette);
+    }
 
     DrawState {
         grid_area,
         pane_rects: rects,
+        tab_rects,
         previous_panes_button,
         previous_pane_rows,
         pane_settings_button,
@@ -340,6 +388,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         pane_settings_stop_goal_button,
         background_jobs_button,
         background_job_rows,
+        ports_button,
+        port_rows,
     }
 }
 
@@ -386,9 +436,14 @@ fn pane_title(
     truncate_text(&format!(" {} ", parts.join(" | ")), max_width)
 }
 
-fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &GridPalette) {
+fn render_tabs(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    tabs: &[TabLabel],
+    palette: &GridPalette,
+) -> Vec<(usize, Rect)> {
     if area.width == 0 || area.height == 0 {
-        return;
+        return Vec::new();
     }
 
     let mut spans = vec![
@@ -401,14 +456,25 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
         ),
         Span::raw(" "),
     ];
+    let mut tab_rects = Vec::with_capacity(tabs.len());
+    let mut tab_x = area
+        .x
+        .saturating_add(u16::try_from(Line::from(STATUS_BRAND).width()).unwrap_or(u16::MAX))
+        .saturating_add(1);
+    let area_right = area.x.saturating_add(area.width);
 
     for (index, tab) in tabs.iter().enumerate() {
-        let marker = if tab.exited {
+        let state_marker = if tab.exited {
             "!"
         } else if tab.activity && !tab.active {
             "*"
         } else {
             ""
+        };
+        let marker = if tab.selected {
+            format!("+{state_marker}")
+        } else {
+            state_marker.to_string()
         };
         let label = format!(
             " {}:{}{} ",
@@ -416,10 +482,44 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
             truncate_text(&tab.title, 18),
             marker
         );
-        let style = if tab.active {
-            Style::default()
+        let label_width = u16::try_from(Line::from(label.as_str()).width()).unwrap_or(u16::MAX);
+        if tab_x < area_right {
+            tab_rects.push((
+                index,
+                Rect::new(
+                    tab_x,
+                    area.y,
+                    label_width.min(area_right.saturating_sub(tab_x)),
+                    1,
+                ),
+            ));
+        }
+        tab_x = tab_x.saturating_add(label_width);
+
+        let style = if tab.waiting {
+            let style = Style::default()
+                .fg(Color::Black)
+                .bg(TAB_WAITING_BG)
+                .add_modifier(Modifier::BOLD);
+            if tab.active {
+                style.add_modifier(Modifier::UNDERLINED)
+            } else {
+                style
+            }
+        } else if tab.active {
+            let style = Style::default()
                 .fg(Color::Black)
                 .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD);
+            if tab.selected {
+                style.add_modifier(Modifier::UNDERLINED)
+            } else {
+                style
+            }
+        } else if tab.selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(palette.selected())
                 .add_modifier(Modifier::BOLD)
         } else if tab.exited {
             Style::default().fg(palette.exited())
@@ -443,6 +543,16 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
     ));
     spans.push(Span::raw(" "));
     spans.push(Span::styled(
+        "Alt+Shift+s select",
+        Style::default().fg(Color::DarkGray),
+    ));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
+        "Alt+x swap",
+        Style::default().fg(Color::DarkGray),
+    ));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(
         "Alt+Shift+r rename",
         Style::default().fg(Color::DarkGray),
     ));
@@ -451,7 +561,14 @@ fn render_tabs(frame: &mut Frame<'_>, area: Rect, tabs: &[TabLabel], palette: &G
         Paragraph::new(Line::from(spans)).style(Style::default().bg(APP_BG)),
         area,
     );
+
+    tab_rects
 }
+
+fn command_line_height(focused: bool) -> u16 {
+    u16::from(focused)
+}
+
 fn command_output_height(total_height: u16, line_count: usize) -> u16 {
     let available = total_height.saturating_sub(3);
     if available < 3 {
@@ -745,6 +862,42 @@ fn background_jobs_button_style(open: bool, palette: &GridPalette) -> Style {
     } else {
         Style::default()
             .fg(palette.accent())
+            .add_modifier(Modifier::BOLD)
+    }
+}
+
+fn ports_button_label(count: usize) -> String {
+    format!(" Ports {count} ")
+}
+
+fn ports_button_rect(status_area: Rect, count: usize) -> Option<Rect> {
+    let width = ports_button_label(count).len() as u16;
+    if status_area.height == 0 || status_area.width < width {
+        return None;
+    }
+    Some(Rect {
+        x: status_area.right().saturating_sub(width),
+        y: status_area.y,
+        width,
+        height: 1,
+    })
+}
+
+fn ports_button_style(open: bool, count: usize, palette: &GridPalette) -> Style {
+    if open {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else if count > 0 {
+        Style::default()
+            .fg(Color::Black)
+            .bg(palette.accent())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(Color::DarkGray)
+            .bg(APP_BG)
             .add_modifier(Modifier::BOLD)
     }
 }
@@ -1784,6 +1937,210 @@ fn previous_panes_command_bar(width: u16) -> Line<'static> {
     ])
 }
 
+fn render_port_inspector(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    view: &PortInspectorView,
+    palette: &GridPalette,
+) -> Vec<(usize, Rect)> {
+    let modal = previous_panes_modal_rect(area, view.ports.len().max(1));
+    let shadow = settings_shadow_rect(area, modal);
+    let mut row_hits = Vec::new();
+
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.accent())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Agent Ports ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+    if inner.width == 0 || inner.height == 0 {
+        return row_hits;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+    let count = match view.ports.len() {
+        1 => "1 TCP listener".to_string(),
+        count => format!("{count} TCP listeners"),
+    };
+    let scan_state = if view.refreshing {
+        "  refreshing..."
+    } else {
+        "  launched by GridBash agents"
+    };
+    let header = vec![
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                count,
+                Style::default()
+                    .fg(palette.accent())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(scan_state, Style::default().fg(Color::Gray)),
+        ]),
+        Line::from(Span::styled(
+            view.error
+                .as_deref()
+                .map(|error| format!("  Scan error: {error}"))
+                .unwrap_or_else(|| "  PORT   PROCESS              PID  PANE / TAB".into()),
+            Style::default().fg(if view.error.is_some() {
+                Color::LightRed
+            } else {
+                SETTINGS_MUTED
+            }),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(header).style(settings_panel_style()),
+        chunks[0],
+    );
+
+    let list_area = chunks[1];
+    if view.ports.is_empty() {
+        let message = if view.refreshing {
+            "  Looking for localhost listeners in agent process trees..."
+        } else {
+            "  No agent-owned localhost listeners are active."
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(message, Style::default().fg(SETTINGS_MUTED)))
+                .style(settings_panel_style()),
+            list_area,
+        );
+    } else {
+        let visible =
+            visible_previous_pane_range(view.ports.len(), view.cursor, list_area.height as usize);
+        let mut rows = Vec::new();
+        for (row_offset, index) in visible.enumerate() {
+            let Some(port) = view.ports.get(index) else {
+                continue;
+            };
+            let row_area = Rect {
+                x: list_area.x,
+                y: list_area.y.saturating_add(row_offset as u16),
+                width: list_area.width,
+                height: 1,
+            };
+            row_hits.push((index, row_area));
+            rows.push(agent_port_line(
+                port.port,
+                port.pid,
+                &port.process,
+                &port.owner,
+                view.cursor == index,
+                view.pending_terminate == Some(port.pid),
+                list_area.width,
+            ));
+        }
+        frame.render_widget(
+            Paragraph::new(rows).style(settings_panel_style()),
+            list_area,
+        );
+    }
+
+    frame.render_widget(
+        Paragraph::new(port_inspector_command_bar(
+            chunks[2].width,
+            view.pending_terminate.is_some(),
+        ))
+        .style(settings_panel_style()),
+        chunks[2],
+    );
+    row_hits
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agent_port_line(
+    port: u16,
+    pid: u32,
+    process: &str,
+    owner: &str,
+    active: bool,
+    pending_terminate: bool,
+    width: u16,
+) -> Line<'static> {
+    let process_width = if width < 62 { 12 } else { 18 };
+    let owner = if active && pending_terminate {
+        "Press Enter to terminate"
+    } else {
+        owner
+    };
+    let text = format!(
+        "{} {:>5}   {:<process_width$} {:>7}  {}",
+        if active { ">" } else { " " },
+        port,
+        truncate_text(process, process_width),
+        pid,
+        owner,
+    );
+    let fg = if active && pending_terminate {
+        Color::LightRed
+    } else if active {
+        SETTINGS_TEXT
+    } else {
+        Color::LightCyan
+    };
+    Line::from(Span::styled(
+        fixed_width(&text, width as usize),
+        row_style(fg, active.then_some(SETTINGS_ROW_ACTIVE), active),
+    ))
+}
+
+fn port_inspector_command_bar(width: u16, pending_terminate: bool) -> Line<'static> {
+    if pending_terminate {
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" terminate process  ", Style::default().fg(Color::LightRed)),
+            command_key("Esc"),
+            Span::styled(" cancel", Style::default().fg(Color::Gray)),
+        ]);
+    }
+    if width < 60 {
+        return Line::from(vec![
+            Span::raw("  "),
+            command_key("Enter"),
+            Span::styled(" stop  ", Style::default().fg(Color::Gray)),
+            command_key("R"),
+            Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
+            command_key("Esc"),
+            Span::styled(" close", Style::default().fg(Color::Gray)),
+        ]);
+    }
+    Line::from(vec![
+        Span::raw("  "),
+        command_key("Up/Down"),
+        Span::styled(" move  ", Style::default().fg(Color::Gray)),
+        command_key("Enter/Delete"),
+        Span::styled(" terminate  ", Style::default().fg(Color::Gray)),
+        command_key("R"),
+        Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
+        command_key("Esc"),
+        Span::styled(" close", Style::default().fg(Color::Gray)),
+    ])
+}
+
 fn render_background_jobs(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -2296,6 +2653,125 @@ fn render_follow_up_dialog(frame: &mut Frame<'_>, area: Rect, dialog: &FollowUpD
     frame.render_widget(block, modal);
     frame.render_widget(
         Paragraph::new(follow_up_lines(dialog, inner.width)).style(settings_panel_style()),
+        inner,
+    );
+}
+
+fn render_quit_confirmation(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    confirmation: &QuitConfirmationView,
+    palette: &GridPalette,
+) {
+    let modal = quit_confirmation_modal_rect(area);
+    let shadow = settings_shadow_rect(area, modal);
+
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+
+    frame.render_widget(Clear, modal);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.accent())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Quit GridBash? ")
+        .title_bottom(" Alt+Q confirms | Any other key cancels ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let behavior = if confirmation.keeps_terminals_running {
+        "Your exact workspace has been saved. Live terminals will stay running."
+    } else {
+        "Your exact workspace has been saved. Pane processes will close with GridBash."
+    };
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(behavior, Style::default().fg(SETTINGS_TEXT))),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Resume this setup directly with:",
+            Style::default().fg(SETTINGS_MUTED),
+        )),
+        Line::from(Span::styled(
+            confirmation.resume_command.clone(),
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )),
+    ];
+    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), inner);
+}
+
+fn render_close_grid_confirmation(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    confirmation: &CloseGridConfirmationView,
+    palette: &GridPalette,
+) {
+    let modal = quit_confirmation_modal_rect(area);
+    let shadow = settings_shadow_rect(area, modal);
+
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+
+    frame.render_widget(Clear, modal);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.exited())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Close current grid? ")
+        .title_bottom(" Enter / Y closes | Esc / N cancels ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+
+    let pane_label = if confirmation.pane_count == 1 {
+        "pane"
+    } else {
+        "panes"
+    };
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!(
+                "Close \"{}\" and terminate {} {pane_label}?",
+                confirmation.title, confirmation.pane_count
+            ),
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Every visible process in this grid will stop.",
+            Style::default().fg(SETTINGS_TEXT),
+        )),
+        Line::from(Span::styled(
+            "Managed worktrees and branches will stay on disk.",
+            Style::default().fg(SETTINGS_MUTED),
+        )),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: true })
+            .style(settings_panel_style()),
         inner,
     );
 }
@@ -3410,6 +3886,22 @@ fn follow_up_modal_rect(area: Rect) -> Rect {
     }
 }
 
+fn quit_confirmation_modal_rect(area: Rect) -> Rect {
+    let width = area.width.saturating_sub(4).min(78).max(area.width.min(1));
+    let height = area
+        .height
+        .saturating_sub(2)
+        .min(10)
+        .max(area.height.min(1));
+
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
 fn settings_shadow_rect(area: Rect, modal: Rect) -> Rect {
     let offset_x = if modal.x.saturating_add(modal.width).saturating_add(2)
         <= area.x.saturating_add(area.width)
@@ -3517,11 +4009,15 @@ fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
 
     let style = Style::default().fg(Color::Black).bg(Color::Black);
     let buffer = frame.buffer_mut();
+    // Indexing a `Buffer` outside its area panics, so clip first and still take
+    // the `Option` path: a pane rect can outlive the frame it was measured in.
+    let area = area.intersection(buffer.area);
     for y in area.top()..area.bottom() {
         for x in area.left()..area.right() {
-            let cell = &mut buffer[(x, y)];
-            cell.reset();
-            cell.set_style(style);
+            if let Some(cell) = buffer.cell_mut((x, y)) {
+                cell.reset();
+                cell.set_style(style);
+            }
         }
     }
 }
@@ -3553,7 +4049,7 @@ fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, pale
         ..area
     };
     let footer = Rect {
-        y: area.y + body.height,
+        y: area.y.saturating_add(body.height),
         height: footer_height,
         ..area
     };
@@ -3561,39 +4057,47 @@ fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, pale
         .rows
         .iter()
         .map(|row| {
-            let spans = row
-                .text
-                .chars()
-                .enumerate()
-                .map(|(offset, ch)| {
-                    let point = TextPoint {
-                        line: row.line,
-                        column: view.left_column + offset,
-                    };
-                    let style = match view.cell_kind(point) {
-                        CopyCellKind::Normal => {
-                            Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)
-                        }
-                        CopyCellKind::Match => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::DarkGray)
-                            .add_modifier(Modifier::BOLD),
-                        CopyCellKind::ActiveMatch => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Yellow)
-                            .add_modifier(Modifier::BOLD),
-                        CopyCellKind::Selection => Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::LightCyan)
-                            .add_modifier(Modifier::BOLD),
-                        CopyCellKind::Cursor => Style::default()
-                            .fg(Color::Black)
-                            .bg(palette.focus())
-                            .add_modifier(Modifier::BOLD),
-                    };
-                    Span::styled(ch.to_string(), style)
-                })
-                .collect::<Vec<_>>();
+            // Coalesce runs of equally styled characters. Rendering is
+            // unchanged, but a full-width row costs a handful of spans instead
+            // of one heap-allocated `Span` per character, every frame.
+            let mut spans = Vec::new();
+            let mut current_style: Option<Style> = None;
+            let mut current_text = String::new();
+            for (offset, ch) in row.text.chars().enumerate() {
+                let point = TextPoint {
+                    line: row.line,
+                    column: view.left_column + offset,
+                };
+                let style = match view.cell_kind(point) {
+                    CopyCellKind::Normal => {
+                        Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)
+                    }
+                    CopyCellKind::Match => Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                    CopyCellKind::ActiveMatch => Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                    CopyCellKind::Selection => Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::LightCyan)
+                        .add_modifier(Modifier::BOLD),
+                    CopyCellKind::Cursor => Style::default()
+                        .fg(Color::Black)
+                        .bg(palette.focus())
+                        .add_modifier(Modifier::BOLD),
+                };
+                if current_style.is_some_and(|active| active == style) {
+                    current_text.push(ch);
+                    continue;
+                }
+                flush_span(&mut spans, &mut current_style, &mut current_text);
+                current_style = Some(style);
+                current_text.push(ch);
+            }
+            flush_span(&mut spans, &mut current_style, &mut current_text);
             Line::from(spans)
         })
         .collect::<Vec<_>>();
@@ -3664,30 +4168,55 @@ fn refresh_screen_cache(
         .map(|row| render_screen_row(screen, row, width, selection))
         .collect::<Vec<_>>();
     let area = Rect::new(0, 0, width, height);
-    let mut buffer = Buffer::empty(area);
+    // Reuse the cached allocation instead of building a fresh pane-sized buffer
+    // on every screen revision, which for an active pane is once per frame.
+    if cache.buffer.area != area {
+        cache.buffer.resize(area);
+    }
+    cache.buffer.reset();
     Widget::render(
         Paragraph::new(lines).style(Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)),
         area,
-        &mut buffer,
+        &mut cache.buffer,
     );
     cache.revision = revision;
     cache.width = width;
     cache.height = height;
     cache.selection = selection;
-    cache.buffer = buffer;
 }
 
+/// Copy a cached pane buffer into the frame at `area`.
+///
+/// Rendering must never take GridBash down. A pane rect can outlive the frame it
+/// was measured against — the terminal can shrink between layout and draw — and
+/// both `Buffer::index_of` and slice indexing panic outright on an out-of-range
+/// position. Clamping to what the two buffers actually cover makes a stale rect
+/// drop cells for one frame instead of killing the process.
 fn blit_buffer(source: &Buffer, target: &mut Buffer, area: Rect) {
     debug_assert_eq!(source.area.width, area.width);
     debug_assert_eq!(source.area.height, area.height);
-    debug_assert_eq!(area.intersection(target.area), area);
 
-    let width = area.width as usize;
-    for row in 0..area.height {
-        let source_start = row as usize * width;
-        let target_start = target.index_of(area.x, area.y + row);
-        target.content[target_start..target_start + width]
-            .clone_from_slice(&source.content[source_start..source_start + width]);
+    let area = area.intersection(target.area);
+    let source_stride = source.area.width as usize;
+    let width = (area.width as usize).min(source_stride);
+    if width == 0 {
+        return;
+    }
+
+    // Index arithmetic mirrors Buffer::index_of without its out-of-range panic.
+    let target_stride = target.area.width as usize;
+    let target_column = area.x.saturating_sub(target.area.x) as usize;
+    for row in 0..area.height.min(source.area.height) {
+        let source_start = row as usize * source_stride;
+        let target_start =
+            (area.y.saturating_sub(target.area.y) + row) as usize * target_stride + target_column;
+        let Some(source_row) = source.content.get(source_start..source_start + width) else {
+            break;
+        };
+        let Some(target_row) = target.content.get_mut(target_start..target_start + width) else {
+            break;
+        };
+        target_row.clone_from_slice(source_row);
     }
 }
 
@@ -3868,6 +4397,8 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{cli::Cli, config::Config};
+    use clap::Parser;
     use ratatui::{Terminal, backend::TestBackend};
 
     fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
@@ -3878,6 +4409,123 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect()
+    }
+
+    /// The event loop catches a panic thrown inside `Terminal::draw`, which
+    /// abandons the frame half-written and never swaps the buffers. Resetting the
+    /// current buffer and clearing is what makes the next frame trustworthy.
+    #[test]
+    fn a_frame_abandoned_by_a_panic_redraws_cleanly() {
+        let backend = TestBackend::new(6, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new("aaaaaa"), frame.area());
+            })
+            .expect("first frame");
+        assert_eq!(buffer_text(&terminal), "aaaaaa");
+
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = terminal.draw(|frame| {
+                frame.render_widget(Paragraph::new("bbbbbb"), frame.area());
+                panic!("half-drawn frame");
+            });
+        }));
+        std::panic::set_hook(previous_hook);
+        assert!(panicked.is_err(), "the draw must have unwound");
+
+        // What the event loop does on recovery.
+        terminal.current_buffer_mut().reset();
+        terminal.clear().expect("clear after a caught panic");
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new("cc"), frame.area());
+            })
+            .expect("frame after recovery");
+        assert_eq!(
+            buffer_text(&terminal),
+            "cc    ",
+            "the abandoned frame must not bleed into the next one"
+        );
+    }
+
+    /// Pane rects are stored between frames, so a rect measured before a resize
+    /// can name cells the current frame does not have. Indexing a `Buffer`
+    /// outside its area panics, and this runs on every sleeping pane.
+    #[test]
+    fn the_sleeping_screen_clips_rects_that_outgrew_the_frame() {
+        let backend = TestBackend::new(10, 4);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| {
+                render_sleeping_screen(frame, Rect::new(0, 0, 200, 200));
+                render_sleeping_screen(frame, Rect::new(8, 3, 40, 40));
+                render_sleeping_screen(frame, Rect::new(50, 50, 4, 4));
+                render_sleeping_screen(frame, Rect::new(0, 0, 0, 0));
+                render_sleeping_screen(frame, Rect::new(u16::MAX, u16::MAX, u16::MAX, u16::MAX));
+            })
+            .expect("drawing a sleeping pane must not panic");
+
+        assert_eq!(buffer_text(&terminal).chars().count(), 40);
+    }
+
+    #[test]
+    fn tab_rendering_returns_click_targets_and_marks_selected_grids() {
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let tabs = vec![
+            TabLabel {
+                title: "Frontend".into(),
+                active: true,
+                selected: false,
+                waiting: false,
+                activity: false,
+                exited: false,
+            },
+            TabLabel {
+                title: "Tests".into(),
+                active: false,
+                selected: true,
+                waiting: false,
+                activity: false,
+                exited: false,
+            },
+            TabLabel {
+                title: "Review".into(),
+                active: false,
+                selected: false,
+                waiting: true,
+                activity: false,
+                exited: false,
+            },
+        ];
+        let mut targets = Vec::new();
+
+        terminal
+            .draw(|frame| {
+                targets = render_tabs(frame, frame.area(), &tabs, &GridPalette::default());
+            })
+            .expect("render tabs");
+
+        assert_eq!(targets.len(), 3);
+        assert_eq!(targets[0].0, 0);
+        assert_eq!(targets[1].0, 1);
+        assert_eq!(targets[0].1.right(), targets[1].1.x);
+        assert_eq!(targets[1].1.right(), targets[2].1.x);
+        assert!(buffer_text(&terminal).contains("2:Tests+"));
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .any(|cell| cell.symbol() == "R" && cell.bg == TAB_WAITING_BG)
+        );
     }
 
     #[test]
@@ -3900,6 +4548,75 @@ mod tests {
         let rendered = buffer_text(&terminal);
         assert!(rendered.contains("GridBash Commands"));
         assert!(rendered.contains("No matching"));
+    }
+
+    #[test]
+    fn quit_confirmation_shows_the_exact_resume_command() {
+        let backend = TestBackend::new(90, 18);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = QuitConfirmationView {
+            resume_command: "gridbash resume 1777777777777-42".into(),
+            keeps_terminals_running: true,
+        };
+
+        terminal
+            .draw(|frame| {
+                render_quit_confirmation(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render quit confirmation");
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("Quit GridBash?"));
+        assert!(rendered.contains("gridbash resume 1777777777777-42"));
+        assert!(rendered.contains("Alt+Q confirms"));
+        assert!(rendered.contains("Live terminals will stay running"));
+    }
+
+    #[test]
+    fn close_grid_confirmation_names_the_grid_and_consequences() {
+        let backend = TestBackend::new(90, 18);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = CloseGridConfirmationView {
+            title: "Backend agents".into(),
+            pane_count: 3,
+        };
+
+        terminal
+            .draw(|frame| {
+                render_close_grid_confirmation(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render close-grid confirmation");
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("Close current grid?"));
+        assert!(rendered.contains("Backend agents"));
+        assert!(rendered.contains("terminate 3 panes"));
+        assert!(rendered.contains("worktrees and branches will stay on disk"));
+        assert!(rendered.contains("Enter / Y closes"));
+    }
+
+    #[test]
+    fn command_line_is_hidden_until_focused() {
+        assert_eq!(command_line_height(false), 0);
+        assert_eq!(command_line_height(true), 1);
+    }
+
+    #[test]
+    fn hidden_command_line_renders_safely_at_small_terminal_sizes() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let app = App::new(cli, Config::default()).expect("app");
+
+        for (width, height) in [(1, 1), (2, 2), (40, 6)] {
+            let backend = TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).expect("test terminal");
+            terminal
+                .draw(|frame| {
+                    draw(frame, &app);
+                })
+                .expect("render hidden command line");
+
+            assert!(!buffer_text(&terminal).contains(" > "));
+        }
     }
 
     #[test]
@@ -4480,5 +5197,43 @@ mod tests {
         assert_eq!(target[(3, 2)].symbol(), "C");
         assert_eq!(target[(4, 2)].symbol(), "D");
         assert_eq!(target[(2, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn blitting_a_pane_rect_wider_than_the_frame_clamps_instead_of_panicking() {
+        // A rect measured before the terminal shrank: the release build used to
+        // panic here in Buffer::index_of and take the whole process down.
+        let mut source = Buffer::empty(Rect::new(0, 0, 4, 3));
+        for x in 0..4 {
+            for y in 0..3 {
+                source[(x, y)].set_symbol("S");
+            }
+        }
+        let mut target = Buffer::empty(Rect::new(0, 0, 3, 2));
+
+        blit_buffer(&source, &mut target, Rect::new(2, 1, 4, 3));
+
+        assert_eq!(target[(2, 1)].symbol(), "S");
+        assert_eq!(target[(0, 0)].symbol(), " ");
+    }
+
+    #[test]
+    fn blitting_a_pane_rect_fully_outside_the_frame_is_a_no_op() {
+        let mut source = Buffer::empty(Rect::new(0, 0, 2, 2));
+        source[(0, 0)].set_symbol("S");
+        let mut target = Buffer::empty(Rect::new(0, 0, 4, 4));
+        let untouched = target.clone();
+
+        blit_buffer(&source, &mut target, Rect::new(9, 9, 2, 2));
+
+        assert_eq!(target, untouched);
+    }
+
+    #[test]
+    fn ports_button_stays_anchored_to_footer_right_edge() {
+        let footer = Rect::new(4, 20, 80, 1);
+        let button = ports_button_rect(footer, 3).expect("ports button");
+        assert_eq!(button.right(), footer.right());
+        assert_eq!(button.width, ports_button_label(3).len() as u16);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -246,7 +246,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         render_shell_command_center(frame, command_center_area, app, palette);
     }
 
-    let status_buttons = render_status_bar(frame, status_area, app, palette);
+    let status_buttons =
+        render_status_bar(frame, status_area, &StatusBar::from_app(app), palette);
     let previous_panes_button = status_buttons.previous_panes;
     let pane_settings_button = status_buttons.pane_settings;
     let background_jobs_button = status_buttons.background_jobs;
@@ -924,6 +925,72 @@ struct StatusButtons {
     ports: Option<Rect>,
 }
 
+/// Everything the status bar draws, with nothing left to look up.
+///
+/// Like `PaneFrame`, this exists so the bar can be rendered without a live
+/// `App` behind it. That is not only convenience: `App::new` starts the agent
+/// control server, so building one just to read a handful of booleans leaves a
+/// bound port and a listener thread behind for the rest of the process.
+#[derive(Debug, Clone, Default)]
+pub struct StatusBar {
+    pub previous_panes_open: bool,
+    pub pane_settings_open: bool,
+    pub background_jobs_open: bool,
+    pub port_inspector_open: bool,
+    pub background_jobs: usize,
+    pub ports: usize,
+    pub voice_listening: bool,
+    pub zoomed: bool,
+    pub command_center_open: bool,
+    pub input_scope: &'static str,
+    pub selected_panes: usize,
+    pub selected_grids: usize,
+    pub status: String,
+}
+
+impl StatusBar {
+    fn from_app(app: &App) -> Self {
+        Self {
+            previous_panes_open: app.previous_panes_open(),
+            pane_settings_open: app.pane_settings_open(),
+            background_jobs_open: app.background_jobs_open(),
+            port_inspector_open: app.port_inspector_open(),
+            background_jobs: app.background_job_count(),
+            ports: app.agent_port_count(),
+            voice_listening: app.voice_listening(),
+            zoomed: app.zoomed(),
+            command_center_open: app.command_center_open(),
+            input_scope: app.input_scope_label(),
+            selected_panes: app.selected().len(),
+            selected_grids: app.selected_grid_count(),
+            status: app.status().to_string(),
+        }
+    }
+
+    fn mode(&self) -> &'static str {
+        if self.voice_listening {
+            "MIC"
+        } else if self.zoomed {
+            "ZOOM"
+        } else {
+            "LIVE"
+        }
+    }
+
+    /// The selection count, or nothing at all when nothing is selected.
+    ///
+    /// "0 panes selected" used to sit on screen permanently, reporting that the
+    /// normal state was the normal state.
+    fn selection_summary(&self) -> Option<String> {
+        match (self.selected_panes, self.selected_grids) {
+            (0, 0) => None,
+            (panes, 0) => Some(format!("{panes} selected")),
+            (0, grids) => Some(format!("{grids} grids selected")),
+            (panes, grids) => Some(format!("{panes} panes, {grids} grids selected")),
+        }
+    }
+}
+
 /// Draws the status bar and reports where its chips landed.
 ///
 /// The chip rects used to be derived a second time by a set of functions that
@@ -934,7 +1001,7 @@ struct StatusButtons {
 fn render_status_bar(
     frame: &mut Frame<'_>,
     area: Rect,
-    app: &App,
+    view: &StatusBar,
     palette: &GridPalette,
 ) -> StatusButtons {
     if area.width == 0 || area.height == 0 {
@@ -973,7 +1040,7 @@ fn render_status_bar(
         &mut spans,
         &mut cursor,
         PREVIOUS_PANES_BUTTON.to_string(),
-        chip_style(app.previous_panes_open(), palette.focus()),
+        chip_style(view.previous_panes_open, palette.focus()),
     );
     spans.push(Span::raw(" "));
     cursor = cursor.saturating_add(1);
@@ -981,19 +1048,18 @@ fn render_status_bar(
         &mut spans,
         &mut cursor,
         PANE_SETTINGS_BUTTON.to_string(),
-        chip_style(app.pane_settings_open(), palette.focus()),
+        chip_style(view.pane_settings_open, palette.focus()),
     );
     spans.push(Span::raw(" "));
     cursor = cursor.saturating_add(1);
-    let jobs = app.background_job_count();
     buttons.background_jobs = chip(
         &mut spans,
         &mut cursor,
-        background_jobs_button_label(jobs),
-        if jobs > 0 {
-            chip_style(app.background_jobs_open(), palette.accent())
+        background_jobs_button_label(view.background_jobs),
+        if view.background_jobs > 0 {
+            chip_style(view.background_jobs_open, palette.accent())
         } else {
-            quiet_chip_style(app.background_jobs_open())
+            quiet_chip_style(view.background_jobs_open)
         },
     );
 
@@ -1002,9 +1068,9 @@ fn render_status_bar(
     // then the last thing that happened.
     spans.push(Span::raw("  "));
     spans.push(Span::styled(
-        session_mode_label(app),
+        view.mode(),
         Style::default()
-            .fg(if app.voice_listening() {
+            .fg(if view.voice_listening {
                 palette.accent()
             } else {
                 palette.focus()
@@ -1012,16 +1078,16 @@ fn render_status_bar(
             .add_modifier(Modifier::BOLD),
     ));
     spans.push(Span::styled(
-        format!("  {}", app.input_scope_label()),
-        Style::default().fg(if app.command_center_open() {
+        format!("  {}", view.input_scope),
+        Style::default().fg(if view.command_center_open {
             palette.accent()
-        } else if app.selected().len() > 1 {
+        } else if view.selected_panes > 1 {
             palette.selected()
         } else {
             TEXT_DIM
         }),
     ));
-    if let Some(selection) = selection_summary(app) {
+    if let Some(selection) = view.selection_summary() {
         spans.push(Span::styled(
             format!("  {selection}"),
             Style::default().fg(palette.selected()),
@@ -1031,8 +1097,7 @@ fn render_status_bar(
     // into what is left over rather than across the whole bar. Rendering both
     // over the full width let a long status message run underneath the chip and
     // get overwritten.
-    let ports = app.agent_port_count();
-    buttons.ports = ports_button_rect(area, ports);
+    buttons.ports = ports_button_rect(area, view.ports);
     let text_area = Rect {
         width: buttons
             .ports
@@ -1043,12 +1108,12 @@ fn render_status_bar(
     // Status messages are sentences and routinely outrun the bar. Trimming to
     // what is left over ends them in an ellipsis rather than mid-word, so a cut
     // message reads as cut rather than as a typo.
-    if !app.status().is_empty() {
+    if !view.status.is_empty() {
         let used = spans.iter().map(Span::width).sum::<usize>();
         let room = (text_area.width as usize).saturating_sub(used + 2);
         if room >= 4 {
             spans.push(Span::styled(
-                format!("  {}", truncate_text(app.status(), room)),
+                format!("  {}", truncate_text(&view.status, room)),
                 Style::default().fg(TEXT_FAINT),
             ));
         }
@@ -1060,12 +1125,12 @@ fn render_status_bar(
 
     if let Some(button) = buttons.ports {
         frame.render_widget(
-            Paragraph::new(ports_button_label(ports))
+            Paragraph::new(ports_button_label(view.ports))
                 .alignment(Alignment::Center)
-                .style(if ports > 0 {
-                    chip_style(app.port_inspector_open(), palette.accent())
+                .style(if view.ports > 0 {
+                    chip_style(view.port_inspector_open, palette.accent())
                 } else {
-                    quiet_chip_style(app.port_inspector_open())
+                    quiet_chip_style(view.port_inspector_open)
                 }),
             button,
         );
@@ -1100,31 +1165,6 @@ fn quiet_chip_style(open: bool) -> Style {
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(TEXT_FAINT).bg(SURFACE_HI)
-    }
-}
-
-fn session_mode_label(app: &App) -> &'static str {
-    if app.voice_listening() {
-        "MIC"
-    } else if app.zoomed() {
-        "ZOOM"
-    } else {
-        "LIVE"
-    }
-}
-
-/// The selection count, or nothing at all when nothing is selected.
-///
-/// "0 panes selected" was on screen permanently to say that the normal state is
-/// the normal state.
-fn selection_summary(app: &App) -> Option<String> {
-    let panes = app.selected().len();
-    let grids = app.selected_grid_count();
-    match (panes, grids) {
-        (0, 0) => None,
-        (panes, 0) => Some(format!("{panes} selected")),
-        (0, grids) => Some(format!("{grids} grids selected")),
-        (panes, grids) => Some(format!("{panes} panes, {grids} grids selected")),
     }
 }
 
@@ -4731,8 +4771,6 @@ mod tests {
     /// about glyphs on a screen. This draws the real chrome functions so that
     /// question can be answered without a terminal full of live PTYs behind it.
     fn preview_shell(width: u16, height: u16, grid: GridSize) -> String {
-        let cli = Cli::parse_from(["gridbash"]);
-        let app = App::new(cli, Config::default()).expect("app");
         let palette = GridPalette::default();
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -4782,7 +4820,14 @@ mod tests {
                 render_status_bar(
                     frame,
                     Rect::new(0, height.saturating_sub(1), width, 1),
-                    &app,
+                    &StatusBar {
+                        input_scope: "focused pane",
+                        selected_panes: 1,
+                        background_jobs: 2,
+                        ports: 3,
+                        status: "agent pane tools ready | Drag copies within pane".into(),
+                        ..StatusBar::default()
+                    },
                     &palette,
                 );
             })
@@ -4943,6 +4988,40 @@ mod tests {
         );
     }
 
+    /// The chrome must be drawable from plain data.
+    ///
+    /// `App::new` starts the agent control server, so an `App` built purely to
+    /// read a few booleans leaves a bound port and a live listener behind for
+    /// the rest of the test process. Two such tests were enough to make the
+    /// timing-sensitive `pane_host` socket tests fail later in the same run.
+    /// Rendering from a view model keeps that out of the test binary entirely.
+    #[test]
+    fn the_status_bar_renders_without_a_live_app() {
+        let backend = TestBackend::new(100, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = StatusBar {
+            background_jobs: 4,
+            ports: 2,
+            zoomed: true,
+            input_scope: "selected panes",
+            selected_panes: 3,
+            status: "everything is fine".into(),
+            ..StatusBar::default()
+        };
+
+        terminal
+            .draw(|frame| {
+                render_status_bar(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render status bar");
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains("ZOOM"), "bar: {rendered}");
+        assert!(rendered.contains(" BG 4 "), "bar: {rendered}");
+        assert!(rendered.contains(" Ports 2 "), "bar: {rendered}");
+        assert!(rendered.contains("3 selected"), "bar: {rendered}");
+    }
+
     /// The hints exist to be discoverable, not to be load-bearing. A terminal
     /// too narrow for them must spend its width on the tabs instead.
     #[test]
@@ -4964,15 +5043,17 @@ mod tests {
     /// renaming a button moved it on screen without moving its click target.
     #[test]
     fn status_bar_click_targets_match_what_was_drawn() {
-        let cli = Cli::parse_from(["gridbash"]);
-        let app = App::new(cli, Config::default()).expect("app");
         let backend = TestBackend::new(120, 1);
         let mut terminal = Terminal::new(backend).expect("test terminal");
         let mut buttons = StatusButtons::default();
+        let view = StatusBar {
+            input_scope: "focused pane",
+            ..StatusBar::default()
+        };
 
         terminal
             .draw(|frame| {
-                buttons = render_status_bar(frame, frame.area(), &app, &GridPalette::default());
+                buttons = render_status_bar(frame, frame.area(), &view, &GridPalette::default());
             })
             .expect("render status bar");
 
@@ -5005,10 +5086,24 @@ mod tests {
     /// unusual was happening.
     #[test]
     fn the_status_bar_stays_silent_about_an_empty_selection() {
-        let cli = Cli::parse_from(["gridbash"]);
-        let app = App::new(cli, Config::default()).expect("app");
+        let quiet = StatusBar::default();
+        assert_eq!(quiet.selection_summary(), None);
 
-        assert_eq!(selection_summary(&app), None);
+        let panes = StatusBar {
+            selected_panes: 3,
+            ..StatusBar::default()
+        };
+        assert_eq!(panes.selection_summary().as_deref(), Some("3 selected"));
+
+        let both = StatusBar {
+            selected_panes: 3,
+            selected_grids: 2,
+            ..StatusBar::default()
+        };
+        assert_eq!(
+            both.selection_summary().as_deref(),
+            Some("3 panes, 2 grids selected")
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,8 +3,9 @@ use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
+    symbols::merge::MergeStrategy,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Widget, Wrap},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 use vt100::Cell;
 
@@ -22,7 +23,48 @@ use crate::{
     image_preview::ImagePreview,
 };
 
+// ---------------------------------------------------------------------------
+// Design tokens
+//
+// One ramp, used everywhere. The chrome used to reach for `Color::DarkGray` and
+// `Color::Yellow` alongside hand-written RGB triples, which put terminal-theme
+// colours next to fixed ones — the same "grey" border landed anywhere from black
+// to near-white depending on the user's scheme, and never matched the panel it
+// framed. Everything structural is a fixed value from this ramp so the shell
+// looks the same in every terminal; only the five palette roles the user
+// actually chose stay configurable.
+// ---------------------------------------------------------------------------
+
+/// Deepest surface: the gutter behind the grid, and the dividers between panes.
+const INK: Color = Color::Rgb(7, 10, 14);
+/// The app background, and the default background of terminal cells.
 const APP_BG: Color = Color::Rgb(11, 15, 20);
+/// Raised chrome: the tab strip and the status bar.
+const SURFACE: Color = Color::Rgb(16, 22, 29);
+/// Chrome under the cursor or otherwise active.
+const SURFACE_HI: Color = Color::Rgb(26, 35, 45);
+
+/// Idle pane border. Present enough to read as a frame, quiet enough that the
+/// focused pane is the only thing on screen drawing the eye.
+const LINE: Color = Color::Rgb(42, 53, 66);
+/// Divider between two panes that are both idle.
+const LINE_SOFT: Color = Color::Rgb(30, 39, 49);
+
+const TEXT: Color = Color::Rgb(230, 237, 243);
+const TEXT_DIM: Color = Color::Rgb(150, 165, 180);
+const TEXT_FAINT: Color = Color::Rgb(98, 113, 129);
+
+/// Terminal-cell defaults, applied to any cell whose own colour is "default".
+const PANE_FG: Color = TEXT;
+const PANE_BG: Color = APP_BG;
+
+/// Mouse text selection inside a pane.
+const SELECTION_FG: Color = Color::Rgb(8, 12, 16);
+const SELECTION_BG: Color = Color::Rgb(126, 231, 235);
+
+/// A pane whose agent is waiting on the user. The one colour allowed to shout.
+const WAITING: Color = Color::Rgb(255, 196, 61);
+
 const SETTINGS_BG: Color = Color::Rgb(9, 14, 19);
 const SETTINGS_SURFACE: Color = Color::Rgb(14, 22, 29);
 const SETTINGS_ROW_ACTIVE: Color = Color::Rgb(25, 36, 44);
@@ -30,7 +72,7 @@ const SETTINGS_SHADOW: Color = Color::Rgb(4, 6, 10);
 const SETTINGS_BORDER: Color = Color::Rgb(58, 210, 210);
 const SETTINGS_MUTED: Color = Color::Rgb(118, 135, 149);
 const SETTINGS_TEXT: Color = Color::Rgb(230, 237, 243);
-const TAB_WAITING_BG: Color = Color::Green;
+const TAB_WAITING_BG: Color = WAITING;
 
 pub struct DrawState {
     pub grid_area: Rect,
@@ -60,7 +102,6 @@ pub struct PaneRenderCache {
     buffer: Buffer,
 }
 
-const QUIET_MARKER: &str = " *";
 const STATUS_BRAND: &str = " GridBash ";
 const PREVIOUS_PANES_BUTTON: &str = " Panes ";
 const PANE_SETTINGS_BUTTON: &str = " Summary ";
@@ -150,7 +191,17 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let mut pane_settings_stop_goal_button = None;
     let tab_rects = render_tabs(frame, tab_area, &app.tab_labels(), palette);
 
-    for (index, pane) in app.panes().iter().enumerate() {
+    // Panes share the border cells that divide them, so whichever pane draws
+    // last owns the colour of the line between them. Drawing in state order lets
+    // a focused or selected pane keep an unbroken outline instead of having half
+    // of it repainted grey by the neighbour that happens to come after it.
+    let mut draw_order = (0..app.panes().len()).collect::<Vec<_>>();
+    draw_order.sort_by_cached_key(|index| pane_draw_layer(app, *index));
+
+    for index in draw_order {
+        let Some(pane) = app.panes().get(index) else {
+            continue;
+        };
         let Some(rect) = rects.get(index).copied() else {
             continue;
         };
@@ -158,45 +209,23 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             continue;
         }
 
-        let focused = app.focused_pane() == Some(index);
-        let selected = app.selected().contains(&index);
         let sleeping = app.pane_sleeping(index);
-        let quiet = app.activity_badges_enabled() && pane.output_quiet();
-        let logging = app.pane_logging(index);
-        let chrome = pane_chrome(
-            selected,
-            focused,
-            pane.exited,
-            sleeping,
-            None,
-            quiet,
-            palette,
-        );
-        let badge = if logging {
-            format!("{} logging", chrome.badge)
-        } else {
-            chrome.badge.to_string()
+        let frame_view = PaneFrame {
+            number: index + 1,
+            label: app.pane_label(index),
+            summary: app.pane_header_summary(index, rect.width as usize),
+            usage: app.pane_usage_label(index),
+            state: pane_state(app, index),
+            focused: app.focused_pane() == Some(index),
+            selected: app.selected().contains(&index),
+            logging: app.pane_logging(index),
+            compact: app.compact_titles_enabled(),
         };
 
-        let header_summary = app.pane_header_summary(index, rect.width as usize);
-        let usage = app.pane_usage_label(index);
-        let title = pane_title(
-            &app.pane_label(index),
-            chrome.quiet_marker,
-            &header_summary,
-            usage.as_deref(),
-            &badge,
-            app.compact_titles_enabled(),
-            rect.width.saturating_sub(2),
-        );
-
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(chrome.border_style)
-            .title(title);
-
-        let inner = block.inner(rect);
-        frame.render_widget(block, rect);
+        let inner = render_pane_frame(frame, rect, &frame_view, palette);
+        if inner.width == 0 || inner.height == 0 {
+            continue;
+        }
         if let Some(copy_mode) = app.copy_mode_view(index, inner.width, inner.height) {
             render_copy_mode(frame, inner, &copy_mode, palette);
         } else if sleeping {
@@ -206,7 +235,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
             app.render_pane_screen(frame, index, inner, selection);
         }
 
-        if focused && !sleeping && !modal_open && pane.screen().scrollback() == 0 {
+        if frame_view.focused && !sleeping && !modal_open && pane.screen().scrollback() == 0 {
             set_terminal_cursor(frame, inner, pane.screen());
         }
     }
@@ -217,94 +246,11 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         render_shell_command_center(frame, command_center_area, app, palette);
     }
 
-    let input_scope = app.input_scope_label();
-    let previous_panes_button = previous_panes_button_rect(status_area);
-    let pane_settings_button = pane_settings_button_rect(status_area);
-    let background_jobs_button =
-        background_jobs_button_rect(status_area, app.background_job_count());
-    let ports_button = ports_button_rect(status_area, app.agent_port_count());
-    let selection_status = if app.selected_grid_count() == 0 {
-        format!("{} panes selected", app.selected().len())
-    } else {
-        format!(
-            "{} panes | {} grids selected",
-            app.selected().len(),
-            app.selected_grid_count()
-        )
-    };
-    let status = Line::from(vec![
-        Span::styled(
-            STATUS_BRAND,
-            Style::default()
-                .fg(Color::Black)
-                .bg(palette.accent())
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            PREVIOUS_PANES_BUTTON,
-            previous_panes_button_style(app.previous_panes_open(), palette),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            PANE_SETTINGS_BUTTON,
-            pane_settings_button_style(app.pane_settings_open(), palette),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            background_jobs_button_label(app.background_job_count()),
-            background_jobs_button_style(app.background_jobs_open(), palette),
-        ),
-        Span::raw(" "),
-        Span::styled(
-            if app.voice_listening() {
-                "MIC"
-            } else if app.zoomed() {
-                "ZOOM"
-            } else {
-                "LIVE"
-            },
-            Style::default()
-                .fg(if app.voice_listening() {
-                    palette.accent()
-                } else {
-                    palette.focus()
-                })
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(" | "),
-        Span::styled(
-            input_scope,
-            Style::default().fg(if app.command_center_open() {
-                palette.accent()
-            } else if app.selected().len() > 1 {
-                palette.selected()
-            } else {
-                Color::Gray
-            }),
-        ),
-        Span::raw(" | "),
-        Span::raw(selection_status),
-        Span::raw(" | "),
-        Span::raw(app.status().to_string()),
-        Span::raw(" | F1 help | Alt+q quit fallback"),
-    ]);
-    frame.render_widget(
-        Paragraph::new(status).style(Style::default().bg(APP_BG)),
-        status_area,
-    );
-    if let Some(button) = ports_button {
-        frame.render_widget(
-            Paragraph::new(ports_button_label(app.agent_port_count()))
-                .alignment(Alignment::Center)
-                .style(ports_button_style(
-                    app.port_inspector_open(),
-                    app.agent_port_count(),
-                    palette,
-                )),
-            button,
-        );
-    }
+    let status_buttons = render_status_bar(frame, status_area, app, palette);
+    let previous_panes_button = status_buttons.previous_panes;
+    let pane_settings_button = status_buttons.pane_settings;
+    let background_jobs_button = status_buttons.background_jobs;
+    let ports_button = status_buttons.ports;
 
     if app.settings_open() {
         render_settings(frame, area, app, palette);
@@ -382,49 +328,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     }
 }
 
-fn pane_title(
-    label: &str,
-    quiet_marker: &str,
-    summary: &str,
-    usage: Option<&str>,
-    badge: &str,
-    compact: bool,
-    max_width: u16,
-) -> String {
-    let max_width = max_width as usize;
-    if max_width == 0 {
-        return String::new();
-    }
-
-    let usage = if !compact && max_width >= 48 {
-        usage.filter(|value| !value.is_empty())
-    } else {
-        None
-    };
-    let summary_reserve = if summary.is_empty() {
-        0
-    } else {
-        3 + summary.chars().count().min(8)
-    };
-    let reserved = 2
-        + quiet_marker.chars().count()
-        + badge.chars().count()
-        + usage
-            .map(|value| 3 + value.chars().count())
-            .unwrap_or_default()
-        + summary_reserve;
-    let label = truncate_text(label, max_width.saturating_sub(reserved).max(1));
-    let mut parts = vec![format!("{label}{quiet_marker}{badge}")];
-    if let Some(usage) = usage {
-        parts.push(usage.to_string());
-    }
-    if !summary.is_empty() {
-        parts.push(summary.to_string());
-    }
-
-    truncate_text(&format!(" {} ", parts.join(" | ")), max_width)
-}
-
 fn render_tabs(
     frame: &mut Frame<'_>,
     area: Rect,
@@ -435,42 +338,15 @@ fn render_tabs(
         return Vec::new();
     }
 
-    let mut spans = vec![
-        Span::styled(
-            STATUS_BRAND,
-            Style::default()
-                .fg(Color::Black)
-                .bg(palette.accent())
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw(" "),
-    ];
+    let mut spans = vec![Span::styled(STATUS_BRAND, brand_style(palette))];
     let mut tab_rects = Vec::with_capacity(tabs.len());
     let mut tab_x = area
         .x
-        .saturating_add(u16::try_from(Line::from(STATUS_BRAND).width()).unwrap_or(u16::MAX))
-        .saturating_add(1);
-    let area_right = area.x.saturating_add(area.width);
+        .saturating_add(u16::try_from(Line::from(STATUS_BRAND).width()).unwrap_or(u16::MAX));
+    let area_right = area.right();
 
     for (index, tab) in tabs.iter().enumerate() {
-        let state_marker = if tab.exited {
-            "!"
-        } else if tab.activity && !tab.active {
-            "*"
-        } else {
-            ""
-        };
-        let marker = if tab.selected {
-            format!("+{state_marker}")
-        } else {
-            state_marker.to_string()
-        };
-        let label = format!(
-            " {}:{}{} ",
-            index + 1,
-            truncate_text(&tab.title, 18),
-            marker
-        );
+        let label = tab_label(index, tab);
         let label_width = u16::try_from(Line::from(label.as_str()).width()).unwrap_or(u16::MAX);
         if tab_x < area_right {
             tab_rects.push((
@@ -484,75 +360,118 @@ fn render_tabs(
             ));
         }
         tab_x = tab_x.saturating_add(label_width);
-
-        let style = if tab.waiting {
-            let style = Style::default()
-                .fg(Color::Black)
-                .bg(TAB_WAITING_BG)
-                .add_modifier(Modifier::BOLD);
-            if tab.active {
-                style.add_modifier(Modifier::UNDERLINED)
-            } else {
-                style
-            }
-        } else if tab.active {
-            let style = Style::default()
-                .fg(Color::Black)
-                .bg(Color::Yellow)
-                .add_modifier(Modifier::BOLD);
-            if tab.selected {
-                style.add_modifier(Modifier::UNDERLINED)
-            } else {
-                style
-            }
-        } else if tab.selected {
-            Style::default()
-                .fg(Color::Black)
-                .bg(palette.selected())
-                .add_modifier(Modifier::BOLD)
-        } else if tab.exited {
-            Style::default().fg(palette.exited())
-        } else if tab.activity {
-            Style::default().fg(palette.quiet())
-        } else {
-            Style::default().fg(Color::Gray)
-        };
-        spans.push(Span::styled(label, style));
+        spans.push(Span::styled(label, tab_style(tab, palette)));
     }
 
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled(
-        "Alt+n new",
-        Style::default().fg(Color::DarkGray),
-    ));
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled(
-        "Alt+t switch",
-        Style::default().fg(Color::DarkGray),
-    ));
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled(
-        "Alt+Shift+s select",
-        Style::default().fg(Color::DarkGray),
-    ));
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled(
-        "Alt+x swap",
-        Style::default().fg(Color::DarkGray),
-    ));
-    spans.push(Span::raw(" "));
-    spans.push(Span::styled(
-        "Alt+Shift+r rename",
-        Style::default().fg(Color::DarkGray),
-    ));
-
     frame.render_widget(
-        Paragraph::new(Line::from(spans)).style(Style::default().bg(APP_BG)),
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(SURFACE)),
         area,
     );
 
+    // Hints go in whatever is left after the tabs, and only what fits. Printing
+    // all five unconditionally spent sixty columns of the most valuable row on
+    // screen restating what F1 already lists, and on a narrow terminal it pushed
+    // the tabs themselves out of view.
+    let spare = area_right.saturating_sub(tab_x);
+    if spare > 4 {
+        let hints = tab_hints(spare.saturating_sub(2));
+        if hints.width() > 0 {
+            frame.render_widget(
+                Paragraph::new(hints.right_aligned()).style(Style::default().bg(SURFACE)),
+                Rect::new(tab_x, area.y, spare, 1),
+            );
+        }
+    }
+
     tab_rects
 }
+
+fn tab_label(index: usize, tab: &TabLabel) -> String {
+    // One glyph carries the state that used to need a `!`/`*`/`+` cipher; the
+    // rest is conveyed by colour, which needs no legend.
+    let marker = if tab.exited {
+        " !"
+    } else if tab.waiting || (tab.activity && !tab.active) {
+        " •"
+    } else {
+        ""
+    };
+    format!(
+        " {} {}{marker} ",
+        index + 1,
+        truncate_text(&tab.title, 18)
+    )
+}
+
+fn tab_style(tab: &TabLabel, palette: &GridPalette) -> Style {
+    // A grid with an agent waiting on the user outranks every other state: it is
+    // the only one that means "come here now".
+    let style = if tab.waiting {
+        Style::default()
+            .fg(INK)
+            .bg(TAB_WAITING_BG)
+            .add_modifier(Modifier::BOLD)
+    } else if tab.active {
+        Style::default()
+            .fg(INK)
+            .bg(palette.accent())
+            .add_modifier(Modifier::BOLD)
+    } else if tab.exited {
+        Style::default().fg(palette.exited()).bg(SURFACE)
+    } else if tab.activity {
+        Style::default().fg(palette.quiet()).bg(SURFACE)
+    } else {
+        Style::default().fg(TEXT_DIM).bg(SURFACE)
+    };
+
+    // Selection is a mark the user put there by hand, so it has to survive
+    // whatever the grid's own state is doing to the colours.
+    if tab.selected {
+        style.add_modifier(Modifier::UNDERLINED | Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
+/// Tab-strip hints, most useful first. Dropped from the end as width runs out.
+const TAB_HINTS: [(&str, &str); 5] = [
+    ("Alt+N", "new"),
+    ("Alt+T", "switch"),
+    ("Alt+Shift+R", "rename"),
+    ("Alt+Shift+S", "select"),
+    ("Alt+X", "swap"),
+];
+
+fn tab_hints(budget: u16) -> Line<'static> {
+    let mut spans = Vec::new();
+    let mut used = 0usize;
+
+    for (key, action) in TAB_HINTS {
+        let width = key.chars().count() + action.chars().count() + 2;
+        if used + width > budget as usize {
+            break;
+        }
+        used += width;
+        spans.push(Span::styled(
+            key,
+            Style::default().fg(TEXT_DIM).add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(
+            format!(" {action}  "),
+            Style::default().fg(TEXT_FAINT),
+        ));
+    }
+
+    Line::from(spans)
+}
+
+fn brand_style(palette: &GridPalette) -> Style {
+    Style::default()
+        .fg(INK)
+        .bg(palette.accent())
+        .add_modifier(Modifier::BOLD)
+}
+
 fn command_center_height(total_height: u16, open: bool, requested: u16) -> u16 {
     if !open {
         return 0;
@@ -618,11 +537,7 @@ fn render_shell_command_center(
         .collect::<Vec<_>>();
 
     frame.render_widget(
-        Paragraph::new(visible).style(
-            Style::default()
-                .fg(Color::Rgb(230, 237, 243))
-                .bg(Color::Rgb(11, 15, 20)),
-        ),
+        Paragraph::new(visible).style(Style::default().fg(TEXT).bg(APP_BG)),
         chunks[0],
     );
 
@@ -640,10 +555,10 @@ fn render_shell_command_center(
             Span::styled(
                 prompt,
                 Style::default()
-                    .fg(Color::Yellow)
+                    .fg(palette.accent())
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(input, Style::default().fg(Color::White)),
+            Span::styled(input, Style::default().fg(TEXT)),
         ]))
         .style(Style::default().bg(SETTINGS_SURFACE)),
         chunks[1],
@@ -714,159 +629,507 @@ fn visible_input(input: &str, cursor_chars: usize, width: usize) -> (String, usi
     (chars[start..end].iter().collect(), cursor - start)
 }
 
-#[derive(Debug, PartialEq)]
-struct PaneChrome {
-    border_style: Style,
-    badge: &'static str,
-    quiet_marker: &'static str,
+/// The one state a pane's header names.
+///
+/// A pane is usually several of these at once — an exited pane is also quiet, a
+/// sleeping pane is also idle — so the header names the most urgent one instead
+/// of stacking badges until they crowd out the pane's own name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneState {
+    /// Producing output.
+    Live,
+    /// An agent that has stopped producing output. This is how an agent asks for
+    /// the user's attention, and in a grid full of agents it is the single most
+    /// useful thing on screen — so it is the one state allowed to shout.
+    Waiting,
+    /// Quiet, but not an agent waiting on anyone.
+    Idle,
+    Sleeping,
+    Exited,
 }
 
-fn pane_chrome(
-    selected: bool,
-    focused: bool,
-    exited: bool,
-    sleeping: bool,
-    group_color: Option<(u8, u8, u8)>,
-    quiet: bool,
-    palette: &GridPalette,
-) -> PaneChrome {
-    let border_style = if sleeping {
-        Style::default().fg(Color::Rgb(32, 36, 42))
-    } else if selected {
-        Style::default()
-            .fg(palette.selected())
-            .add_modifier(Modifier::BOLD)
-    } else if focused {
-        Style::default()
+impl PaneState {
+    fn badge(self) -> &'static str {
+        match self {
+            Self::Live => "",
+            Self::Waiting => "needs you",
+            Self::Idle => "idle",
+            Self::Sleeping => "asleep",
+            Self::Exited => "exited",
+        }
+    }
+
+    fn color(self, palette: &GridPalette) -> Color {
+        match self {
+            Self::Live => TEXT_FAINT,
+            Self::Waiting => WAITING,
+            Self::Idle => palette.quiet(),
+            Self::Sleeping => TEXT_FAINT,
+            Self::Exited => palette.exited(),
+        }
+    }
+}
+
+/// Everything the chrome around one pane draws, with nothing left to look up.
+///
+/// Keeping this separate from `App` is what lets the frame be rendered — and
+/// therefore seen and tested — without a live PTY behind it.
+#[derive(Debug, Clone)]
+pub struct PaneFrame {
+    pub number: usize,
+    pub label: String,
+    pub summary: String,
+    pub usage: Option<String>,
+    pub state: PaneState,
+    pub focused: bool,
+    pub selected: bool,
+    pub logging: bool,
+    pub compact: bool,
+}
+
+/// Which panes get to keep their outline where two panes share a border cell.
+///
+/// Higher draws later, and the last pane to touch a shared cell owns its colour.
+/// Focus outranks everything: knowing where your keystrokes are going matters
+/// more than any other signal the grid shows.
+fn pane_draw_layer(app: &App, index: usize) -> u8 {
+    if app.focused_pane() == Some(index) {
+        3
+    } else if app.selected().contains(&index) {
+        2
+    } else if pane_state(app, index) == PaneState::Waiting {
+        1
+    } else {
+        0
+    }
+}
+
+fn pane_state(app: &App, index: usize) -> PaneState {
+    let Some(pane) = app.panes().get(index) else {
+        return PaneState::Exited;
+    };
+    if pane.exited {
+        return PaneState::Exited;
+    }
+    if app.pane_sleeping(index) {
+        return PaneState::Sleeping;
+    }
+    // Both remaining states are read off the same quiet-output signal the
+    // activity-badge setting governs.
+    if !app.activity_badges_enabled() || !pane.output_quiet() {
+        return PaneState::Live;
+    }
+    if app.pane_needs_input(index) {
+        PaneState::Waiting
+    } else {
+        PaneState::Idle
+    }
+}
+
+fn pane_border_style(view: &PaneFrame, palette: &GridPalette) -> Style {
+    if view.focused {
+        return Style::default()
             .fg(palette.focus())
-            .add_modifier(Modifier::BOLD)
-    } else if exited {
-        Style::default().fg(palette.exited())
-    } else if let Some(group_color) = group_color {
+            .add_modifier(Modifier::BOLD);
+    }
+    if view.selected {
+        return Style::default()
+            .fg(palette.selected())
+            .add_modifier(Modifier::BOLD);
+    }
+
+    match view.state {
+        PaneState::Waiting => Style::default().fg(WAITING),
+        PaneState::Exited => Style::default().fg(palette.exited()),
+        PaneState::Idle => Style::default().fg(LINE),
+        PaneState::Sleeping => Style::default().fg(LINE_SOFT),
+        PaneState::Live => Style::default().fg(LINE),
+    }
+}
+
+/// The pane number, as a filled chip when the pane is focused or selected.
+///
+/// A filled chip is reserved for the two things the user chose — where input
+/// goes, and what a bulk action would hit — so it never competes with a state
+/// the pane arrived at on its own.
+fn pane_number_style(view: &PaneFrame, palette: &GridPalette) -> Style {
+    if view.focused {
+        return Style::default()
+            .fg(INK)
+            .bg(palette.focus())
+            .add_modifier(Modifier::BOLD);
+    }
+    if view.selected {
+        return Style::default()
+            .fg(INK)
+            .bg(palette.selected())
+            .add_modifier(Modifier::BOLD);
+    }
+
+    Style::default()
+        .fg(view.state.color(palette))
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Draws a pane's frame and returns the area left for its terminal.
+fn render_pane_frame(
+    frame: &mut Frame<'_>,
+    rect: Rect,
+    view: &PaneFrame,
+    palette: &GridPalette,
+) -> Rect {
+    let mut block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(pane_border_style(view, palette))
+        // Panes are laid out overlapping by one cell, so each shared cell is
+        // drawn twice. Merging resolves the pair into a single line with the
+        // junction glyph the crossing actually calls for.
+        .merge_borders(MergeStrategy::Exact)
+        .style(Style::default().bg(APP_BG));
+
+    // Below about eight columns a header is all truncation and no information,
+    // and the number alone tells the user more than a sliced-up word would.
+    if rect.width >= 8 {
+        let budget = rect.width.saturating_sub(2);
+        // The state is reserved out of the budget before the name and summary
+        // are measured, rather than fitted around them afterwards. A pane whose
+        // agent is waiting has to say so at every width — that signal is the
+        // whole reason to look at a grid of nine panes — and sizing it last is
+        // what made it the first thing a narrow header dropped.
+        let trailing = pane_header_trailing(view, palette, rect.width);
+        let trailing_width = trailing.width() as u16;
+        // The two titles are drawn independently, one from each end, so the
+        // state only goes up if the number it would sit beside still fits too.
+        // Without that floor a narrow pane draws both and they overlap.
+        let fits = trailing_width > 0 && pane_number_width(view) + trailing_width <= budget;
+        let leading = pane_header_leading(
+            view,
+            palette,
+            if fits { budget - trailing_width } else { budget },
+        );
+        if fits {
+            block = block.title_top(trailing.right_aligned());
+        }
+        block = block.title_top(leading);
+    }
+
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+    inner
+}
+
+/// Width of the pane-number chip, which is the one part of a header that is
+/// never dropped — it is how the user names a pane to a keyboard shortcut.
+fn pane_number_width(view: &PaneFrame) -> u16 {
+    // Panes are capped well below four digits, so this cannot overflow.
+    view.number.to_string().chars().count() as u16 + 2
+}
+
+/// The pane's identity, fitted to whatever the state left behind.
+///
+/// Every piece is measured against the running total, so the line never exceeds
+/// `budget` — which is what lets the caller reserve the state's width up front
+/// and trust that it still fits.
+fn pane_header_leading(view: &PaneFrame, palette: &GridPalette, budget: u16) -> Line<'static> {
+    let budget = budget as usize;
+    let number = format!(" {} ", view.number);
+    let mut used = number.chars().count();
+    let mut spans = vec![Span::styled(number, pane_number_style(view, palette))];
+    if used >= budget {
+        return Line::from(spans);
+    }
+
+    // The name is how the user tells one pane from another, so it is the last
+    // thing to go.
+    let label = truncate_text(&view.label, budget - used - 1);
+    if !label.is_empty() {
+        used += label.chars().count() + 1;
+        spans.push(Span::styled(
+            format!("{label} "),
+            if view.focused {
+                Style::default().fg(TEXT).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(TEXT_DIM)
+            },
+        ));
+    }
+
+    // The activity summary is the header's least urgent text: useful to read,
+    // never needed to act. It appears only once everything else is safely on
+    // screen, and only if enough of it survives to still mean something.
+    let summary_budget = budget.saturating_sub(used + 3);
+    if !view.compact && !view.summary.is_empty() && summary_budget >= 6 {
+        let summary = truncate_text(&view.summary, summary_budget);
+        spans.push(Span::styled(
+            format!("· {summary} "),
+            Style::default().fg(TEXT_FAINT),
+        ));
+    }
+
+    Line::from(spans)
+}
+
+/// The width below which a pane's header has no room for its usage figure.
+///
+/// Usage is reference material — you go looking for it. Below this the header is
+/// down to the pane's name and its state, and spending a third of a narrow
+/// header on a quota reading buys nothing.
+const USAGE_HEADER_WIDTH: u16 = 48;
+
+fn pane_header_trailing(view: &PaneFrame, palette: &GridPalette, width: u16) -> Line<'static> {
+    let mut spans = Vec::new();
+
+    if view.logging {
+        spans.push(Span::styled(
+            "rec ",
+            Style::default()
+                .fg(palette.accent())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(usage) = view.usage.as_deref().filter(|usage| !usage.is_empty())
+        && !view.compact
+        && width >= USAGE_HEADER_WIDTH
+    {
+        spans.push(Span::styled(
+            format!("{usage} "),
+            Style::default().fg(TEXT_FAINT),
+        ));
+    }
+
+    let badge = view.state.badge();
+    if !badge.is_empty() {
+        let mut style = Style::default().fg(view.state.color(palette));
+        if view.state == PaneState::Waiting {
+            style = style.add_modifier(Modifier::BOLD);
+        }
+        spans.push(Span::styled(format!("{badge} "), style));
+    }
+
+    // Right-aligned text lands flush against the border rule that fills the rest
+    // of the header, so it needs a gap of its own to read as a separate thing.
+    if !spans.is_empty() {
+        spans.insert(0, Span::raw(" "));
+    }
+
+    Line::from(spans)
+}
+
+/// Where the status bar's clickable chips ended up.
+#[derive(Debug, Clone, Copy, Default)]
+struct StatusButtons {
+    previous_panes: Option<Rect>,
+    pane_settings: Option<Rect>,
+    background_jobs: Option<Rect>,
+    ports: Option<Rect>,
+}
+
+/// Draws the status bar and reports where its chips landed.
+///
+/// The chip rects used to be derived a second time by a set of functions that
+/// re-added the same string lengths the renderer had just laid out by hand. Two
+/// copies of one layout is one copy too many: renaming a button moved it on
+/// screen without moving the thing the mouse hit. Laying out once and returning
+/// the rects makes that class of bug unrepresentable.
+fn render_status_bar(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &App,
+    palette: &GridPalette,
+) -> StatusButtons {
+    if area.width == 0 || area.height == 0 {
+        return StatusButtons::default();
+    }
+
+    frame.render_widget(
+        Paragraph::new("").style(Style::default().bg(SURFACE)),
+        area,
+    );
+
+    let mut buttons = StatusButtons::default();
+    let mut spans = vec![Span::styled(STATUS_BRAND, brand_style(palette))];
+    let mut cursor = area.x.saturating_add(STATUS_BRAND.chars().count() as u16);
+
+    let chip = |spans: &mut Vec<Span<'static>>,
+                    cursor: &mut u16,
+                    label: String,
+                    style: Style|
+     -> Option<Rect> {
+        let width = label.chars().count() as u16;
+        let rect = (*cursor < area.right()).then(|| {
+            Rect::new(
+                *cursor,
+                area.y,
+                width.min(area.right().saturating_sub(*cursor)),
+                1,
+            )
+        });
+        *cursor = cursor.saturating_add(width);
+        spans.push(Span::styled(label, style));
+        rect
+    };
+
+    buttons.previous_panes = chip(
+        &mut spans,
+        &mut cursor,
+        PREVIOUS_PANES_BUTTON.to_string(),
+        chip_style(app.previous_panes_open(), palette.focus()),
+    );
+    spans.push(Span::raw(" "));
+    cursor = cursor.saturating_add(1);
+    buttons.pane_settings = chip(
+        &mut spans,
+        &mut cursor,
+        PANE_SETTINGS_BUTTON.to_string(),
+        chip_style(app.pane_settings_open(), palette.focus()),
+    );
+    spans.push(Span::raw(" "));
+    cursor = cursor.saturating_add(1);
+    let jobs = app.background_job_count();
+    buttons.background_jobs = chip(
+        &mut spans,
+        &mut cursor,
+        background_jobs_button_label(jobs),
+        if jobs > 0 {
+            chip_style(app.background_jobs_open(), palette.accent())
+        } else {
+            quiet_chip_style(app.background_jobs_open())
+        },
+    );
+
+    // Everything past the chips is read, not clicked, so it is styled as a
+    // sentence rather than as more buttons: mode, then what typing will reach,
+    // then the last thing that happened.
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(
+        session_mode_label(app),
         Style::default()
-            .fg(rgb_color(group_color))
-            .add_modifier(Modifier::BOLD)
-    } else if quiet {
-        Style::default().fg(palette.quiet())
-    } else {
-        Style::default().fg(Color::DarkGray)
-    };
-
-    let badge = if exited {
-        " exited"
-    } else if sleeping {
-        " asleep"
-    } else if selected {
-        " selected"
-    } else {
-        ""
-    };
-    let quiet_marker = if quiet && !exited && !sleeping {
-        QUIET_MARKER
-    } else {
-        ""
-    };
-
-    PaneChrome {
-        border_style,
-        badge,
-        quiet_marker,
+            .fg(if app.voice_listening() {
+                palette.accent()
+            } else {
+                palette.focus()
+            })
+            .add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(
+        format!("  {}", app.input_scope_label()),
+        Style::default().fg(if app.command_center_open() {
+            palette.accent()
+        } else if app.selected().len() > 1 {
+            palette.selected()
+        } else {
+            TEXT_DIM
+        }),
+    ));
+    if let Some(selection) = selection_summary(app) {
+        spans.push(Span::styled(
+            format!("  {selection}"),
+            Style::default().fg(palette.selected()),
+        ));
     }
+    // The ports chip is anchored to the right edge, so the left side is drawn
+    // into what is left over rather than across the whole bar. Rendering both
+    // over the full width let a long status message run underneath the chip and
+    // get overwritten.
+    let ports = app.agent_port_count();
+    buttons.ports = ports_button_rect(area, ports);
+    let text_area = Rect {
+        width: buttons
+            .ports
+            .map_or(area.width, |chip| chip.x.saturating_sub(area.x + 1)),
+        ..area
+    };
+
+    // Status messages are sentences and routinely outrun the bar. Trimming to
+    // what is left over ends them in an ellipsis rather than mid-word, so a cut
+    // message reads as cut rather than as a typo.
+    if !app.status().is_empty() {
+        let used = spans.iter().map(Span::width).sum::<usize>();
+        let room = (text_area.width as usize).saturating_sub(used + 2);
+        if room >= 4 {
+            spans.push(Span::styled(
+                format!("  {}", truncate_text(app.status(), room)),
+                Style::default().fg(TEXT_FAINT),
+            ));
+        }
+    }
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(SURFACE)),
+        text_area,
+    );
+
+    if let Some(button) = buttons.ports {
+        frame.render_widget(
+            Paragraph::new(ports_button_label(ports))
+                .alignment(Alignment::Center)
+                .style(if ports > 0 {
+                    chip_style(app.port_inspector_open(), palette.accent())
+                } else {
+                    quiet_chip_style(app.port_inspector_open())
+                }),
+            button,
+        );
+    }
+
+    buttons
 }
 
-fn previous_panes_button_rect(status_area: Rect) -> Option<Rect> {
-    let offset = STATUS_BRAND.len() as u16 + 1;
-    let width = PREVIOUS_PANES_BUTTON.len() as u16;
-    if status_area.height == 0 || status_area.width < offset.saturating_add(width) {
-        return None;
-    }
-
-    Some(Rect {
-        x: status_area.x.saturating_add(offset),
-        y: status_area.y,
-        width,
-        height: 1,
-    })
-}
-
-fn previous_panes_button_style(open: bool, palette: &GridPalette) -> Style {
+/// A chip the user can click. Filled when its panel is open, so the status bar
+/// always says which overlay is up without the user having to look at it.
+fn chip_style(open: bool, color: Color) -> Style {
     if open {
         Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
+            .fg(INK)
+            .bg(WAITING)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default()
-            .fg(Color::Black)
-            .bg(palette.focus())
+            .fg(INK)
+            .bg(color)
             .add_modifier(Modifier::BOLD)
     }
 }
 
-fn pane_settings_button_rect(status_area: Rect) -> Option<Rect> {
-    let offset = STATUS_BRAND.len() as u16 + 1 + PREVIOUS_PANES_BUTTON.len() as u16 + 1;
-    let width = PANE_SETTINGS_BUTTON.len() as u16;
-    if status_area.height == 0 || status_area.width < offset.saturating_add(width) {
-        return None;
-    }
-
-    Some(Rect {
-        x: status_area.x.saturating_add(offset),
-        y: status_area.y,
-        width,
-        height: 1,
-    })
-}
-
-fn pane_settings_button_style(open: bool, palette: &GridPalette) -> Style {
+/// A chip with nothing behind it. Still clickable, but it has no business
+/// drawing the eye when the count it carries is zero.
+fn quiet_chip_style(open: bool) -> Style {
     if open {
         Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
+            .fg(INK)
+            .bg(WAITING)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default()
-            .fg(Color::Black)
-            .bg(palette.focus())
-            .add_modifier(Modifier::BOLD)
+        Style::default().fg(TEXT_FAINT).bg(SURFACE_HI)
+    }
+}
+
+fn session_mode_label(app: &App) -> &'static str {
+    if app.voice_listening() {
+        "MIC"
+    } else if app.zoomed() {
+        "ZOOM"
+    } else {
+        "LIVE"
+    }
+}
+
+/// The selection count, or nothing at all when nothing is selected.
+///
+/// "0 panes selected" was on screen permanently to say that the normal state is
+/// the normal state.
+fn selection_summary(app: &App) -> Option<String> {
+    let panes = app.selected().len();
+    let grids = app.selected_grid_count();
+    match (panes, grids) {
+        (0, 0) => None,
+        (panes, 0) => Some(format!("{panes} selected")),
+        (0, grids) => Some(format!("{grids} grids selected")),
+        (panes, grids) => Some(format!("{panes} panes, {grids} grids selected")),
     }
 }
 
 fn background_jobs_button_label(count: usize) -> String {
     format!(" BG {count} ")
-}
-
-fn background_jobs_button_rect(status_area: Rect, count: usize) -> Option<Rect> {
-    let offset = STATUS_BRAND.len() as u16
-        + 1
-        + PREVIOUS_PANES_BUTTON.len() as u16
-        + 1
-        + PANE_SETTINGS_BUTTON.len() as u16
-        + 1;
-    let width = background_jobs_button_label(count).len() as u16;
-    if status_area.height == 0 || status_area.width < offset.saturating_add(width) {
-        return None;
-    }
-
-    Some(Rect {
-        x: status_area.x.saturating_add(offset),
-        y: status_area.y,
-        width,
-        height: 1,
-    })
-}
-
-fn background_jobs_button_style(open: bool, palette: &GridPalette) -> Style {
-    if open {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-            .fg(palette.accent())
-            .add_modifier(Modifier::BOLD)
-    }
 }
 
 fn ports_button_label(count: usize) -> String {
@@ -884,25 +1147,6 @@ fn ports_button_rect(status_area: Rect, count: usize) -> Option<Rect> {
         width,
         height: 1,
     })
-}
-
-fn ports_button_style(open: bool, count: usize, palette: &GridPalette) -> Style {
-    if open {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else if count > 0 {
-        Style::default()
-            .fg(Color::Black)
-            .bg(palette.accent())
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-            .fg(Color::DarkGray)
-            .bg(APP_BG)
-            .add_modifier(Modifier::BOLD)
-    }
 }
 
 fn render_pane_settings(
@@ -3965,7 +4209,10 @@ fn render_sleeping_screen(frame: &mut Frame<'_>, area: Rect) {
         return;
     }
 
-    let style = Style::default().fg(Color::Black).bg(Color::Black);
+    // A shade below the app background rather than pure black. A sleeping pane
+    // should read as dormant, not as a hole cut in the grid — and on a terminal
+    // whose own background is not black, a black rectangle is exactly that.
+    let style = Style::default().fg(INK).bg(INK);
     let buffer = frame.buffer_mut();
     // Indexing a `Buffer` outside its area panics, so clip first and still take
     // the `Option` path: a pane rect can outlive the frame it was measured in.
@@ -4027,23 +4274,24 @@ fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, pale
                     column: view.left_column + offset,
                 };
                 let style = match view.cell_kind(point) {
-                    CopyCellKind::Normal => {
-                        Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)
-                    }
+                    CopyCellKind::Normal => Style::default().fg(TEXT).bg(APP_BG),
+                    // Every match is highlighted, so the one the cursor is on
+                    // has to be the brighter of the two or "next match" gives no
+                    // feedback.
                     CopyCellKind::Match => Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::DarkGray)
+                        .fg(TEXT)
+                        .bg(SURFACE_HI)
                         .add_modifier(Modifier::BOLD),
                     CopyCellKind::ActiveMatch => Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Yellow)
+                        .fg(INK)
+                        .bg(WAITING)
                         .add_modifier(Modifier::BOLD),
                     CopyCellKind::Selection => Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::LightCyan)
+                        .fg(SELECTION_FG)
+                        .bg(SELECTION_BG)
                         .add_modifier(Modifier::BOLD),
                     CopyCellKind::Cursor => Style::default()
-                        .fg(Color::Black)
+                        .fg(INK)
                         .bg(palette.focus())
                         .add_modifier(Modifier::BOLD),
                 };
@@ -4060,7 +4308,7 @@ fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, pale
         })
         .collect::<Vec<_>>();
     frame.render_widget(
-        Paragraph::new(lines).style(Style::default().fg(Color::White).bg(APP_BG)),
+        Paragraph::new(lines).style(Style::default().fg(TEXT).bg(APP_BG)),
         body,
     );
 
@@ -4097,7 +4345,7 @@ fn render_copy_mode(frame: &mut Frame<'_>, area: Rect, view: &CopyModeView, pale
         frame.render_widget(
             Paragraph::new(truncate_text(&label, footer.width as usize)).style(
                 Style::default()
-                    .fg(Color::Black)
+                    .fg(INK)
                     .bg(palette.focus())
                     .add_modifier(Modifier::BOLD),
             ),
@@ -4122,21 +4370,13 @@ fn refresh_screen_cache(
         return;
     }
 
-    let lines = (0..height)
-        .map(|row| render_screen_row(screen, row, width, selection))
-        .collect::<Vec<_>>();
     let area = Rect::new(0, 0, width, height);
     // Reuse the cached allocation instead of building a fresh pane-sized buffer
     // on every screen revision, which for an active pane is once per frame.
     if cache.buffer.area != area {
         cache.buffer.resize(area);
     }
-    cache.buffer.reset();
-    Widget::render(
-        Paragraph::new(lines).style(Style::default().fg(Color::Rgb(230, 237, 243)).bg(APP_BG)),
-        area,
-        &mut cache.buffer,
-    );
+    rasterize_screen(&mut cache.buffer, screen, selection);
     cache.revision = revision;
     cache.width = width;
     cache.height = height;
@@ -4179,65 +4419,185 @@ fn blit_buffer(source: &Buffer, target: &mut Buffer, area: Rect) {
     }
 }
 
-fn render_screen_row<'a>(
-    screen: &vt100::Screen,
-    row: u16,
-    width: u16,
-    selection: Option<PaneSelection>,
-) -> Line<'a> {
-    let mut spans = Vec::new();
-    let mut current_style: Option<Style> = None;
-    let mut current_text = String::new();
+/// Writes a terminal screen straight into buffer cells.
+///
+/// Terminal cells already *are* cells. The path this replaced turned every row
+/// into a `Line` of `Span`s — a heap `String` per style run and a `Vec` per row —
+/// then handed the pane to `Paragraph`, which re-segmented each row into
+/// graphemes and re-measured their widths to lay out text that was already laid
+/// out on a grid. For a pane producing output that ran once per frame. Copying
+/// cell to cell skips the whole text layer and allocates nothing.
+///
+/// Every cell in `buffer` is written, so the caller does not clear it first. That
+/// matters: keeping the previous frame's cells lets the symbol comparison below
+/// skip the write for the cells that did not change, which in a terminal is most
+/// of them.
+fn rasterize_screen(buffer: &mut Buffer, screen: &vt100::Screen, selection: Option<PaneSelection>) {
+    let width = buffer.area.width;
+    let height = buffer.area.height;
+    let stride = width as usize;
+    let mut colors = ColorMemo::default();
 
-    for column in 0..width {
-        let Some(cell) = screen.cell(row, column) else {
-            push_cell_text(
-                &mut spans,
-                &mut current_style,
-                &mut current_text,
-                selection_style(Style::default(), selection, row, column),
-                " ",
-            );
-            continue;
-        };
+    for row in 0..height {
+        let base = row as usize * stride;
+        let mut column = 0;
+        while column < width {
+            let source = screen.cell(row, column);
+            // vt100 stores a wide character as a cell holding both columns'
+            // worth of content plus a contentless continuation cell. Ratatui
+            // wants the symbol on the lead cell and a blank behind it, so the
+            // pair is emitted together and the continuation column skipped.
+            let wide = source.is_some_and(|cell| cell.is_wide()) && column + 1 < width;
+            let (symbol, style) = match source {
+                // A continuation cell reached on its own means its lead was
+                // clipped away; it has no content of its own to show.
+                Some(cell) if cell.is_wide_continuation() => (" ", colors.style_for(cell)),
+                Some(cell) => {
+                    let symbol = match cell.has_contents() {
+                        // A wide glyph in the last column has nowhere to put its
+                        // second half. Emitting it would let the terminal spill
+                        // it over whatever the blit puts to the right.
+                        true if cell.is_wide() && !wide => " ",
+                        true => cell.contents(),
+                        false => " ",
+                    };
+                    (symbol, colors.style_for(cell))
+                }
+                None => (" ", CellStyle::default()),
+            };
+            let style = style.with_selection(selection, row, column);
 
-        if cell.is_wide_continuation() {
-            continue;
+            if let Some(target) = buffer.content.get_mut(base + column as usize) {
+                style.apply(target, symbol);
+            }
+            if wide {
+                if let Some(trailing) = buffer.content.get_mut(base + column as usize + 1) {
+                    // Ratatui's diff assumes a wide symbol is followed by a blank
+                    // and skips that column; anything else would be printed over
+                    // the second half of the glyph.
+                    style.apply(trailing, " ");
+                }
+                column += 2;
+            } else {
+                column += 1;
+            }
         }
-
-        let text = if cell.has_contents() {
-            cell.contents()
-        } else {
-            " "
-        };
-        push_cell_text(
-            &mut spans,
-            &mut current_style,
-            &mut current_text,
-            selection_style(cell_style(cell), selection, row, column),
-            text,
-        );
     }
-
-    flush_span(&mut spans, &mut current_style, &mut current_text);
-    Line::from(spans)
 }
 
-fn push_cell_text<'a>(
-    spans: &mut Vec<Span<'a>>,
-    current_style: &mut Option<Style>,
-    current_text: &mut String,
-    style: Style,
-    text: &str,
-) {
-    if current_style.is_some_and(|active| active == style) {
-        current_text.push_str(text);
-        return;
+/// A terminal cell's appearance, in the form a buffer cell actually stores.
+///
+/// Deliberately not a `Style`: a `Style` carries `Option` colours and an
+/// add/remove modifier pair, and patching one onto a cell that persists between
+/// frames leaves last frame's modifiers set. These three fields are assigned, so
+/// dropping bold is as reliable as adding it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CellStyle {
+    fg: Color,
+    bg: Color,
+    modifier: Modifier,
+}
+
+impl Default for CellStyle {
+    fn default() -> Self {
+        Self {
+            fg: PANE_FG,
+            bg: PANE_BG,
+            modifier: Modifier::empty(),
+        }
+    }
+}
+
+impl CellStyle {
+    fn with_selection(self, selection: Option<PaneSelection>, row: u16, column: u16) -> Self {
+        if selection.is_some_and(|selection| selection.contains(row, column)) {
+            Self {
+                fg: SELECTION_FG,
+                bg: SELECTION_BG,
+                modifier: self.modifier | Modifier::BOLD,
+            }
+        } else {
+            self
+        }
     }
 
-    flush_span(spans, current_style, current_text);
-    *current_style = Some(style);
-    current_text.push_str(text);
+    fn apply(self, target: &mut ratatui::buffer::Cell, symbol: &str) {
+        // Building a `CompactString` is the most expensive part of writing a
+        // cell, and in terminal output the symbol is usually the one already
+        // there.
+        if target.symbol() != symbol {
+            target.set_symbol(symbol);
+        }
+        target.fg = self.fg;
+        target.bg = self.bg;
+        target.modifier = self.modifier;
+    }
+}
+
+/// Remembers the last colour pair translated out of vt100.
+///
+/// Styled output arrives in runs — a word, usually a whole line, shares one
+/// colour pair — so this turns the palette lookup for almost every cell into two
+/// comparisons. The keys start at vt100's own default, which is what an untouched
+/// screen is full of.
+#[derive(Debug, Clone, Copy)]
+struct ColorMemo {
+    fg_key: vt100::Color,
+    bg_key: vt100::Color,
+    fg: Color,
+    bg: Color,
+}
+
+impl Default for ColorMemo {
+    fn default() -> Self {
+        // There is no "nothing remembered yet" state to guard against: vt100's
+        // default colour maps to the pane defaults, so seeding the memo with
+        // that pair starts it already correct for an untouched screen.
+        Self {
+            fg_key: vt100::Color::Default,
+            bg_key: vt100::Color::Default,
+            fg: PANE_FG,
+            bg: PANE_BG,
+        }
+    }
+}
+
+impl ColorMemo {
+    fn style_for(&mut self, cell: &Cell) -> CellStyle {
+        let fg_key = cell.fgcolor();
+        if self.fg_key != fg_key {
+            self.fg_key = fg_key;
+            self.fg = vt_color(fg_key, PANE_FG);
+        }
+        let bg_key = cell.bgcolor();
+        if self.bg_key != bg_key {
+            self.bg_key = bg_key;
+            self.bg = vt_color(bg_key, PANE_BG);
+        }
+
+        let mut modifier = Modifier::empty();
+        if cell.bold() {
+            modifier |= Modifier::BOLD;
+        }
+        if cell.dim() {
+            modifier |= Modifier::DIM;
+        }
+        if cell.italic() {
+            modifier |= Modifier::ITALIC;
+        }
+        if cell.underline() {
+            modifier |= Modifier::UNDERLINED;
+        }
+        if cell.inverse() {
+            modifier |= Modifier::REVERSED;
+        }
+
+        CellStyle {
+            fg: self.fg,
+            bg: self.bg,
+            modifier,
+        }
+    }
 }
 
 fn flush_span<'a>(
@@ -4253,45 +4613,6 @@ fn flush_span<'a>(
         std::mem::take(current_text),
         current_style.take().unwrap_or_default(),
     ));
-}
-
-fn cell_style(cell: &Cell) -> Style {
-    let mut style = Style::default()
-        .fg(vt_color(cell.fgcolor(), Color::Rgb(230, 237, 243)))
-        .bg(vt_color(cell.bgcolor(), Color::Rgb(11, 15, 20)));
-
-    if cell.bold() {
-        style = style.add_modifier(Modifier::BOLD);
-    }
-    if cell.dim() {
-        style = style.add_modifier(Modifier::DIM);
-    }
-    if cell.italic() {
-        style = style.add_modifier(Modifier::ITALIC);
-    }
-    if cell.underline() {
-        style = style.add_modifier(Modifier::UNDERLINED);
-    }
-    if cell.inverse() {
-        style = style.add_modifier(Modifier::REVERSED);
-    }
-
-    style
-}
-
-fn selection_style(style: Style, selection: Option<PaneSelection>, row: u16, column: u16) -> Style {
-    if selection.is_some_and(|selection| selection.contains(row, column)) {
-        style
-            .fg(Color::Black)
-            .bg(Color::LightCyan)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        style
-    }
-}
-
-fn rgb_color((red, green, blue): (u8, u8, u8)) -> Color {
-    Color::Rgb(red, green, blue)
 }
 
 fn vt_color(color: vt100::Color, default: Color) -> Color {
@@ -4356,9 +4677,139 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{cli::Cli, config::Config};
+    use crate::{
+        cli::Cli,
+        config::Config,
+        layout::{GridLayout, GridSize},
+    };
     use clap::Parser;
     use ratatui::{Terminal, backend::TestBackend};
+
+    /// One pane in a rendered preview of the shell.
+    struct PreviewPane {
+        frame: PaneFrame,
+        body: &'static str,
+    }
+
+    fn preview_panes() -> Vec<PreviewPane> {
+        let pane = |number: usize,
+                    label: &str,
+                    summary: &str,
+                    state: PaneState,
+                    body: &'static str| PreviewPane {
+            frame: PaneFrame {
+                number,
+                label: label.into(),
+                summary: summary.into(),
+                usage: Some("5h 80% left".into()),
+                state,
+                focused: number == 1,
+                selected: number == 4,
+                logging: number == 6,
+                compact: false,
+            },
+            body,
+        };
+
+        vec![
+            pane(1, "api", "editing src/routes.rs", PaneState::Live, "$ cargo test"),
+            pane(2, "web", "waiting for review", PaneState::Waiting, "Continue? [y/N]"),
+            pane(3, "docs", "wrote the changelog", PaneState::Idle, "$ "),
+            pane(4, "infra", "terraform plan clean", PaneState::Live, "$ tf apply"),
+            pane(5, "tests", "3 failures remain", PaneState::Waiting, "FAILED 3"),
+            pane(6, "bench", "recording a trace", PaneState::Live, "sampling..."),
+            pane(7, "spike", "paused by the user", PaneState::Sleeping, ""),
+            pane(8, "old", "process exited", PaneState::Exited, "exit 130"),
+            pane(9, "shell", "", PaneState::Live, "$ git status"),
+        ]
+    }
+
+    /// Renders the main shell — tab strip, pane lattice, status bar — to text.
+    ///
+    /// The grid is the one part of GridBash that cannot be judged from its
+    /// source: whether nine panes read as a workspace or as noise is a question
+    /// about glyphs on a screen. This draws the real chrome functions so that
+    /// question can be answered without a terminal full of live PTYs behind it.
+    fn preview_shell(width: u16, height: u16, grid: GridSize) -> String {
+        let cli = Cli::parse_from(["gridbash"]);
+        let app = App::new(cli, Config::default()).expect("app");
+        let palette = GridPalette::default();
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                frame.render_widget(Paragraph::new("").style(Style::default().bg(INK)), area);
+
+                let tabs = ["Frontend", "Backend", "Review"]
+                    .iter()
+                    .enumerate()
+                    .map(|(index, title)| TabLabel {
+                        title: (*title).into(),
+                        active: index == 0,
+                        selected: index == 1,
+                        waiting: index == 2,
+                        activity: false,
+                        exited: false,
+                    })
+                    .collect::<Vec<_>>();
+                render_tabs(frame, Rect::new(0, 0, width, 1), &tabs, &palette);
+
+                let grid_area = Rect::new(0, 1, width, height.saturating_sub(2));
+                let panes = preview_panes();
+                let rects = GridLayout::new(grid).rects(grid_area, panes.len());
+                let mut order = (0..panes.len()).collect::<Vec<_>>();
+                order.sort_by_key(|index| {
+                    let view = &panes[*index].frame;
+                    u8::from(view.selected) + 2 * u8::from(view.focused)
+                });
+                for index in order {
+                    let Some(rect) = rects.get(index).copied() else {
+                        continue;
+                    };
+                    let pane = &panes[index];
+                    let inner = render_pane_frame(frame, rect, &pane.frame, &palette);
+                    if inner.width > 0 && inner.height > 0 {
+                        frame.render_widget(
+                            Paragraph::new(pane.body)
+                                .style(Style::default().fg(TEXT).bg(APP_BG)),
+                            inner,
+                        );
+                    }
+                }
+
+                render_status_bar(
+                    frame,
+                    Rect::new(0, height.saturating_sub(1), width, 1),
+                    &app,
+                    &palette,
+                );
+            })
+            .expect("render preview");
+
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Prints the shell so the layout can be looked at. Run with:
+    /// `cargo test -- --ignored --nocapture main_tui_preview`
+    #[test]
+    #[ignore = "visual preview"]
+    fn main_tui_preview() {
+        for (width, height, rows, columns) in [(120, 34, 3, 3), (100, 28, 2, 2), (72, 20, 2, 2)] {
+            let grid = GridSize::new(rows, columns).expect("grid");
+            eprintln!("\n===== {width}x{height} · {rows}x{columns} =====");
+            eprintln!("{}", preview_shell(width, height, grid));
+        }
+    }
 
     fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
         terminal
@@ -4476,7 +4927,12 @@ mod tests {
         assert_eq!(targets[1].0, 1);
         assert_eq!(targets[0].1.right(), targets[1].1.x);
         assert_eq!(targets[1].1.right(), targets[2].1.x);
-        assert!(buffer_text(&terminal).contains("2:Tests+"));
+
+        let rendered = buffer_text(&terminal);
+        assert!(rendered.contains(" 1 Frontend "), "tabs: {rendered}");
+        assert!(rendered.contains(" 2 Tests "), "tabs: {rendered}");
+        // A grid with an agent waiting on the user is the one thing in the strip
+        // allowed a filled background.
         assert!(
             terminal
                 .backend()
@@ -4485,6 +4941,74 @@ mod tests {
                 .iter()
                 .any(|cell| cell.symbol() == "R" && cell.bg == TAB_WAITING_BG)
         );
+    }
+
+    /// The hints exist to be discoverable, not to be load-bearing. A terminal
+    /// too narrow for them must spend its width on the tabs instead.
+    #[test]
+    fn tab_hints_give_way_to_the_tabs_themselves() {
+        assert_eq!(tab_hints(0).width(), 0);
+        assert!(tab_hints(200).width() > 0);
+        assert!(tab_hints(200).width() >= tab_hints(20).width());
+
+        for budget in [0, 1, 7, 13, 40, 200] {
+            assert!(
+                tab_hints(budget).width() <= budget as usize,
+                "hints overflowed a {budget}-column budget"
+            );
+        }
+    }
+
+    /// The status bar lays out its chips once and reports where they landed.
+    /// When that layout was duplicated by a second set of offset calculations,
+    /// renaming a button moved it on screen without moving its click target.
+    #[test]
+    fn status_bar_click_targets_match_what_was_drawn() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let app = App::new(cli, Config::default()).expect("app");
+        let backend = TestBackend::new(120, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let mut buttons = StatusButtons::default();
+
+        terminal
+            .draw(|frame| {
+                buttons = render_status_bar(frame, frame.area(), &app, &GridPalette::default());
+            })
+            .expect("render status bar");
+
+        let buffer = terminal.backend().buffer().clone();
+        let text_at = |rect: Rect| {
+            (rect.x..rect.right())
+                .map(|x| buffer[(x, rect.y)].symbol())
+                .collect::<String>()
+        };
+
+        assert_eq!(
+            text_at(buttons.previous_panes.expect("panes chip")),
+            PREVIOUS_PANES_BUTTON
+        );
+        assert_eq!(
+            text_at(buttons.pane_settings.expect("summary chip")),
+            PANE_SETTINGS_BUTTON
+        );
+        assert_eq!(
+            text_at(buttons.background_jobs.expect("jobs chip")),
+            background_jobs_button_label(0)
+        );
+        assert_eq!(
+            text_at(buttons.ports.expect("ports chip")),
+            ports_button_label(0)
+        );
+    }
+
+    /// "0 panes selected" was permanently on screen to report that nothing
+    /// unusual was happening.
+    #[test]
+    fn the_status_bar_stays_silent_about_an_empty_selection() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let app = App::new(cli, Config::default()).expect("app");
+
+        assert_eq!(selection_summary(&app), None);
     }
 
     #[test]
@@ -4579,12 +5103,87 @@ mod tests {
         }
     }
 
+    /// The pane path as it stood before the rasterizer: a `Line` of `Span`s per
+    /// row, laid out by `Paragraph`. Kept only so the benchmark below can put a
+    /// number on what replacing it bought.
+    fn legacy_screen_render(buffer: &mut Buffer, screen: &vt100::Screen, width: u16, height: u16) {
+        use ratatui::widgets::Widget;
+
+        fn legacy_cell_style(cell: &Cell) -> Style {
+            let mut style = Style::default()
+                .fg(vt_color(cell.fgcolor(), PANE_FG))
+                .bg(vt_color(cell.bgcolor(), PANE_BG));
+            if cell.bold() {
+                style = style.add_modifier(Modifier::BOLD);
+            }
+            if cell.dim() {
+                style = style.add_modifier(Modifier::DIM);
+            }
+            if cell.italic() {
+                style = style.add_modifier(Modifier::ITALIC);
+            }
+            if cell.underline() {
+                style = style.add_modifier(Modifier::UNDERLINED);
+            }
+            if cell.inverse() {
+                style = style.add_modifier(Modifier::REVERSED);
+            }
+            style
+        }
+
+        let lines = (0..height)
+            .map(|row| {
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                let mut current_style: Option<Style> = None;
+                let mut current_text = String::new();
+                for column in 0..width {
+                    let (style, text) = match screen.cell(row, column) {
+                        Some(cell) if cell.is_wide_continuation() => continue,
+                        Some(cell) => (
+                            legacy_cell_style(cell),
+                            if cell.has_contents() {
+                                cell.contents()
+                            } else {
+                                " "
+                            },
+                        ),
+                        None => (Style::default(), " "),
+                    };
+                    if current_style.is_some_and(|active| active == style) {
+                        current_text.push_str(text);
+                        continue;
+                    }
+                    flush_span(&mut spans, &mut current_style, &mut current_text);
+                    current_style = Some(style);
+                    current_text.push_str(text);
+                }
+                flush_span(&mut spans, &mut current_style, &mut current_text);
+                Line::from(spans)
+            })
+            .collect::<Vec<_>>();
+
+        let area = Rect::new(0, 0, width, height);
+        if buffer.area != area {
+            buffer.resize(area);
+        }
+        buffer.reset();
+        Widget::render(
+            Paragraph::new(lines).style(Style::default().fg(PANE_FG).bg(APP_BG)),
+            area,
+            buffer,
+        );
+    }
+
+    /// Times the pane hot path against the one it replaced.
+    ///
+    /// The version of this benchmark that shipped before held `revision` at 1,
+    /// so every iteration after the first hit the cache's early return and the
+    /// loop timed `blit_buffer` alone — the rasterizer it was named after never
+    /// ran. Varying the revision is what makes the number mean anything.
     #[test]
     #[ignore = "manual performance benchmark"]
     fn benchmark_cached_screen_render() {
         use std::{hint::black_box, time::Instant};
-
-        use ratatui::buffer::Buffer;
 
         const ITERATIONS: usize = 5_000;
         let mut parser = vt100::Parser::new(40, 120, 10_000);
@@ -4597,28 +5196,52 @@ mod tests {
             })
             .collect::<String>();
         parser.process(output.as_bytes());
+        let screen = parser.screen();
 
         let area = Rect::new(0, 0, 120, 40);
-        let mut buffer = Buffer::empty(area);
-        let mut cache = PaneRenderCache::default();
+        let mut frame_buffer = Buffer::empty(area);
+
+        let mut legacy = Buffer::empty(area);
         let start = Instant::now();
         for _ in 0..ITERATIONS {
+            legacy_screen_render(&mut legacy, screen, area.width, area.height);
+            black_box(&legacy);
+        }
+        let legacy_elapsed = start.elapsed() / ITERATIONS as u32;
+
+        let mut cache = PaneRenderCache::default();
+        let start = Instant::now();
+        for iteration in 0..ITERATIONS {
+            // A fresh revision every pass, so the cache never short-circuits and
+            // the rasterizer actually runs.
             refresh_screen_cache(
                 &mut cache,
-                1,
-                parser.screen(),
+                iteration as u64,
+                screen,
                 area.width,
                 area.height,
                 None,
             );
-            blit_buffer(black_box(&cache.buffer), &mut buffer, area);
+            black_box(&cache.buffer);
         }
-        let elapsed = start.elapsed();
+        let rasterize_elapsed = start.elapsed() / ITERATIONS as u32;
+
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            blit_buffer(black_box(&cache.buffer), &mut frame_buffer, area);
+        }
+        let blit_elapsed = start.elapsed() / ITERATIONS as u32;
+
+        eprintln!("120x40 pane, {ITERATIONS} iterations each:");
+        eprintln!("  spans + Paragraph (old): {legacy_elapsed:?}");
+        eprintln!("  direct rasterize (new):  {rasterize_elapsed:?}");
+        eprintln!("  blit to frame:           {blit_elapsed:?}");
         eprintln!(
-            "cached screen render: {ITERATIONS} iterations in {elapsed:?} ({:?}/iteration)",
-            elapsed / ITERATIONS as u32
+            "  full frame old/new:      {:?} -> {:?}",
+            legacy_elapsed + blit_elapsed,
+            rasterize_elapsed + blit_elapsed
         );
-        black_box(buffer);
+        black_box((frame_buffer, legacy));
     }
 
     #[test]
@@ -4711,119 +5334,181 @@ mod tests {
         );
     }
 
-    #[test]
-    fn idle_pane_has_no_state_badges() {
-        let palette = GridPalette::default();
-        let chrome = pane_chrome(false, false, false, false, None, false, &palette);
+    fn pane_frame(state: PaneState) -> PaneFrame {
+        PaneFrame {
+            number: 1,
+            label: "api".into(),
+            summary: "reviewing the latest changes".into(),
+            usage: Some("5h 80% left".into()),
+            state,
+            focused: false,
+            selected: false,
+            logging: false,
+            compact: false,
+        }
+    }
 
-        assert_eq!(chrome.badge, "");
-        assert_eq!(chrome.quiet_marker, "");
+    fn header_text(view: &PaneFrame, width: u16) -> String {
+        let backend = TestBackend::new(width, 3);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                render_pane_frame(
+                    frame,
+                    Rect::new(0, 0, width, 3),
+                    view,
+                    &GridPalette::default(),
+                );
+            })
+            .expect("render pane frame");
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .take(width as usize)
+            .map(|cell| cell.symbol())
+            .collect()
     }
 
     #[test]
-    fn selected_and_exited_badges_remain_visible() {
-        let palette = GridPalette::default();
+    fn a_live_pane_header_shows_its_number_name_and_activity() {
+        let header = header_text(&pane_frame(PaneState::Live), 80);
 
-        assert_eq!(
-            pane_chrome(true, false, false, false, None, true, &palette).badge,
-            " selected"
-        );
-        assert_eq!(
-            pane_chrome(true, false, true, false, None, true, &palette).badge,
-            " exited"
-        );
+        assert!(header.contains(" 1 api"), "header: {header}");
+        assert!(header.contains("reviewing the latest"), "header: {header}");
+        // A pane doing its job has no state worth naming.
+        for badge in ["idle", "asleep", "exited", "needs you"] {
+            assert!(!header.contains(badge), "header: {header}");
+        }
+    }
+
+    /// An agent that has gone quiet is asking for the user. In a grid full of
+    /// agents that is the single most useful thing on screen, so it has to be
+    /// stated in words rather than left to a one-character marker.
+    #[test]
+    fn a_waiting_agent_says_so_in_its_header() {
+        let header = header_text(&pane_frame(PaneState::Waiting), 80);
+
+        assert!(header.contains("needs you"), "header: {header}");
     }
 
     #[test]
-    fn sleeping_panes_show_sleep_badge() {
-        let palette = GridPalette::default();
+    fn every_resting_state_names_itself() {
+        for (state, badge) in [
+            (PaneState::Idle, "idle"),
+            (PaneState::Sleeping, "asleep"),
+            (PaneState::Exited, "exited"),
+        ] {
+            let header = header_text(&pane_frame(state), 80);
+            assert!(header.contains(badge), "{state:?} header: {header}");
+        }
+    }
 
-        assert_eq!(
-            pane_chrome(false, false, false, true, None, true, &palette).badge,
-            " asleep"
-        );
+    /// The name is the only way to tell one pane from another, so it is the last
+    /// thing a narrow header gives up — before the summary, and before usage.
+    #[test]
+    fn a_narrow_header_keeps_the_name_and_drops_the_extras() {
+        let header = header_text(&pane_frame(PaneState::Idle), 26);
+
+        assert!(header.contains("api"), "header: {header}");
+        assert!(!header.contains("5h 80% left"), "header: {header}");
+        assert_eq!(header.chars().count(), 26);
     }
 
     #[test]
-    fn pane_title_uses_activity_summary_instead_of_launch_metadata() {
-        assert_eq!(
-            pane_title(
-                "api",
-                "",
-                "reviewing the latest changes",
-                None,
-                "",
-                false,
-                120,
-            ),
-            " api | reviewing the latest changes "
-        );
-        assert_eq!(
-            pane_title("1", "", "tests passed", None, " selected", false, 120),
-            " 1 selected | tests passed "
-        );
-        assert_eq!(
-            pane_title(
-                "2",
-                "",
-                "goal: finish the API",
-                Some("5h 80% left"),
-                " selected",
-                false,
-                120,
-            ),
-            " 2 selected | 5h 80% left | goal: finish the API "
-        );
+    fn compact_headers_keep_the_summary_but_drop_usage() {
+        let mut view = pane_frame(PaneState::Live);
+        view.compact = true;
+        let header = header_text(&view, 80);
+
+        assert!(header.contains("api"), "header: {header}");
+        assert!(!header.contains("5h 80% left"), "header: {header}");
+    }
+
+    /// Panes overlap by a cell so their borders merge. If a pane ever drew
+    /// outside the rect it was handed, it would erase its neighbour's content
+    /// rather than just share a line with it.
+    #[test]
+    fn a_pane_frame_draws_only_inside_its_own_rect() {
+        let backend = TestBackend::new(20, 6);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                render_pane_frame(
+                    frame,
+                    Rect::new(0, 0, 10, 4),
+                    &pane_frame(PaneState::Live),
+                    &GridPalette::default(),
+                );
+            })
+            .expect("render pane frame");
+
+        let buffer = terminal.backend().buffer();
+        for y in 0..6 {
+            for x in 0..20 {
+                if x < 10 && y < 4 {
+                    continue;
+                }
+                assert_eq!(buffer[(x, y)].symbol(), " ", "cell ({x}, {y}) was painted");
+            }
+        }
+    }
+
+    /// The header is drawn as two titles, one from each end. They must never
+    /// reach far enough to write over each other, at any width a pane can have.
+    #[test]
+    fn header_titles_never_collide_at_any_width() {
+        for state in [
+            PaneState::Live,
+            PaneState::Waiting,
+            PaneState::Idle,
+            PaneState::Sleeping,
+            PaneState::Exited,
+        ] {
+            let mut view = pane_frame(state);
+            view.number = 100;
+            view.label = "a-rather-long-pane-name".into();
+            view.logging = true;
+
+            for width in 8..=80u16 {
+                let budget = width - 2;
+                let trailing = pane_header_trailing(&view, &GridPalette::default(), width);
+                let trailing_width = trailing.width() as u16;
+                let fits =
+                    trailing_width > 0 && pane_number_width(&view) + trailing_width <= budget;
+                let leading = pane_header_leading(
+                    &view,
+                    &GridPalette::default(),
+                    if fits { budget - trailing_width } else { budget },
+                );
+
+                let used = leading.width() as u16 + if fits { trailing_width } else { 0 };
+                assert!(
+                    used <= budget,
+                    "{state:?} at width {width}: header needs {used} of {budget}"
+                );
+            }
+        }
     }
 
     #[test]
-    fn pane_title_keeps_quiet_marker_with_custom_label() {
-        assert_eq!(
-            pane_title(
-                "api",
-                QUIET_MARKER,
-                "waiting for output",
-                None,
-                "",
-                false,
-                120,
-            ),
-            " api * | waiting for output "
-        );
-    }
+    fn a_pane_frame_reports_the_area_left_for_its_terminal() {
+        let backend = TestBackend::new(40, 8);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let mut inner = Rect::default();
+        terminal
+            .draw(|frame| {
+                inner = render_pane_frame(
+                    frame,
+                    Rect::new(2, 1, 30, 6),
+                    &pane_frame(PaneState::Live),
+                    &GridPalette::default(),
+                );
+            })
+            .expect("render pane frame");
 
-    #[test]
-    fn compact_pane_title_keeps_summary_but_omits_usage_details() {
-        assert_eq!(
-            pane_title(
-                "api",
-                QUIET_MARKER,
-                "reviewing the latest changes",
-                Some("5h 80% left"),
-                " selected",
-                true,
-                120,
-            ),
-            " api * selected | reviewing the latest changes "
-        );
-    }
-
-    #[test]
-    fn narrow_pane_title_keeps_state_before_truncated_activity() {
-        let title = pane_title(
-            "very-long-pane-name",
-            QUIET_MARKER,
-            "reviewing the latest changes",
-            Some("5h 80% left"),
-            " selected",
-            false,
-            30,
-        );
-
-        assert!(title.chars().count() <= 30);
-        assert!(title.contains("selected"));
-        assert!(title.contains("review"));
-        assert!(!title.contains("5h 80% left"));
+        assert_eq!(inner, Rect::new(3, 2, 28, 4));
     }
 
     #[test]
@@ -5069,36 +5754,136 @@ mod tests {
         );
     }
 
+    /// Focus is the answer to "where do my keystrokes go", so it outranks every
+    /// state a pane arrived at on its own — including an agent asking for help,
+    /// which still gets to say so in words.
     #[test]
-    fn quiet_output_marks_idle_pane_without_active_chrome() {
+    fn focus_and_selection_outrank_a_panes_own_state() {
         let palette = GridPalette::default();
-        let quiet = pane_chrome(false, false, false, false, None, true, &palette);
+        let mut view = pane_frame(PaneState::Waiting);
 
-        assert_eq!(quiet.quiet_marker, QUIET_MARKER);
-        assert_eq!(quiet.border_style, Style::default().fg(palette.quiet()));
-    }
-
-    #[test]
-    fn grouped_quiet_pane_keeps_group_border_and_marker() {
-        let palette = GridPalette::default();
-        let group_color = (82, 166, 255);
-        let chrome = pane_chrome(
-            false,
-            false,
-            false,
-            false,
-            Some(group_color),
-            true,
-            &palette,
+        assert_eq!(
+            pane_border_style(&view, &palette),
+            Style::default().fg(WAITING)
         );
 
-        assert_eq!(chrome.quiet_marker, QUIET_MARKER);
+        view.selected = true;
         assert_eq!(
-            chrome.border_style,
+            pane_border_style(&view, &palette),
             Style::default()
-                .fg(rgb_color(group_color))
+                .fg(palette.selected())
                 .add_modifier(Modifier::BOLD)
         );
+
+        view.focused = true;
+        assert_eq!(
+            pane_border_style(&view, &palette),
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD)
+        );
+        assert!(header_text(&view, 80).contains("needs you"));
+    }
+
+    /// A resting pane must stay quiet. Borders that shout at the user from every
+    /// idle pane are how a grid stops being readable at nine panes.
+    #[test]
+    fn a_resting_pane_uses_a_quiet_border() {
+        let palette = GridPalette::default();
+
+        for state in [PaneState::Live, PaneState::Idle] {
+            assert_eq!(
+                pane_border_style(&pane_frame(state), &palette),
+                Style::default().fg(LINE),
+                "{state:?} must not draw attention"
+            );
+        }
+        assert_eq!(
+            pane_border_style(&pane_frame(PaneState::Sleeping), &palette),
+            Style::default().fg(LINE_SOFT)
+        );
+    }
+
+    /// The seam is the whole point of overlapping the rects. If ratatui's border
+    /// merging ever stops resolving the overlap, panes go back to showing two
+    /// parallel lines between every pair — so assert on the junction glyph
+    /// rather than trusting the layout arithmetic alone.
+    #[test]
+    fn adjacent_panes_merge_into_a_single_dividing_line() {
+        let backend = TestBackend::new(21, 5);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let palette = GridPalette::default();
+
+        terminal
+            .draw(|frame| {
+                let mut left = pane_frame(PaneState::Live);
+                left.summary = String::new();
+                left.usage = None;
+                let mut right = left.clone();
+                right.number = 2;
+                // Overlapping by one column is what `weighted_grid_rects` hands
+                // the renderer for two side-by-side panes.
+                render_pane_frame(frame, Rect::new(0, 0, 11, 5), &left, &palette);
+                render_pane_frame(frame, Rect::new(10, 0, 11, 5), &right, &palette);
+            })
+            .expect("render two panes");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(10, 0)].symbol(), "┬", "top junction");
+        assert_eq!(buffer[(10, 2)].symbol(), "│", "shared divider");
+        assert_eq!(buffer[(10, 4)].symbol(), "┴", "bottom junction");
+    }
+
+    /// Cache buffers live between frames, so a cell keeps whatever it was last
+    /// given. Patching a `Style` onto one only ever adds modifiers, which would
+    /// leave text bold forever once anything nearby had been bold.
+    #[test]
+    fn rasterizing_clears_attributes_that_no_longer_apply() {
+        let mut parser = vt100::Parser::new(1, 4, 100);
+        let mut cache = PaneRenderCache::default();
+
+        parser.process(b"\x1b[1;31mbold");
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 4, 1, None);
+        assert!(cache.buffer[(0, 0)].modifier.contains(Modifier::BOLD));
+
+        parser.process(b"\r\x1b[0mflat");
+        refresh_screen_cache(&mut cache, 2, parser.screen(), 4, 1, None);
+        assert!(
+            !cache.buffer[(0, 0)].modifier.contains(Modifier::BOLD),
+            "bold outlived the output that set it"
+        );
+        assert_eq!(cache.buffer[(0, 0)].symbol(), "f");
+    }
+
+    /// Ratatui's diff assumes a double-width symbol is followed by a blank and
+    /// skips that column. Leaving anything else there prints over the second
+    /// half of the glyph.
+    #[test]
+    fn wide_characters_leave_their_second_column_blank() {
+        let mut parser = vt100::Parser::new(1, 4, 100);
+        parser.process("東京".as_bytes());
+        let mut cache = PaneRenderCache::default();
+
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 4, 1, None);
+
+        assert_eq!(cache.buffer[(0, 0)].symbol(), "東");
+        assert_eq!(cache.buffer[(1, 0)].symbol(), " ");
+        assert_eq!(cache.buffer[(2, 0)].symbol(), "京");
+        assert_eq!(cache.buffer[(3, 0)].symbol(), " ");
+    }
+
+    /// A wide glyph in the last column has nowhere to put its second half, and
+    /// the cell to its right belongs to the next pane's border.
+    #[test]
+    fn a_wide_character_clipped_by_the_pane_edge_is_dropped() {
+        let mut parser = vt100::Parser::new(1, 4, 100);
+        parser.process("a東".as_bytes());
+        let mut cache = PaneRenderCache::default();
+
+        refresh_screen_cache(&mut cache, 1, parser.screen(), 2, 1, None);
+
+        assert_eq!(cache.buffer[(0, 0)].symbol(), "a");
+        assert_eq!(cache.buffer[(1, 0)].symbol(), " ");
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -11,7 +11,7 @@ use std::{
 
 use serde::Deserialize;
 
-use crate::auth::AgentKind;
+use crate::{auth::AgentKind, diagnostics};
 
 const CLAUDE_USAGE_ENDPOINT: &str = "https://api.anthropic.com/api/oauth/usage";
 const CODEX_USAGE_ENDPOINT: &str = "https://chatgpt.com/backend-api/codex/usage";
@@ -66,33 +66,31 @@ struct UsageBlock {
 
 pub fn spawn_usage_monitor(targets: Vec<UsageTarget>, tx: Sender<UsageEvent>) {
     thread::spawn(move || {
-        let targets = resolve_usage_sources(&targets);
+        let Ok(targets) = diagnostics::recovering("usage monitor startup", || {
+            Ok(resolve_usage_sources(&targets))
+        }) else {
+            return;
+        };
         loop {
-            let mut disconnected = false;
-
-            for source in &targets {
-                let label = profile_usage_label(source);
-                if tx
-                    .send(UsageEvent::Profile {
+            // Each round reads and parses files the agents own. A panic on one
+            // malformed read would otherwise end usage reporting for the rest of
+            // the session, so recover and try again next round.
+            let round = diagnostics::recovering("a usage refresh", || {
+                let mut events = Vec::with_capacity(targets.len() + 1);
+                for source in &targets {
+                    events.push(UsageEvent::Profile {
                         usage_key: source.usage_key.clone(),
-                        label,
-                    })
-                    .is_err()
-                {
-                    disconnected = true;
-                    break;
+                        label: profile_usage_label(source),
+                    });
                 }
-            }
-
-            if disconnected {
-                break;
-            }
-
-            if tx
-                .send(UsageEvent::ApiSpend {
+                events.push(UsageEvent::ApiSpend {
                     label: api_spend_label(),
-                })
-                .is_err()
+                });
+                Ok(events)
+            });
+
+            if let Ok(events) = round
+                && events.into_iter().any(|event| tx.send(event).is_err())
             {
                 break;
             }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -12,6 +12,8 @@ use std::process::Stdio;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::{env, path::PathBuf};
 
+use crate::diagnostics;
+
 #[cfg(target_os = "linux")]
 use crate::voice_model;
 
@@ -157,7 +159,13 @@ impl VoiceInput {
         let event_tx = self.event_tx.clone();
 
         thread::spawn(move || {
-            if let Some(outcome) = recognize(cancel_rx) {
+            // A panicking recognizer would otherwise leave the request in flight
+            // and the microphone indicator on for the rest of the session.
+            let outcome = match diagnostics::recovering("dictation", || Ok(recognize(cancel_rx))) {
+                Ok(outcome) => outcome,
+                Err(error) => Some(VoiceOutcome::Error(error)),
+            };
+            if let Some(outcome) = outcome {
                 let _ = event_tx.send(VoiceEvent {
                     request_id,
                     outcome,

--- a/src/worktrees.rs
+++ b/src/worktrees.rs
@@ -19,6 +19,63 @@ pub struct ManagedPaneWorktree {
     pub branch_name: String,
 }
 
+/// Whether a folder can back one managed git worktree per pane right now.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorktreeReadiness {
+    Ready { base_slug: String },
+    Blocked { reason: String },
+}
+
+impl WorktreeReadiness {
+    pub fn base_slug(&self) -> Option<&str> {
+        match self {
+            Self::Ready { base_slug } => Some(base_slug),
+            Self::Blocked { .. } => None,
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready { .. })
+    }
+
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Ready { .. } => None,
+            Self::Blocked { reason } => Some(reason),
+        }
+    }
+}
+
+/// Answer the same questions `ensure_pane_worktrees` asks, without touching the
+/// repository. The composer polls this so it can show why worktrees are or are
+/// not available before anything is launched.
+pub fn probe_worktree_readiness(cwd: &Path) -> WorktreeReadiness {
+    if git_output(cwd, args(&["rev-parse", "--git-dir"])).is_err() {
+        return blocked("not a git repository");
+    }
+    let Ok(repo) = GitRepo::from_cwd(cwd) else {
+        return blocked("repository has no commit to branch from");
+    };
+    if ensure_clean_tracked_checkout(&repo.root).is_err() {
+        return blocked("uncommitted tracked changes in the base checkout");
+    }
+
+    WorktreeReadiness::Ready {
+        base_slug: repo.base_slug,
+    }
+}
+
+/// Branch name `ensure_pane_worktrees` will create for a zero-based pane index.
+pub fn managed_branch_name(prefix: &str, base_slug: &str, index: usize) -> String {
+    format!("{prefix}/{base_slug}-pane-{:02}", index + 1)
+}
+
+fn blocked(reason: &str) -> WorktreeReadiness {
+    WorktreeReadiness::Blocked {
+        reason: reason.into(),
+    }
+}
+
 #[derive(Debug)]
 struct GitRepo {
     root: PathBuf,
@@ -104,10 +161,7 @@ fn ensure_pane_worktree(
     index: usize,
 ) -> Result<ManagedPaneWorktree> {
     let pane_number = index + 1;
-    let branch_name = format!(
-        "{}/{}-pane-{pane_number:02}",
-        options.prefix, repo.base_slug
-    );
+    let branch_name = managed_branch_name(&options.prefix, &repo.base_slug, index);
     if let Some(worktree) = existing
         .iter()
         .find(|worktree| worktree.branch.as_deref() == Some(branch_name.as_str()))
@@ -434,6 +488,43 @@ mod tests {
             .to_string();
 
         assert!(error.contains("tracked changes are present"));
+    }
+
+    #[test]
+    fn readiness_probe_reports_the_base_branch_and_blocking_reasons() {
+        let repo = TempRepo::new("readiness");
+        let cwd = repo.root.join("crates").join("cli");
+
+        assert_eq!(
+            probe_worktree_readiness(&cwd),
+            WorktreeReadiness::Ready {
+                base_slug: "main".into()
+            }
+        );
+        assert_eq!(
+            managed_branch_name("gridbash", "main", 2),
+            "gridbash/main-pane-03"
+        );
+
+        fs::write(cwd.join("README.md"), "dirty\n").expect("dirty file");
+        let dirty = probe_worktree_readiness(&cwd);
+        assert!(!dirty.is_ready());
+        assert_eq!(
+            dirty.reason(),
+            Some("uncommitted tracked changes in the base checkout")
+        );
+
+        let plain = std::env::temp_dir().join(format!(
+            "gridbash-readiness-plain-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        fs::create_dir_all(&plain).expect("plain dir");
+        assert_eq!(
+            probe_worktree_readiness(&plain).reason(),
+            Some("not a git repository")
+        );
+        let _ = fs::remove_dir_all(plain);
     }
 
     fn unique_suffix() -> u128 {


### PR DESCRIPTION
Reworks the main TUI (not the onboarding composer) for looks and speed.

## Grid

Panes now overlap by one cell and use ratatui's border merging, so neighbours
share a single divider with proper `┬ ┼ ┤ ┴` junctions instead of two parallel
rules. Every pane gains a column and a row of usable terminal, and PTY sizing
follows automatically because it already derived from `block.inner`.

```
┌ 1 api · editing src/routes.rs ────────┬ 2 web · waiting for review  needs you ┐
│$ cargo test                           │Continue? [y/N]                        │
├ 4 infra · terraform plan clean ───────┼ 5 tests · 3 failures re...  needs you ┤
└───────────────────────────────────────┴───────────────────────────────────────┘
```

## Pane headers

Number chip and name on the left, state right-aligned, activity summary dimmed
between them. The width budget is explicit and ordered: a narrowing pane drops
its usage figure first and its summary second, while the name and state always
survive. Previously the state was fitted last, so `needs you` was the first
thing a narrow pane dropped.

A quiet agent pane now says `needs you` instead of showing a bare marker,
reading the same predicate the tab strip already used so per-pane and per-tab
"waiting" cannot disagree.

## Chrome

- One fixed colour ramp replaces terminal-theme `DarkGray`/`Yellow` mixed with
  hand-written RGB. Only the five configurable palette roles stay theme-driven.
- Panes draw in state order, so a focused or selected pane keeps an unbroken
  outline rather than having half repainted by whichever neighbour drew last.
- The status bar lays out once and returns its chip rects instead of
  recomputing them from string lengths elsewhere — that duplication had let a
  renamed button move on screen without moving its click target.
- Tab-strip hints fit the space left over instead of always spending sixty
  columns of the top row.

## Renderer

Pane screens rasterize straight into buffer cells. The old path built a `Line`
of `Span`s per row and handed the pane to `Paragraph`, which re-segmented text
already laid out on a grid. The hot path no longer allocates.

Measured in release, both paths in one binary, 120x40 pane:

| path | per frame |
| --- | --- |
| spans + `Paragraph` (old) | 742.8µs |
| direct rasterize (new) | **233.3µs** (3.18x) |
| blit cached buffer to frame | 46.0µs |
| **full pane frame** | **788.8µs → 279.3µs (2.8x)** |

Rasterizing costs 5x the blit, which is what justifies keeping the render
cache: an unchanged pane pays 46µs instead of 233µs.

This also fixes the benchmark that was supposed to measure it. It held the
cache revision at 1, so every iteration after the first hit the early return
and timed `blit_buffer` alone — the rasterizer it was named after never ran.

## Tests

`cargo test`: 362 pass. New coverage for the shared-divider junctions, header
width priority at every width from 8 to 80 columns, wide-character handling,
attributes not outliving the output that set them, and status-bar click targets
matching what was drawn. Adds an ignored `main_tui_preview` that dumps the whole
shell to text at three sizes.
