### PR TITLE
feat: preserve the whole workspace across resume

### DIFF
--- a/docs/devlogs/2026-07-30-preserve-the-whole-workspace-across-resume.md
+++ b/docs/devlogs/2026-07-30-preserve-the-whole-workspace-across-resume.md
@@ -1,0 +1,65 @@
+# Preserve the whole workspace across resume
+
+Date: 2026-07-30
+Release target: unreleased
+
+## Summary
+
+- Resuming a workspace now rebuilds it as it was: grid sizes, pane positions,
+  grid and pane names, focus, zoom, dragged dividers, tab order, and each pane's
+  agent conversation.
+- Claude panes resume their conversation instead of coming back as bare shells.
+- Fixes #304.
+
+## What Changed
+
+- Snapshot format v2 records pane names, Claude session ids, sleeping panes,
+  per-grid view state (focus, zoom, divider weights), the active grid's position
+  in the tab strip, and the next grid number. Version 1 snapshots still load with
+  the new fields defaulted.
+- Saved grid dimensions are used verbatim. A 2x3 grid holding four panes comes
+  back 2x3 with two empty cells, and panes are placed by the cell they recorded
+  rather than by their order in the file.
+- Crash recovery carries each interrupted workspace's grids over unchanged.
+  It previously pooled panes by working directory and re-derived a grid size from
+  the pane count, which reshaped a 2x3 grid into 3x3 and replaced grid names with
+  folder names. Recovery now also keeps background panes and opens on the grid
+  that was interrupted.
+- Claude panes are pinned to a conversation at launch with `--session-id`, so a
+  snapshot names it exactly even with several Claude panes in one folder.
+  Restores use `claude --resume` after checking the transcript still exists, and
+  fall back to a plain launch when it does not. Panes are re-checked periodically
+  so one that clears its conversation follows onto the new one.
+- Snapshots are written durably: contents are flushed to disk before the rename
+  publishes them, the previous snapshot is kept as a `.bak`, and loading falls
+  back to it when the primary copy is unreadable.
+- Changes to a workspace's shape are saved immediately rather than waiting for
+  the autosave tick, and a drop guard saves state that a panic outside the event
+  loop's firewall would otherwise take with it.
+- The resume picker lists every grid with the size it will be rebuilt at, and
+  `Tab` walks a positional map showing each pane in its cell with the name it was
+  given and a mark for conversations that resume.
+
+## Why It Matters
+
+- A crash used to cost the arrangement even when the panes came back: grids were
+  the wrong size, grids and panes lost their names, and Claude conversations were
+  gone while the restored scrollback made it look like they had survived.
+
+## Validation
+
+- `cargo test` (371 passed), `cargo clippy --all-targets -- -D warnings`,
+  `cargo fmt --check`, and a release build.
+- New regression tests cover grid-dimension preservation, cell placement, tab
+  order and the active grid, recovery fidelity, background-pane retention, Claude
+  pinning/resume/fallback/follow-on, version 1 migration, and backup fallback.
+- `gridbash resume --list` read the existing version 1 snapshots on this machine
+  from both the debug and release binaries.
+
+## Release Notes
+
+- Resumed and recovered workspaces keep their grid sizes, pane positions, grid
+  and pane names, focus, zoom, and tab order.
+- Claude panes resume their conversation, including one started after the pane
+  launched.
+- Session snapshots survive an interrupted write.

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,8 +53,10 @@ use crate::{
     profiles::{default_profile_name, find_profile, is_terminal_profile, startup_profiles},
     pty::{PtyEvent, PtyWriteToken},
     session::{
-        InterruptedRecovery, InterruptedRecoveryClaim, SavedBackgroundPane, SavedPane,
-        SavedPaneHistory, SavedTab, SessionRecord, SessionRecorder, complete_interrupted_recovery,
+        InterruptedRecovery, InterruptedRecoveryClaim, LiveGrid, LiveWorkspace,
+        SavedBackgroundPane, SavedPane, SavedPaneHistory, SavedTab, SavedView, SessionRecord,
+        SessionRecorder, claude_session_in_command, complete_interrupted_recovery,
+        latest_claude_session, pin_claude_session,
     },
     setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
     ui,
@@ -84,6 +86,10 @@ const PTY_DRAIN_MAX_TIME: Duration = Duration::from_millis(4);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const PORT_SCAN_INTERVAL: Duration = Duration::from_secs(2);
 const SESSION_AUTOSAVE_INTERVAL: Duration = Duration::from_secs(5);
+/// How often panes are checked for having moved onto a new agent conversation.
+/// Each check reads one directory per agent pane, so it is kept off the path of
+/// every keystroke-driven save.
+const AGENT_SESSION_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 const PANE_GOAL_OUTPUT_MAX_BYTES: usize = 12_000;
 const PANE_GOAL_REVIEW_IDLE: Duration = Duration::from_secs(2);
 const PANE_GOAL_RETRY_DELAY: Duration = Duration::from_secs(30);
@@ -178,9 +184,7 @@ pub struct App {
     auth_refresh_rx: Option<std_mpsc::Receiver<Result<Vec<AuthProfile>, String>>>,
     pane_settings: PaneSettingsState,
     status: String,
-    restored_histories: Vec<SavedPaneHistory>,
-    restored_hosts: Vec<Option<PtyHostRef>>,
-    restored_tabs: Vec<SavedTab>,
+    restored: RestoredWorkspace,
     session_recorder: Option<SessionRecorder>,
     interrupted_recovery_claim: Option<InterruptedRecoveryClaim>,
     output_logs: OutputLogs,
@@ -215,6 +219,7 @@ pub struct App {
     last_activity_decay: Instant,
     last_exit_poll: Instant,
     last_session_autosave: Instant,
+    last_agent_session_refresh: Instant,
 }
 
 struct AppInit {
@@ -229,13 +234,43 @@ struct AppInit {
     control_rx: Option<std_mpsc::Receiver<ControlEnvelope>>,
     settings: SettingsState,
     tab_title: String,
-    restored_histories: Vec<SavedPaneHistory>,
-    restored_background_panes: Vec<SavedBackgroundPane>,
-    restored_hosts: Vec<Option<PtyHostRef>>,
-    restored_tabs: Vec<SavedTab>,
+    restored: RestoredWorkspace,
     session_recorder: Option<SessionRecorder>,
     interrupted_recovery_claim: Option<InterruptedRecoveryClaim>,
     status: String,
+}
+
+/// Everything a resumed or recovered workspace brings back that a launch plan
+/// does not describe: what the user named things, which pane had focus, how the
+/// grids were arranged, and the order they sat in.
+#[derive(Default)]
+struct RestoredWorkspace {
+    histories: Vec<SavedPaneHistory>,
+    hosts: Vec<Option<PtyHostRef>>,
+    pane_names: Vec<Option<String>>,
+    sleeping: BTreeSet<usize>,
+    view: SavedView,
+    background_panes: Vec<SavedBackgroundPane>,
+    /// Grids other than the one that opens first, in workspace order.
+    tabs: Vec<SavedTab>,
+    /// Slot the opening grid should occupy once the others are back.
+    active_tab: usize,
+    /// Number to hand the next new grid, or zero to derive it.
+    next_tab_number: usize,
+}
+
+impl RestoredWorkspace {
+    /// State for the grid that opens first, taken from a saved grid.
+    fn from_grid(grid: &SavedTab) -> Self {
+        Self {
+            histories: grid.pane_histories(),
+            hosts: grid.pane_hosts(),
+            pane_names: grid.pane_names(),
+            sleeping: grid.sleeping_panes(),
+            view: grid.view.clone(),
+            ..Self::default()
+        }
+    }
 }
 
 struct GridTabSnapshot {
@@ -266,6 +301,65 @@ struct BackgroundJob {
     host: Option<PtyHostRef>,
     history: SavedPaneHistory,
     idle: PaneIdleState,
+}
+
+/// Move the grid that opens first from the front of the strip into the slot it
+/// held, and report where it landed.
+///
+/// Restored grids are rebuilt after the active one, so without this every resume
+/// pulled whichever grid had been open to the front of the tab strip.
+fn move_active_slot<T>(slots: &mut Vec<Option<T>>, target: usize) -> usize {
+    let target = target.min(slots.len().saturating_sub(1));
+    if target == 0 {
+        return 0;
+    }
+
+    // The active grid's live state lives on `App`, so its slot is the empty one
+    // and moving that slot is enough to reorder the strip.
+    let active = slots.remove(0);
+    slots.insert(target, active);
+    target
+}
+
+/// Move one pane onto the conversation it is talking to now.
+///
+/// A pane whose agent has exited keeps the conversation it ended on: there is
+/// nothing running to have started a new one.
+fn follow_agent_session(pane: &mut PtyPane, followed: &mut BTreeSet<String>) {
+    if pane.exited {
+        return;
+    }
+    let Some(current) = pane.agent_session_id().map(str::to_string) else {
+        return;
+    };
+    let Some(next) =
+        latest_claude_session(pane.cwd(), Some(&current), pane.started_at_ms(), followed)
+    else {
+        return;
+    };
+
+    followed.remove(&current);
+    followed.insert(next.clone());
+    pane.set_agent_session_id(Some(next));
+}
+
+/// Pane names sized to the grid being restored, so a snapshot that disagrees
+/// with its pane count cannot shift names onto the wrong panes.
+fn restored_pane_names(names: &[Option<String>], pane_count: usize) -> Vec<Option<String>> {
+    let mut restored = vec![None; pane_count];
+    for (slot, name) in restored.iter_mut().zip(names.iter()) {
+        *slot = name.clone().filter(|name| !name.trim().is_empty());
+    }
+    restored
+}
+
+/// Saved pane indexes, dropping any that fall outside the restored grid.
+fn restored_pane_indexes(indexes: &BTreeSet<usize>, pane_count: usize) -> BTreeSet<usize> {
+    indexes
+        .iter()
+        .copied()
+        .filter(|index| *index < pane_count)
+        .collect()
 }
 
 fn retire_pane(pane: &mut PtyPane) -> Result<()> {
@@ -2594,10 +2688,7 @@ impl App {
             control_rx,
             settings,
             tab_title: "Grid 1".into(),
-            restored_histories: Vec::new(),
-            restored_background_panes: Vec::new(),
-            restored_hosts: Vec::new(),
-            restored_tabs: Vec::new(),
+            restored: RestoredWorkspace::default(),
             session_recorder: None,
             interrupted_recovery_claim: None,
             status,
@@ -2611,17 +2702,25 @@ impl App {
         agent_control_enabled: bool,
         agent_control_port: u16,
     ) -> Result<Self> {
-        let mut launch_plan = record.session.launch_plan()?;
+        // The grid that was open is restored into the same slot it held, so the
+        // workspace comes back with its grids in order rather than reordered
+        // around whichever one happened to be active.
+        let (mut grids, active_index) = record.session.ordered_grids();
+        let active = grids.remove(active_index);
+        let mut launch_plan = active.launch_plan()?;
         apply_auth_defaults(&mut launch_plan, &config)?;
         let grid = launch_plan.grid;
-        let restored_histories = record.session.pane_histories();
-        let restored_background_panes = record.session.background_panes.clone();
-        let restored_hosts = record.session.pane_hosts();
-        let restored_tabs = record.session.tabs.clone();
-        let tab_title = if record.session.title.is_empty() {
+        let restored = RestoredWorkspace {
+            background_panes: record.session.background_panes.clone(),
+            tabs: grids,
+            active_tab: active_index,
+            next_tab_number: record.session.next_grid_number(),
+            ..RestoredWorkspace::from_grid(&active)
+        };
+        let tab_title = if active.title.is_empty() {
             "Grid 1".into()
         } else {
-            record.session.title.clone()
+            active.title.clone()
         };
         let session_id = record.session.id.clone();
         let recorder = SessionRecorder::continue_record(record);
@@ -2651,10 +2750,7 @@ impl App {
             control_rx,
             settings,
             tab_title,
-            restored_histories,
-            restored_background_panes,
-            restored_hosts,
-            restored_tabs,
+            restored,
             session_recorder: Some(recorder),
             interrupted_recovery_claim: None,
             status,
@@ -2670,27 +2766,37 @@ impl App {
     ) -> Result<Self> {
         let InterruptedRecovery {
             mut tabs,
+            active_tab,
+            background_panes,
+            next_tab_number,
             session_count,
             pane_count,
             claim,
         } = recovery;
-        let active = if tabs.is_empty() {
+        if tabs.is_empty() {
             return Err(anyhow!("interrupted recovery has no tabs"));
-        } else {
-            tabs.remove(0)
-        };
+        }
+        // Recovery opens on the grid the crash interrupted, and every other grid
+        // keeps the position it had.
+        let active_tab = active_tab.min(tabs.len() - 1);
+        let active = tabs.remove(active_tab);
         let mut launch_plan = active.launch_plan()?;
         apply_auth_defaults(&mut launch_plan, &config)?;
         let grid = launch_plan.grid;
-        let restored_histories = active.pane_histories();
-        let restored_hosts = active.pane_hosts();
+        let restored = RestoredWorkspace {
+            background_panes,
+            tabs,
+            active_tab,
+            next_tab_number,
+            ..RestoredWorkspace::from_grid(&active)
+        };
         let settings = SettingsState::from_config(&config);
         let command_cwd = launch_plan
             .panes
             .first()
             .map(|pane| pane.cwd.clone())
             .unwrap_or(resolved_current_dir()?);
-        let tab_count = tabs.len() + 1;
+        let tab_count = restored.tabs.len() + 1;
         let (control_handle, control_rx) =
             start_agent_control(agent_control_enabled, agent_control_port)?;
         let agent_control_status = if control_handle.is_some() {
@@ -2711,10 +2817,7 @@ impl App {
             control_rx,
             settings,
             tab_title: active.title,
-            restored_histories,
-            restored_background_panes: Vec::new(),
-            restored_hosts,
-            restored_tabs: tabs,
+            restored,
             session_recorder: None,
             interrupted_recovery_claim: Some(claim),
             status: format!(
@@ -2732,7 +2835,8 @@ impl App {
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         let (goal_tx, goal_rx) = std_mpsc::channel();
         let background_jobs = init
-            .restored_background_panes
+            .restored
+            .background_panes
             .iter()
             .map(BackgroundJob::from_saved)
             .collect::<Vec<_>>();
@@ -2813,9 +2917,7 @@ impl App {
             auth_refresh_rx: None,
             pane_settings: PaneSettingsState::default(),
             status: init.status,
-            restored_histories: init.restored_histories,
-            restored_hosts: init.restored_hosts,
-            restored_tabs: init.restored_tabs,
+            restored: init.restored,
             session_recorder: init.session_recorder,
             interrupted_recovery_claim: init.interrupted_recovery_claim,
             output_logs: OutputLogs::default(),
@@ -2850,6 +2952,7 @@ impl App {
             last_activity_decay: Instant::now(),
             last_exit_poll: Instant::now(),
             last_session_autosave: Instant::now(),
+            last_agent_session_refresh: Instant::now(),
         })
     }
 
@@ -2934,9 +3037,8 @@ impl App {
         }
         self.layout = GridLayout::new(plan.grid);
         self.launch_plan = Some(plan);
-        self.restored_histories.clear();
-        self.restored_hosts.clear();
-        self.restored_tabs.clear();
+        // A freshly composed plan replaces whatever was being restored.
+        self.restored = RestoredWorkspace::default();
         Ok(())
     }
 
@@ -2951,10 +3053,10 @@ impl App {
         self.tab_rename.close();
         self.layout = GridLayout::new(plan.grid);
         self.panes.clear();
-        self.pane_names = vec![None; plan.panes.len()];
+        self.pane_names = restored_pane_names(&self.restored.pane_names, plan.panes.len());
         self.text_selection = None;
         self.copy_mode = None;
-        self.sleeping.clear();
+        self.sleeping = restored_pane_indexes(&self.restored.sleeping, plan.panes.len());
         self.manager_goal = None;
         self.next_pane_id = 0;
         self.pane_idle.clear();
@@ -2974,9 +3076,10 @@ impl App {
                 });
             }
         }
-        self.restored_histories.clear();
-        self.restored_hosts.clear();
-        for saved_tab in mem::take(&mut self.restored_tabs) {
+        self.apply_restored_view();
+        self.restored.histories.clear();
+        self.restored.hosts.clear();
+        for saved_tab in mem::take(&mut self.restored.tabs) {
             match self.restore_saved_tab(saved_tab) {
                 Ok(snapshot) => self.tabs.push(Some(snapshot)),
                 Err(error) => {
@@ -2990,11 +3093,29 @@ impl App {
                 }
             }
         }
+        self.restore_active_tab_position();
         self.restore_background_panes();
-        self.next_tab_number = self.tabs.len() + 1;
+        self.next_tab_number = self.restored.next_tab_number.max(self.tabs.len() + 1);
         self.start_usage_monitor(&plan);
 
         self.save_session_snapshot()
+    }
+
+    /// Put the grid that opens first back in the slot it held. Restored grids are
+    /// appended after it, so without this every resume moved the active grid to
+    /// the front of the tab strip.
+    fn restore_active_tab_position(&mut self) {
+        self.active_tab = move_active_slot(&mut self.tabs, self.restored.active_tab);
+    }
+
+    /// Restore how the opening grid was arranged: focus, zoom, and any dividers
+    /// the user dragged.
+    fn apply_restored_view(&mut self) {
+        let view = mem::take(&mut self.restored.view);
+        self.focus = view.focus.min(self.panes.len().saturating_sub(1));
+        self.zoomed = view.zoomed && !self.panes.is_empty();
+        self.layout
+            .restore_weights(&view.row_weights, &view.column_weights);
     }
 
     fn retire_owned_panes(&mut self) -> Result<()> {
@@ -3033,7 +3154,8 @@ impl App {
                 &job.history.input_history,
                 self.event_tx.clone(),
             ) {
-                Ok(pane) => {
+                Ok(mut pane) => {
+                    pane.set_agent_session_id(claude_session_in_command(&job.spec.command));
                     job.pane = Some(pane);
                     job.host = None;
                 }
@@ -3096,21 +3218,27 @@ impl App {
             .map(|pane| pane.cwd.clone())
             .unwrap_or_default();
         let grid_id = self.allocate_grid_id();
+        let mut layout = GridLayout::new(grid);
+        layout.restore_weights(&saved.view.row_weights, &saved.view.column_weights);
+        let pane_names = restored_pane_names(&saved.pane_names(), pane_count);
+        let sleeping = restored_pane_indexes(&saved.sleeping_panes(), pane_count);
+        let focus = saved.focus();
+        let zoomed = saved.view.zoomed && pane_count > 0;
         Ok(GridTabSnapshot {
             grid_id,
             title: saved.title,
             launch_plan: Some(plan),
-            layout: GridLayout::new(grid),
-            zoomed: false,
+            layout,
+            zoomed,
             panes,
             pane_idle: (0..pane_count)
                 .map(|_| PaneIdleState::new(Instant::now()))
                 .collect(),
-            focus: 0,
+            focus,
             selected: BTreeSet::new(),
-            pane_names: vec![None; pane_count],
+            pane_names,
             text_selection: None,
-            sleeping: BTreeSet::new(),
+            sleeping,
             manager_goal: None,
             assistant: WorkspaceAssistantState::default(),
             command_line: CommandLineState::new(command_cwd),
@@ -3207,8 +3335,10 @@ impl App {
         self.assistant = WorkspaceAssistantState::default();
         self.rects.clear();
         self.follow_up = None;
-        self.restored_histories.clear();
-        self.restored_hosts.clear();
+        self.restored.histories.clear();
+        self.restored.hosts.clear();
+        self.restored.pane_names.clear();
+        self.restored.sleeping.clear();
         self.command_line = CommandLineState::new(
             plan.panes
                 .first()
@@ -3235,7 +3365,9 @@ impl App {
             .and_then(normalized_tab_title)
             .unwrap_or(fallback);
         self.close_tab_modals();
-        self.activate_plan_as_tab(title, plan)
+        self.activate_plan_as_tab(title, plan)?;
+        self.save_session_structure();
+        Ok(())
     }
 
     fn start_usage_monitor(&mut self, plan: &LaunchPlan) {
@@ -3257,11 +3389,12 @@ impl App {
 
     fn spawn_pane_spec(&mut self, index: usize, spec: &PaneLaunchSpec) -> Result<()> {
         let history = self
-            .restored_histories
+            .restored
+            .histories
             .get(index)
             .cloned()
             .unwrap_or_default();
-        let host = self.restored_hosts.get(index).cloned().flatten();
+        let host = self.restored.hosts.get(index).cloned().flatten();
         let pane = self.create_pane(spec, index, &history, host)?;
         self.panes.push(pane);
         self.pane_idle.push(PaneIdleState::new(Instant::now()));
@@ -3289,7 +3422,13 @@ impl App {
                 &history.input_history,
                 self.event_tx.clone(),
             ) {
-                Ok(pane) => return Ok(pane),
+                Ok(mut pane) => {
+                    // The terminal kept running, so it is still in the
+                    // conversation its command named. Carry that forward instead
+                    // of pinning a new one.
+                    pane.set_agent_session_id(claude_session_in_command(&spec.command));
+                    return Ok(pane);
+                }
                 Err(error) => {
                     if error.is::<PaneHostBusy>() {
                         return Err(error).with_context(|| {
@@ -3333,11 +3472,17 @@ impl App {
         spec: &PaneLaunchSpec,
         pane_index: Option<usize>,
     ) -> Result<PtyPane> {
+        // Claude keeps nothing that ties a transcript back to a pane, so the
+        // conversation id is chosen here and passed in. The pane then carries it,
+        // and snapshots can name the conversation instead of guessing which of
+        // several Claude panes in a folder wrote which transcript.
+        let mut spec = spec.clone();
+        let claude_session_id = pin_claude_session(&mut spec.command);
         let launch = spec.resolved_command()?;
         let id = PaneId(self.next_pane_id);
         self.next_pane_id += 1;
         let extra_env = self.pane_env(pane_index, id);
-        PtyPane::spawn(
+        let mut pane = PtyPane::spawn(
             &spec.profile_name,
             id,
             0,
@@ -3351,7 +3496,9 @@ impl App {
             self.config.defaults.pane_workload,
             self.config.ui.keep_terminals_running,
             self.event_tx.clone(),
-        )
+        )?;
+        pane.set_agent_session_id(claude_session_id);
+        Ok(pane)
     }
 
     fn pane_env(&self, pane_index: Option<usize>, pane_id: PaneId) -> Vec<(OsString, OsString)> {
@@ -6523,6 +6670,7 @@ impl App {
         } else {
             "restored grid layout".into()
         };
+        self.save_session_structure();
     }
 
     fn handle_grid_resizer_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -6725,6 +6873,7 @@ impl App {
             self.status = format!("active tab {}", self.tab_title);
         }
         self.sync_pane_sizes_for_current_layout();
+        self.save_session_structure();
     }
 
     fn begin_tab_rename(&mut self) {
@@ -6800,6 +6949,7 @@ impl App {
                 self.tab_title = name.clone();
                 self.tab_rename.close();
                 self.status = format!("renamed tab to {name}");
+                self.save_session_structure();
             }
             None => {
                 self.status = "tab name cannot be empty".into();
@@ -7852,6 +8002,7 @@ impl App {
         }
 
         self.rename.close();
+        self.save_session_structure();
     }
 
     fn swap_selected_tiles(&mut self) {
@@ -7897,6 +8048,9 @@ impl App {
         swap_set_indices(&mut self.sleeping, first, second);
         self.focus = swapped_index(self.focus, first, second);
         self.status = format!("swapped panes {} and {}", first + 1, second + 1);
+        // Pane positions are the first thing a resume is judged on, so the new
+        // arrangement is written before anything else can interrupt.
+        self.save_session_structure();
     }
 
     fn swap_selected_grids(&mut self) {
@@ -7933,6 +8087,7 @@ impl App {
         self.restore_tab_snapshot(snapshot);
         self.sync_pane_sizes_for_current_layout();
         self.status = format!("swapped grids {} and {}", first + 1, second + 1);
+        self.save_session_structure();
     }
 
     #[allow(dead_code)]
@@ -8911,6 +9066,9 @@ impl App {
             self.status
                 .push_str(&format!("; pane cleanup reported: {error:#}"));
         }
+        // The new dimensions are what a resume rebuilds the grid from, so they go
+        // to disk with the resize rather than at the next autosave.
+        self.save_session_structure();
 
         Ok(())
     }
@@ -9002,6 +9160,7 @@ impl App {
                 next.columns
             )
         };
+        self.save_session_structure();
     }
 
     fn toggle_sleep_for_targets(&mut self) {
@@ -9042,6 +9201,7 @@ impl App {
 
         let action = if should_sleep { "slept" } else { "woke" };
         self.status = format!("{} {} {}", action, targets.len(), pane_word(targets.len()));
+        self.save_session_structure();
     }
 
     fn handle_todo_edit_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
@@ -10833,20 +10993,86 @@ impl App {
             .map(SessionRecorder::resume_command)
     }
 
+    /// Follow panes onto conversations they started after launching.
+    ///
+    /// Clearing a conversation inside a pane begins a new one in the same
+    /// terminal. The snapshot has to name what each pane is talking to now, not
+    /// what it opened with, or resuming reopens the abandoned conversation.
+    fn refresh_agent_sessions(&mut self) {
+        if self.last_agent_session_refresh.elapsed() < AGENT_SESSION_REFRESH_INTERVAL {
+            return;
+        }
+        self.last_agent_session_refresh = Instant::now();
+
+        // Conversations already spoken for, so two panes in one folder cannot end
+        // up following the same one.
+        let mut followed = self
+            .panes
+            .iter()
+            .chain(
+                self.tabs
+                    .iter()
+                    .filter_map(Option::as_ref)
+                    .flat_map(|tab| tab.panes.iter()),
+            )
+            .chain(
+                self.background_jobs
+                    .iter()
+                    .filter_map(|job| job.pane.as_ref()),
+            )
+            .filter_map(|pane| pane.agent_session_id().map(str::to_string))
+            .collect::<BTreeSet<_>>();
+
+        for pane in self.panes.iter_mut() {
+            follow_agent_session(pane, &mut followed);
+        }
+        for tab in self.tabs.iter_mut().filter_map(Option::as_mut) {
+            for pane in tab.panes.iter_mut() {
+                follow_agent_session(pane, &mut followed);
+            }
+        }
+        for job in self.background_jobs.iter_mut() {
+            if let Some(pane) = job.pane.as_mut() {
+                follow_agent_session(pane, &mut followed);
+            }
+        }
+    }
+
     fn save_session_snapshot(&mut self) -> Result<()> {
+        self.refresh_agent_sessions();
         let Some(plan) = self.launch_plan.clone() else {
             return Ok(());
         };
-        let tabs = self
-            .tabs
-            .iter()
-            .filter_map(Option::as_ref)
-            .filter_map(|tab| {
-                tab.launch_plan
-                    .as_ref()
-                    .map(|plan| SavedTab::from_live(&tab.title, plan, &tab.panes))
-            })
-            .collect();
+        let mut tabs = Vec::new();
+        // Counted rather than taken from `active_tab` directly: grids that hold
+        // no live state are skipped here, and the active grid has to land back
+        // among the ones that are written.
+        let mut active_tab = 0;
+        for (index, tab) in self.tabs.iter().enumerate() {
+            if index == self.active_tab {
+                active_tab = tabs.len();
+                continue;
+            }
+            let Some(tab) = tab.as_ref() else {
+                continue;
+            };
+            let Some(plan) = tab.launch_plan.as_ref() else {
+                continue;
+            };
+            tabs.push(SavedTab::from_live(&LiveGrid {
+                title: &tab.title,
+                plan,
+                panes: &tab.panes,
+                pane_names: &tab.pane_names,
+                sleeping: &tab.sleeping,
+                view: SavedView {
+                    focus: tab.focus,
+                    zoomed: tab.zoomed,
+                    row_weights: tab.layout.row_weights().to_vec(),
+                    column_weights: tab.layout.column_weights().to_vec(),
+                },
+            }));
+        }
         let Some(recorder) = self.session_recorder.as_mut() else {
             return Ok(());
         };
@@ -10856,7 +11082,25 @@ impl App {
             .iter()
             .map(BackgroundJob::saved)
             .collect();
-        recorder.update(&self.tab_title, &plan, &self.panes, tabs, background_panes);
+        recorder.update(LiveWorkspace {
+            active: LiveGrid {
+                title: &self.tab_title,
+                plan: &plan,
+                panes: &self.panes,
+                pane_names: &self.pane_names,
+                sleeping: &self.sleeping,
+                view: SavedView {
+                    focus: self.focus,
+                    zoomed: self.zoomed,
+                    row_weights: self.layout.row_weights().to_vec(),
+                    column_weights: self.layout.column_weights().to_vec(),
+                },
+            },
+            tabs,
+            background_panes,
+            active_tab,
+            next_tab_number: self.next_tab_number,
+        });
         recorder.save()
     }
 
@@ -10872,12 +11116,48 @@ impl App {
         false
     }
 
+    /// Persist a change to the workspace's shape right away.
+    ///
+    /// Autosave alone means a crash in the seconds after renaming a grid or
+    /// moving a pane loses that edit, and those are exactly the changes a resume
+    /// is judged on. Unchanged snapshots are skipped by the recorder, so calling
+    /// this freely is cheap.
+    fn save_session_structure(&mut self) {
+        self.last_session_autosave = Instant::now();
+        if let Err(error) = self.save_session_snapshot() {
+            self.status = format!("session save failed: {error:#}");
+        }
+    }
+
     fn finish_session(&mut self) -> Result<()> {
         self.save_session_snapshot()?;
         if let Some(recorder) = self.session_recorder.as_mut() {
             recorder.finish()?;
         }
         Ok(())
+    }
+
+    /// Whether the live workspace still describes itself consistently.
+    ///
+    /// Moving a grid or closing one briefly separates the panes from the plan
+    /// that lists them. A snapshot taken in that window would look like a
+    /// workspace whose panes had all vanished.
+    fn workspace_is_coherent(&self) -> bool {
+        self.launch_plan
+            .as_ref()
+            .is_some_and(|plan| plan.panes.len() == self.panes.len())
+    }
+}
+
+impl Drop for App {
+    fn drop(&mut self) {
+        // Last line of defence. The event loop catches its own panics and both
+        // exit paths save, but a panic raised outside that firewall would
+        // otherwise take the workspace with it. Unchanged snapshots are skipped,
+        // so a clean exit pays nothing here.
+        if self.session_recorder.is_some() && self.workspace_is_coherent() {
+            let _ = self.save_session_snapshot();
+        }
     }
 }
 
@@ -13136,6 +13416,58 @@ mod tests {
 
     fn selected(indices: &[usize]) -> BTreeSet<usize> {
         indices.iter().copied().collect()
+    }
+
+    /// The grid that was open goes back to the slot it held, instead of being
+    /// pulled to the front of the tab strip on every resume.
+    #[test]
+    fn the_active_grid_returns_to_its_own_slot() {
+        let mut slots = vec![None, Some("first"), Some("second")];
+
+        assert_eq!(move_active_slot(&mut slots, 1), 1);
+        assert_eq!(slots, [Some("first"), None, Some("second")]);
+
+        // A workspace that was on its first grid is already in place.
+        let mut front = vec![None, Some("first")];
+        assert_eq!(move_active_slot(&mut front, 0), 0);
+        assert_eq!(front, [None, Some("first")]);
+
+        // A snapshot naming a slot that no longer exists lands on the last one.
+        let mut short = vec![None, Some("first")];
+        assert_eq!(move_active_slot(&mut short, 9), 1);
+        assert_eq!(short, [Some("first"), None]);
+    }
+
+    /// Pane names come back on the panes they belonged to, and a snapshot that
+    /// disagrees with its pane count cannot shift them onto the wrong ones.
+    #[test]
+    fn restored_pane_names_line_up_with_their_panes() {
+        let saved = vec![Some("planner".to_string()), None, Some("  ".to_string())];
+
+        assert_eq!(
+            restored_pane_names(&saved, 3),
+            [Some("planner".into()), None, None]
+        );
+        // Fewer panes than names: the extras are dropped rather than shifted.
+        assert_eq!(
+            restored_pane_names(&saved, 2),
+            [Some("planner".into()), None]
+        );
+        // More panes than names: the rest are simply unnamed.
+        assert_eq!(
+            restored_pane_names(&saved, 4),
+            [Some("planner".into()), None, None, None]
+        );
+    }
+
+    /// Sleeping panes outside the restored grid are dropped, so a smaller grid
+    /// cannot come back with a pane marked asleep that does not exist.
+    #[test]
+    fn restored_sleeping_panes_stay_inside_the_grid() {
+        let saved = selected(&[0, 2, 7]);
+
+        assert_eq!(restored_pane_indexes(&saved, 3), selected(&[0, 2]));
+        assert_eq!(restored_pane_indexes(&saved, 8), selected(&[0, 2, 7]));
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -97,6 +97,32 @@ impl GridLayout {
         resize_weights(&mut self.column_weights, size.columns.min(MAX_PANES));
     }
 
+    pub fn row_weights(&self) -> &[u16] {
+        &self.row_weights
+    }
+
+    pub fn column_weights(&self) -> &[u16] {
+        &self.column_weights
+    }
+
+    /// Put dragged dividers back where they were.
+    ///
+    /// Saved weights are only applied when they describe the grid being
+    /// restored; a mismatched count means the snapshot and the grid disagree, and
+    /// even spacing is the safe reading.
+    pub fn restore_weights(&mut self, row_weights: &[u16], column_weights: &[u16]) {
+        if row_weights.len() == self.row_weights.len()
+            && row_weights.iter().all(|weight| *weight > 0)
+        {
+            self.row_weights.copy_from_slice(row_weights);
+        }
+        if column_weights.len() == self.column_weights.len()
+            && column_weights.iter().all(|weight| *weight > 0)
+        {
+            self.column_weights.copy_from_slice(column_weights);
+        }
+    }
+
     pub fn rects(&self, area: Rect, count: usize) -> Vec<Rect> {
         weighted_grid_rects(
             area,
@@ -396,6 +422,27 @@ mod tests {
                 columns: 1,
             }
         );
+    }
+
+    /// Dragged dividers are part of how a workspace looked, so a resume puts
+    /// them back. Weights that do not describe the restored grid are ignored.
+    #[test]
+    fn restoring_weights_reproduces_dragged_dividers() {
+        let mut layout = GridLayout::new(GridSize {
+            rows: 1,
+            columns: 2,
+        });
+
+        layout.restore_weights(&[1000], &[1400, 600]);
+        assert_eq!(layout.column_weights(), [1400, 600]);
+        let rects = layout.rects(Rect::new(0, 0, 100, 10), 2);
+        assert!(rects[0].width > rects[1].width);
+
+        // A snapshot that disagrees with the grid leaves the even spacing alone.
+        layout.restore_weights(&[1000], &[500, 500, 500]);
+        assert_eq!(layout.column_weights(), [1400, 600]);
+        layout.restore_weights(&[1000], &[0, 0]);
+        assert_eq!(layout.column_weights(), [1400, 600]);
     }
 
     #[test]

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -480,8 +480,16 @@ mod tests {
             6,
         );
 
-        assert_eq!(rects[1].x, rects[0].right() - 1, "columns must overlap by 1");
-        assert_eq!(rects[2].x, rects[1].right() - 1, "columns must overlap by 1");
+        assert_eq!(
+            rects[1].x,
+            rects[0].right() - 1,
+            "columns must overlap by 1"
+        );
+        assert_eq!(
+            rects[2].x,
+            rects[1].right() - 1,
+            "columns must overlap by 1"
+        );
         assert_eq!(rects[3].y, rects[0].bottom() - 1, "rows must overlap by 1");
     }
 

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -217,6 +217,10 @@ pub struct PtyPane {
     host_process_id: Option<u32>,
     view: PtyView,
     keep_running: bool,
+    /// Conversation this pane's agent is talking to, when GridBash knows it
+    /// exactly. Codex is discovered from its state DB after the fact; Claude is
+    /// pinned at launch, so the snapshot can name it without guessing.
+    agent_session_id: Option<String>,
     pub active: bool,
     pub exited: bool,
 }
@@ -476,6 +480,7 @@ impl PtyPane {
             host_process_id,
             view,
             keep_running,
+            agent_session_id: None,
             active: !background_output.is_empty(),
             exited,
         })
@@ -495,6 +500,23 @@ impl PtyPane {
 
     pub fn host_process_id(&self) -> Option<u32> {
         self.host_process_id
+    }
+
+    /// When this terminal started, used to tell the agent state it created apart
+    /// from whatever was already on disk.
+    pub fn started_at_ms(&self) -> Option<u64> {
+        self.host.started_at_ms
+    }
+
+    /// Conversation id GridBash pinned when this pane launched. Snapshots trust
+    /// this over any search of the agent's own state, because it cannot be
+    /// confused by a sibling pane working in the same directory.
+    pub fn agent_session_id(&self) -> Option<&str> {
+        self.agent_session_id.as_deref()
+    }
+
+    pub fn set_agent_session_id(&mut self, session_id: Option<String>) {
+        self.agent_session_id = session_id.filter(|value| !value.trim().is_empty());
     }
 
     pub fn codex_thread_id(&self, cwd: &Path) -> Option<String> {

--- a/src/resume_picker.rs
+++ b/src/resume_picker.rs
@@ -20,7 +20,7 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use crate::session::{SessionRecord, delete_saved_session, process_is_running};
+use crate::session::{SavedTab, SessionRecord, delete_saved_session, process_is_running};
 
 type ResumeTerminal = Terminal<CrosstermBackend<Stdout>>;
 
@@ -33,6 +33,9 @@ const MUTED: Color = Color::Rgb(72, 128, 88);
 const DIM_GREEN: Color = Color::Rgb(50, 176, 92);
 const TERMINAL_GREEN: Color = Color::Rgb(91, 255, 139);
 const SOFT_GREEN: Color = Color::Rgb(159, 255, 183);
+
+/// Marks a pane whose agent conversation comes back with it.
+const RESUMABLE_MARK: &str = "*";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionState {
@@ -54,7 +57,7 @@ impl SessionState {
             return Self::Interrupted;
         }
 
-        if all_panes(record).any(|pane| pane.host.is_some()) {
+        if session.all_panes().any(|pane| pane.host.is_some()) {
             Self::Detached
         } else {
             Self::Saved
@@ -85,10 +88,14 @@ impl SessionState {
                 format!("Already attached to a live GridBash client (PID {owner_pid}).")
             }
             Self::Interrupted => {
-                "The previous client stopped. GridBash will recover this workspace.".into()
+                "The previous client stopped. Every grid comes back as it was.".into()
             }
-            Self::Detached => "Saved pane hosts are ready to reconnect.".into(),
-            Self::Saved => "Recreates terminals from the saved layout and history.".into(),
+            Self::Detached => "Terminals are still running and will reconnect.".into(),
+            Self::Saved => {
+                "Rebuilds each grid at its saved size, with its panes, names, and agent \
+                 conversations."
+                    .into()
+            }
         }
     }
 }
@@ -101,9 +108,148 @@ enum PickerAction {
     Cancel,
 }
 
+/// One pane as the picker draws it: where it sat, what it was called, and
+/// whether its agent conversation comes back.
+#[derive(Debug, Clone)]
+struct PaneCell {
+    label: String,
+    resumable: bool,
+}
+
+/// A saved grid, laid out the way it will be restored.
+#[derive(Debug, Clone)]
+struct GridPreview {
+    title: String,
+    rows: usize,
+    columns: usize,
+    pane_count: usize,
+    /// One entry per cell, row by row. `None` is a cell the grid kept empty.
+    cells: Vec<Option<PaneCell>>,
+    active: bool,
+}
+
+impl GridPreview {
+    fn dimensions(&self) -> String {
+        format!("{}x{}", self.rows, self.columns)
+    }
+}
+
+/// A saved workspace with the parts that cost real work to compute already
+/// resolved, so redrawing never touches the filesystem again.
+struct SessionEntry {
+    record: SessionRecord,
+    title: String,
+    grids: Vec<GridPreview>,
+    pane_count: usize,
+    resumable_count: usize,
+    background_count: usize,
+    folders: Option<String>,
+    profiles: Option<String>,
+}
+
+impl SessionEntry {
+    fn new(record: SessionRecord) -> Self {
+        let (grids, active) = record.session.ordered_grids();
+        let grids = grids
+            .iter()
+            .enumerate()
+            .map(|(index, grid)| grid_preview(grid, index == active))
+            .collect::<Vec<_>>();
+        let pane_count = record.session.all_panes().count();
+        let resumable_count = record
+            .session
+            .all_panes()
+            .filter(|pane| pane.resumable_conversation().is_some())
+            .count();
+        let folders = compact_labels(
+            record
+                .session
+                .all_panes()
+                .map(|pane| pane.folder_name.as_str()),
+        );
+        let profiles = compact_labels(
+            record
+                .session
+                .all_panes()
+                .map(|pane| pane.profile_name.as_str()),
+        );
+
+        Self {
+            title: session_title(&record),
+            grids,
+            pane_count,
+            resumable_count,
+            background_count: record.session.background_panes.len(),
+            folders,
+            profiles,
+            record,
+        }
+    }
+
+    fn state(&self) -> SessionState {
+        SessionState::for_record(&self.record)
+    }
+
+    /// One line naming every grid with the size it will be rebuilt at.
+    fn grid_summary(&self) -> String {
+        let shown = self
+            .grids
+            .iter()
+            .take(4)
+            .map(|grid| format!("{} {}", grid.title, grid.dimensions()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let extra = self.grids.len().saturating_sub(4);
+        if extra > 0 {
+            format!("{shown} +{extra}")
+        } else {
+            shown
+        }
+    }
+}
+
+/// Lay a saved grid out cell by cell so the picker can show that every pane
+/// comes back in the position it held.
+fn grid_preview(grid: &SavedTab, active: bool) -> GridPreview {
+    let rows = grid.grid.rows.max(1);
+    let columns = grid.grid.columns.max(1);
+    let mut cells = vec![None; rows.saturating_mul(columns)];
+    let mut panes = grid.panes.iter().collect::<Vec<_>>();
+    panes.sort_by_key(|pane| pane.index);
+    for (position, pane) in panes.iter().enumerate() {
+        let Some(cell) = cells.get_mut(position) else {
+            break;
+        };
+        *cell = Some(PaneCell {
+            label: pane
+                .name
+                .clone()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| pane.profile_name.clone()),
+            resumable: pane.resumable_conversation().is_some(),
+        });
+    }
+
+    GridPreview {
+        title: if grid.title.trim().is_empty() {
+            "Untitled grid".into()
+        } else {
+            grid.title.clone()
+        },
+        rows,
+        columns,
+        pane_count: grid.panes.len(),
+        cells,
+        active,
+    }
+}
+
 struct ResumePicker {
-    sessions: Vec<SessionRecord>,
+    sessions: Vec<SessionEntry>,
     list_state: ListState,
+    /// Grid of the selected workspace shown in the map, so every saved grid can
+    /// be inspected before resuming.
+    grid_cursor: usize,
     page_size: usize,
     notice: Option<String>,
     pending_delete: Option<String>,
@@ -133,9 +279,16 @@ impl ResumePicker {
     fn new(sessions: &[SessionRecord]) -> Self {
         let mut list_state = ListState::default();
         list_state.select((!sessions.is_empty()).then_some(0));
+        let sessions = sessions
+            .iter()
+            .cloned()
+            .map(SessionEntry::new)
+            .collect::<Vec<_>>();
+        let grid_cursor = sessions.first().map(active_grid_index).unwrap_or(0);
         Self {
-            sessions: sessions.to_vec(),
+            sessions,
             list_state,
+            grid_cursor,
             page_size: 1,
             notice: None,
             pending_delete: None,
@@ -159,18 +312,19 @@ impl ResumePicker {
             match self.handle_key(key) {
                 PickerAction::Continue => {}
                 PickerAction::Cancel => return Ok(None),
-                PickerAction::Select(index) => return Ok(Some(self.sessions[index].clone())),
+                PickerAction::Select(index) => {
+                    return Ok(Some(self.sessions[index].record.clone()));
+                }
                 PickerAction::Delete(index) => {
-                    let title = session_title(&self.sessions[index]);
-                    match delete_saved_session(&self.sessions[index]) {
+                    let title = self.sessions[index].title.clone();
+                    match delete_saved_session(&self.sessions[index].record) {
                         Ok(()) => {
                             self.sessions.remove(index);
                             self.pending_delete = None;
                             if self.sessions.is_empty() {
                                 return Ok(None);
                             }
-                            self.list_state
-                                .select(Some(index.min(self.sessions.len().saturating_sub(1))));
+                            self.select(index.min(self.sessions.len().saturating_sub(1)));
                             self.notice = Some(format!("Deleted saved session {title}."));
                         }
                         Err(error) => {
@@ -204,6 +358,14 @@ impl ResumePicker {
                 self.select((selected + 1).min(self.sessions.len().saturating_sub(1)));
                 PickerAction::Continue
             }
+            KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => {
+                self.cycle_grid(1);
+                PickerAction::Continue
+            }
+            KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => {
+                self.cycle_grid(-1);
+                PickerAction::Continue
+            }
             KeyCode::Home => {
                 self.select(0);
                 PickerAction::Continue
@@ -222,9 +384,7 @@ impl ResumePicker {
             }
             KeyCode::Delete => self.request_delete(selected),
             KeyCode::Enter => {
-                if let SessionState::Open(owner_pid) =
-                    SessionState::for_record(&self.sessions[selected])
-                {
+                if let SessionState::Open(owner_pid) = self.sessions[selected].state() {
                     self.notice = Some(format!(
                         "Session is already open in PID {owner_pid}. Switch to that GridBash window or close it before resuming."
                     ));
@@ -239,13 +399,35 @@ impl ResumePicker {
 
     fn select(&mut self, index: usize) {
         self.list_state.select(Some(index));
+        self.grid_cursor = self.sessions.get(index).map(active_grid_index).unwrap_or(0);
         self.notice = None;
         self.pending_delete = None;
     }
 
+    /// Step through the selected workspace's grids, wrapping at both ends.
+    fn cycle_grid(&mut self, delta: isize) {
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        let count = entry.grids.len();
+        if count <= 1 {
+            return;
+        }
+
+        let current = self.grid_cursor.min(count - 1) as isize;
+        self.grid_cursor = (current + delta).rem_euclid(count as isize) as usize;
+        self.notice = None;
+    }
+
+    fn selected_entry(&self) -> Option<&SessionEntry> {
+        self.list_state
+            .selected()
+            .and_then(|index| self.sessions.get(index))
+    }
+
     fn request_delete(&mut self, selected: usize) -> PickerAction {
-        let record = &self.sessions[selected];
-        if let SessionState::Open(owner_pid) = SessionState::for_record(record) {
+        let entry = &self.sessions[selected];
+        if let SessionState::Open(owner_pid) = entry.state() {
             self.pending_delete = None;
             self.notice = Some(format!(
                 "Session is open in PID {owner_pid}. Close that GridBash window before deleting it."
@@ -253,12 +435,16 @@ impl ResumePicker {
             return PickerAction::Continue;
         }
 
-        if self.pending_delete.as_deref() == Some(record.session.id.as_str()) {
+        if self.pending_delete.as_deref() == Some(entry.record.session.id.as_str()) {
             return PickerAction::Delete(selected);
         }
 
-        self.pending_delete = Some(record.session.id.clone());
-        let detached = all_panes(record).any(|pane| pane.host.is_some());
+        self.pending_delete = Some(entry.record.session.id.clone());
+        let detached = entry
+            .record
+            .session
+            .all_panes()
+            .any(|pane| pane.host.is_some());
         self.notice = Some(if detached {
             "Press Delete again to stop detached terminals and permanently delete this session."
                 .into()
@@ -302,10 +488,10 @@ impl ResumePicker {
             return;
         }
 
-        let (header_height, detail_height, controls_height) = if inner.height >= 22 {
-            (3, 9, 3)
+        let (header_height, detail_height, controls_height) = if inner.height >= 24 {
+            (3, 11, 3)
         } else {
-            (2, 7, 2)
+            (2, 9, 2)
         };
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -317,7 +503,7 @@ impl ResumePicker {
             ])
             .split(inner);
         self.draw_header(frame, chunks[0]);
-        self.draw_details(frame, chunks[1]);
+        self.draw_selected(frame, chunks[1]);
         self.draw_sessions(frame, chunks[2]);
         self.draw_controls(frame, chunks[3]);
     }
@@ -325,10 +511,8 @@ impl ResumePicker {
     fn draw_header(&self, frame: &mut Frame<'_>, area: Rect) {
         let selected = self.list_state.selected().unwrap_or(0) + 1;
         let selected_state = self
-            .list_state
-            .selected()
-            .and_then(|index| self.sessions.get(index))
-            .map(SessionState::for_record)
+            .selected_entry()
+            .map(SessionEntry::state)
             .unwrap_or(SessionState::Saved);
         let right_width = area.width.min(24);
         let columns = Layout::default()
@@ -342,7 +526,7 @@ impl ResumePicker {
                     Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
                 )),
                 Line::from(Span::styled(
-                    "Saved terminals, layout, and working context.",
+                    "Grid sizes, pane positions, names, and agent conversations are restored.",
                     Style::default().fg(MUTED),
                 )),
             ])
@@ -366,37 +550,39 @@ impl ResumePicker {
         }
     }
 
+    /// Details on the left, the selected grid drawn in position on the right.
+    fn draw_selected(&self, frame: &mut Frame<'_>, area: Rect) {
+        let map_width = if area.width >= 96 {
+            area.width / 2
+        } else if area.width >= 70 {
+            area.width * 2 / 5
+        } else {
+            0
+        };
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(30), Constraint::Length(map_width)])
+            .split(area);
+        self.draw_details(frame, columns[0]);
+        if map_width > 0 {
+            self.draw_grid_map(frame, columns[1]);
+        }
+    }
+
     fn draw_details(&self, frame: &mut Frame<'_>, area: Rect) {
-        let block = panel_block("SELECTED SESSION");
+        let block = panel_block("SELECTED WORKSPACE");
         let inner = inset(block.inner(area), 1, 0);
         frame.render_widget(block, area);
-        let Some(record) = self
-            .list_state
-            .selected()
-            .and_then(|index| self.sessions.get(index))
-        else {
+        let Some(entry) = self.selected_entry() else {
             return;
         };
 
-        let state = SessionState::for_record(record);
-        let session = &record.session;
-        let panes = all_panes(record).count();
-        let tabs = session.tabs.len() + 1;
-        let folders = compact_labels(all_panes(record).map(|pane| pane.folder_name.as_str()));
-        let profiles = compact_labels(all_panes(record).map(|pane| pane.profile_name.as_str()));
-        let host_count = all_panes(record).filter(|pane| pane.host.is_some()).count();
-        let resume_mode = if host_count > 0 {
-            format!(
-                "reconnect {host_count} PTY host{}",
-                if host_count == 1 { "" } else { "s" }
-            )
-        } else {
-            "recreate from snapshot".into()
-        };
-        let lines = vec![
+        let state = entry.state();
+        let grid_count = entry.grids.len();
+        let mut lines = vec![
             Line::from(vec![
                 Span::styled(
-                    session_title(record),
+                    entry.title.clone(),
                     Style::default()
                         .fg(TERMINAL_GREEN)
                         .add_modifier(Modifier::BOLD),
@@ -408,20 +594,46 @@ impl ResumePicker {
                 state.description(),
                 Style::default().fg(MUTED),
             )),
-            detail_row("SESSION ID", session.id.clone()),
+            detail_row("SESSION", entry.record.session.id.clone()),
             detail_row(
-                "WORKSPACE",
+                "GRIDS",
                 format!(
-                    "{}x{} | {panes} pane{} | {tabs} tab{} | {resume_mode}",
-                    session.grid.rows,
-                    session.grid.columns,
-                    if panes == 1 { "" } else { "s" },
-                    if tabs == 1 { "" } else { "s" },
+                    "{grid_count} | {}",
+                    if entry.grids.is_empty() {
+                        "none recorded".into()
+                    } else {
+                        entry.grid_summary()
+                    }
                 ),
             ),
-            detail_row("FOLDERS", folders.unwrap_or_else(|| "Unknown".into())),
-            detail_row("PROFILES", profiles.unwrap_or_else(|| "Unknown".into())),
+            detail_row(
+                "PANES",
+                format!(
+                    "{} | {} agent conversation{} resume",
+                    entry.pane_count,
+                    entry.resumable_count,
+                    if entry.resumable_count == 1 { "" } else { "s" },
+                ),
+            ),
+            detail_row(
+                "FOLDERS",
+                entry.folders.clone().unwrap_or_else(|| "Unknown".into()),
+            ),
+            detail_row(
+                "PROFILES",
+                entry.profiles.clone().unwrap_or_else(|| "Unknown".into()),
+            ),
         ];
+        if entry.background_count > 0 {
+            lines.push(detail_row(
+                "BACKGROUND",
+                format!(
+                    "{} pane{} kept out of the grids",
+                    entry.background_count,
+                    if entry.background_count == 1 { "" } else { "s" },
+                ),
+            ));
+        }
         frame.render_widget(
             Paragraph::new(lines)
                 .wrap(Wrap { trim: true })
@@ -430,8 +642,63 @@ impl ResumePicker {
         );
     }
 
+    /// Draw the selected grid as a map, one row of cells per grid row, so the
+    /// user can see the arrangement that will come back.
+    fn draw_grid_map(&self, frame: &mut Frame<'_>, area: Rect) {
+        let Some(entry) = self.selected_entry() else {
+            frame.render_widget(panel_block("GRID"), area);
+            return;
+        };
+        let index = self.grid_cursor.min(entry.grids.len().saturating_sub(1));
+        let Some(grid) = entry.grids.get(index) else {
+            frame.render_widget(panel_block("GRID"), area);
+            return;
+        };
+
+        let heading = format!(
+            " {} · {} · {} pane{} ",
+            grid.title,
+            grid.dimensions(),
+            grid.pane_count,
+            if grid.pane_count == 1 { "" } else { "s" },
+        );
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .title(Line::from(Span::styled(
+                heading,
+                Style::default()
+                    .fg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .border_style(Style::default().fg(HAIRLINE))
+            .style(Style::default().bg(RAISED_BG));
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let mut lines = grid_map_lines(grid, inner.width);
+        if entry.grids.len() > 1 {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "grid {} of {}{}",
+                    index + 1,
+                    entry.grids.len(),
+                    if grid.active { " · opens here" } else { "" }
+                ),
+                Style::default().fg(MUTED),
+            )));
+        }
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
+            inner,
+        );
+    }
+
     fn draw_sessions(&mut self, frame: &mut Frame<'_>, area: Rect) {
-        let block = panel_block("RECENT SESSIONS");
+        let block = panel_block("RECENT WORKSPACES");
         let inner = block.inner(area);
         frame.render_widget(block, area);
         self.page_size = usize::from((inner.height / 2).max(1));
@@ -439,20 +706,19 @@ impl ResumePicker {
         let items = self
             .sessions
             .iter()
-            .map(|record| {
-                let state = SessionState::for_record(record);
+            .map(|entry| {
                 ListItem::new(vec![
                     Line::from(vec![
-                        state_badge(state),
+                        state_badge(entry.state()),
                         Span::raw(" "),
                         Span::styled(
-                            session_title(record),
+                            entry.title.clone(),
                             Style::default().fg(SOFT_GREEN).add_modifier(Modifier::BOLD),
                         ),
                     ]),
                     Line::from(vec![
                         Span::styled("           ", Style::default().fg(MUTED)),
-                        Span::styled(record.summary(), Style::default().fg(MUTED)),
+                        Span::styled(entry.record.summary(), Style::default().fg(MUTED)),
                     ]),
                 ])
             })
@@ -473,8 +739,10 @@ impl ResumePicker {
             ])
         } else {
             Line::from(vec![
-                keycap("UP/DOWN or J/K"),
-                Span::styled(" NAVIGATE   ", Style::default().fg(MUTED)),
+                keycap("UP/DOWN"),
+                Span::styled(" WORKSPACE   ", Style::default().fg(MUTED)),
+                keycap("TAB"),
+                Span::styled(" GRID   ", Style::default().fg(MUTED)),
                 launch_keycap("ENTER"),
                 Span::styled(" RESUME   ", Style::default().fg(MUTED)),
                 keycap("DELETE x2"),
@@ -493,13 +761,58 @@ impl ResumePicker {
     }
 }
 
-fn all_panes(record: &SessionRecord) -> impl Iterator<Item = &crate::session::SavedPane> {
-    record
-        .session
-        .panes
-        .iter()
-        .chain(record.session.tabs.iter().flat_map(|tab| tab.panes.iter()))
-        .chain(record.session.background_panes.iter().map(|job| &job.pane))
+fn active_grid_index(entry: &SessionEntry) -> usize {
+    entry.grids.iter().position(|grid| grid.active).unwrap_or(0)
+}
+
+/// Render a grid as bracketed cells, one line per grid row. Panes whose agent
+/// conversation resumes are marked, and empty cells are drawn as empty.
+fn grid_map_lines(grid: &GridPreview, width: u16) -> Vec<Line<'static>> {
+    let columns = grid.columns.max(1);
+    // Each cell spends two characters on its brackets. A grid with many columns
+    // gets narrow cells rather than a row that runs off the panel.
+    let cell_width = usize::from(width)
+        .saturating_div(columns)
+        .saturating_sub(2)
+        .clamp(1, 18);
+
+    (0..grid.rows.max(1))
+        .map(|row| {
+            let spans = (0..columns)
+                .map(|column| {
+                    let position = row.saturating_mul(columns).saturating_add(column);
+                    match grid.cells.get(position).and_then(Option::as_ref) {
+                        Some(cell) => Span::styled(
+                            format!("[{}]", cell_text(cell, position + 1, cell_width)),
+                            Style::default().fg(if cell.resumable {
+                                TERMINAL_GREEN
+                            } else {
+                                SOFT_GREEN
+                            }),
+                        ),
+                        None => Span::styled(
+                            format!("[{}]", " ".repeat(cell_width)),
+                            Style::default().fg(HAIRLINE),
+                        ),
+                    }
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
+        })
+        .collect()
+}
+
+/// A cell's text: its pane number, its name, and a mark when its conversation
+/// comes back. Truncated to the space the grid leaves it.
+fn cell_text(cell: &PaneCell, number: usize, width: usize) -> String {
+    let mark = if cell.resumable { RESUMABLE_MARK } else { "" };
+    let prefix = format!("{number}{mark} ");
+    let room = width.saturating_sub(prefix.chars().count());
+    let mut text = prefix;
+    text.extend(cell.label.chars().take(room));
+    let padding = width.saturating_sub(text.chars().count());
+    text.push_str(&" ".repeat(padding));
+    text.chars().take(width).collect()
 }
 
 fn session_title(record: &SessionRecord) -> String {
@@ -664,7 +977,7 @@ mod tests {
     use super::*;
     use crate::{
         profiles::Profile,
-        session::{SavedGrid, SavedPane, SavedPaneHistory, SavedSession},
+        session::{SavedGrid, SavedPane, SavedPaneHistory, SavedSession, SavedView},
     };
 
     #[test]
@@ -702,8 +1015,8 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
-        let details_at = rendered.find("SELECTED SESSION").expect("details panel");
-        let sessions_at = rendered.find("RECENT SESSIONS").expect("sessions panel");
+        let details_at = rendered.find("SELECTED WORKSPACE").expect("details panel");
+        let sessions_at = rendered.find("RECENT WORKSPACES").expect("sessions panel");
         assert!(
             details_at < sessions_at,
             "details should render above sessions"
@@ -712,13 +1025,89 @@ mod tests {
         assert!(rendered.contains("Fluent workspace"));
         assert!(rendered.contains("DETACHED"));
         assert!(rendered.contains("DELETE x2"));
-        assert!(!rendered.contains("01 /"));
-        assert!(!rendered.contains("02 /"));
         assert!(
             buffer
                 .content()
                 .iter()
                 .any(|cell| cell.fg == TERMINAL_GREEN)
+        );
+    }
+
+    /// The picker has to prove the arrangement survives, so it shows each grid's
+    /// saved size and draws its panes in the cells they occupied.
+    #[test]
+    fn shows_saved_grid_dimensions_and_pane_positions() {
+        let mut session = record("Fluent workspace", false, None, false).session;
+        session.title = "Main".into();
+        session.grid = SavedGrid {
+            rows: 2,
+            columns: 3,
+        };
+        session.panes = vec![
+            named_pane(0, "codex", Some("planner")),
+            named_pane(1, "claude", None),
+            named_pane(2, "git-bash", None),
+            named_pane(3, "codex", None),
+        ];
+        session.tabs = vec![SavedTab {
+            title: "api".into(),
+            grid: SavedGrid {
+                rows: 1,
+                columns: 2,
+            },
+            view: SavedView::default(),
+            panes: vec![named_pane(0, "codex", None), named_pane(1, "codex", None)],
+        }];
+        let sessions = vec![SessionRecord {
+            path: PathBuf::from("session.toml"),
+            session,
+        }];
+        let mut picker = ResumePicker::new(&sessions);
+        let backend = TestBackend::new(130, 34);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|frame| picker.draw(frame))
+            .expect("draw resume picker");
+        let rendered = rendered_text(&terminal);
+
+        // Both grids are named with the size they will be rebuilt at.
+        assert!(rendered.contains("Main 2x3"), "{rendered}");
+        assert!(rendered.contains("api 1x2"), "{rendered}");
+        // The active grid's map shows the user's pane name in the first cell and
+        // leaves the two unused cells of the 2x3 grid empty.
+        assert!(rendered.contains("Main · 2x3"), "{rendered}");
+        assert!(rendered.contains("planner"), "{rendered}");
+    }
+
+    /// Tab walks the saved grids so every one can be checked before resuming.
+    #[test]
+    fn tab_cycles_through_saved_grids() {
+        let mut session = record("Fluent workspace", false, None, false).session;
+        session.title = "Main".into();
+        session.tabs = vec![SavedTab {
+            title: "api".into(),
+            grid: SavedGrid {
+                rows: 1,
+                columns: 1,
+            },
+            view: SavedView::default(),
+            panes: vec![named_pane(0, "codex", None)],
+        }];
+        let sessions = vec![SessionRecord {
+            path: PathBuf::from("session.toml"),
+            session,
+        }];
+        let mut picker = ResumePicker::new(&sessions);
+        assert_eq!(picker.grid_cursor, 0);
+
+        let tab = KeyEvent::new(KeyCode::Tab, crossterm::event::KeyModifiers::NONE);
+        assert_eq!(picker.handle_key(tab), PickerAction::Continue);
+        assert_eq!(picker.grid_cursor, 1);
+        assert_eq!(picker.handle_key(tab), PickerAction::Continue);
+        assert_eq!(
+            picker.grid_cursor, 0,
+            "cycling wraps back to the first grid"
         );
     }
 
@@ -754,23 +1143,43 @@ mod tests {
         );
     }
 
-    fn record(title: &str, running: bool, owner_pid: Option<u32>, host: bool) -> SessionRecord {
-        let pane = SavedPane {
+    fn rendered_text(terminal: &Terminal<TestBackend>) -> String {
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    fn named_pane(index: usize, profile_name: &str, name: Option<&str>) -> SavedPane {
+        let mut pane = pane(profile_name, false);
+        pane.index = index;
+        pane.name = name.map(str::to_string);
+        pane
+    }
+
+    fn pane(profile_name: &str, host: bool) -> SavedPane {
+        SavedPane {
             index: 0,
-            profile_name: "codex".into(),
+            profile_name: profile_name.into(),
             command: Profile {
-                command: "codex".into(),
+                command: profile_name.into(),
                 args: Vec::new(),
-                title: Some("Codex".into()),
+                title: Some(profile_name.into()),
                 agent_kind: None,
             },
             cwd: PathBuf::from("fluent"),
             folder_name: "fluent".into(),
+            name: None,
             worktree_name: None,
             auth_name: None,
             auth_kind: None,
+            sleeping: false,
             history: SavedPaneHistory::default(),
             codex_thread_id: None,
+            claude_session_id: None,
             host: host.then(|| crate::pane_host::PtyHostRef {
                 endpoint: "127.0.0.1:12345".into(),
                 token: "token".into(),
@@ -778,20 +1187,26 @@ mod tests {
                 codex_sqlite_home: None,
                 started_at_ms: None,
             }),
-        };
+        }
+    }
+
+    fn record(title: &str, running: bool, owner_pid: Option<u32>, host: bool) -> SessionRecord {
         SessionRecord {
             path: PathBuf::from("session.toml"),
             session: SavedSession {
-                version: 1,
+                version: 2,
                 id: "session-id".into(),
                 started_at: 1,
                 updated_at: 1,
                 title: title.into(),
+                active_tab: 0,
+                next_tab_number: 2,
                 grid: SavedGrid {
                     rows: 1,
                     columns: 1,
                 },
-                panes: vec![pane],
+                view: SavedView::default(),
+                panes: vec![pane("codex", host)],
                 background_panes: Vec::new(),
                 tabs: Vec::new(),
                 running,

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,11 +3,12 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, IsTerminal, Write},
     path::{Path, PathBuf},
+    sync::OnceLock,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
@@ -24,9 +25,15 @@ use crate::{
     setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
 };
 
-const SESSION_VERSION: u16 = 1;
+/// Snapshot format GridBash writes. Version 2 added the state that made a
+/// resumed workspace identical to the one that closed: pane names, the focused
+/// pane, zoom, divider weights, tab order, and the Claude conversation each
+/// agent pane was talking to.
+const SESSION_VERSION: u16 = 2;
+/// Oldest format still understood. Older snapshots load with the version 2
+/// fields defaulted, so upgrading GridBash never strands a saved workspace.
+const MIN_SESSION_VERSION: u16 = 1;
 const MAX_SAVED_SESSIONS: usize = 50;
-const MAX_RECOVERED_PANES_PER_TAB: usize = 100;
 
 #[derive(Debug, Clone)]
 pub struct SessionRecord {
@@ -42,11 +49,22 @@ pub struct SavedSession {
     pub updated_at: u64,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub title: String,
+    /// Where the grid held in `panes` sits among `tabs`. Without it a resumed
+    /// workspace reordered every grid so the active one came first.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub active_tab: usize,
+    /// Number the next new grid should take, so resuming does not hand out a
+    /// name an existing grid already uses.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub next_tab_number: usize,
     pub grid: SavedGrid,
+    #[serde(default, skip_serializing_if = "SavedView::is_default")]
+    pub view: SavedView,
     #[serde(default)]
     pub panes: Vec<SavedPane>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub background_panes: Vec<SavedBackgroundPane>,
+    /// Every grid except the active one, in workspace order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tabs: Vec<SavedTab>,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -65,21 +83,30 @@ pub struct SavedGrid {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedPane {
+    /// Grid slot this pane occupied, counting left to right then top to bottom.
+    /// Restores read it back so a pane never lands in a different cell.
     pub index: usize,
     pub profile_name: String,
     pub command: Profile,
     pub cwd: PathBuf,
     pub folder_name: String,
+    /// Name the user typed for this pane, kept separate from the profile title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_kind: Option<AgentKind>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub sleeping: bool,
     #[serde(default)]
     pub history: SavedPaneHistory,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host: Option<PtyHostRef>,
 }
@@ -88,8 +115,30 @@ pub struct SavedPane {
 pub struct SavedTab {
     pub title: String,
     pub grid: SavedGrid,
+    #[serde(default, skip_serializing_if = "SavedView::is_default")]
+    pub view: SavedView,
     #[serde(default)]
     pub panes: Vec<SavedPane>,
+}
+
+/// How a grid looked, beyond which panes it held: which pane had focus, whether
+/// it was zoomed, and where the user dragged its dividers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SavedView {
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub focus: usize,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub zoomed: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub row_weights: Vec<u16>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub column_weights: Vec<u16>,
+}
+
+impl SavedView {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,7 +160,12 @@ pub struct SavedPaneHistory {
 
 #[derive(Debug, Clone)]
 pub struct InterruptedRecovery {
+    /// Every grid from every interrupted workspace, in the order it was shown.
     pub tabs: Vec<SavedTab>,
+    /// Grid to open on, so recovery lands where the user left off.
+    pub active_tab: usize,
+    pub background_panes: Vec<SavedBackgroundPane>,
+    pub next_tab_number: usize,
     pub session_count: usize,
     pub pane_count: usize,
     pub claim: InterruptedRecoveryClaim,
@@ -146,16 +200,37 @@ impl SessionRecord {
 }
 
 impl SavedSession {
-    pub fn launch_plan(&self) -> Result<LaunchPlan> {
-        launch_plan_from_saved(&self.id, self.grid, &self.panes)
+    /// The active grid described the same way as every other grid, so restore
+    /// paths only ever handle one shape.
+    pub fn active_grid(&self) -> SavedTab {
+        SavedTab {
+            title: self.title.clone(),
+            grid: self.grid,
+            view: self.view.clone(),
+            panes: self.panes.clone(),
+        }
     }
 
-    pub fn pane_histories(&self) -> Vec<SavedPaneHistory> {
-        self.panes.iter().map(|pane| pane.history.clone()).collect()
+    /// Every grid in the order the workspace showed them, plus the position the
+    /// active grid held.
+    pub fn ordered_grids(&self) -> (Vec<SavedTab>, usize) {
+        let mut grids = self.tabs.clone();
+        let active = self.active_tab.min(grids.len());
+        grids.insert(active, self.active_grid());
+        (grids, active)
     }
 
-    pub fn pane_hosts(&self) -> Vec<Option<PtyHostRef>> {
-        self.panes.iter().map(|pane| pane.host.clone()).collect()
+    /// Number the workspace should give its next new grid. Older snapshots did
+    /// not record it, so fall back to one past the grids they do describe.
+    pub fn next_grid_number(&self) -> usize {
+        self.next_tab_number.max(self.tabs.len() + 2)
+    }
+
+    pub fn all_panes(&self) -> impl Iterator<Item = &SavedPane> {
+        self.panes
+            .iter()
+            .chain(self.tabs.iter().flat_map(|tab| tab.panes.iter()))
+            .chain(self.background_panes.iter().map(|job| &job.pane))
     }
 
     fn new(id: String, title: &str, plan: &LaunchPlan) -> Self {
@@ -166,13 +241,16 @@ impl SavedSession {
             started_at: now,
             updated_at: now,
             title: title.to_string(),
+            active_tab: 0,
+            next_tab_number: 2,
             grid: plan.grid.into(),
+            view: SavedView::default(),
             panes: plan
                 .panes
                 .iter()
                 .enumerate()
                 .map(|(index, spec)| {
-                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None, None)
+                    SavedPane::from_spec(index, spec, SavedPaneHistory::default(), None, None, None)
                 })
                 .collect(),
             background_panes: Vec::new(),
@@ -204,27 +282,23 @@ impl SavedSession {
     }
 
     fn has_agent_pane(&self) -> bool {
-        self.panes
-            .iter()
-            .chain(self.tabs.iter().flat_map(|tab| tab.panes.iter()))
-            .chain(self.background_panes.iter().map(|job| &job.pane))
-            .any(|pane| pane.launch_spec().agent_label().is_some())
+        self.all_panes().any(SavedPane::runs_an_agent)
     }
 
-    fn update_from_live(
-        &mut self,
-        title: &str,
-        plan: &LaunchPlan,
-        panes: &[PtyPane],
-        tabs: Vec<SavedTab>,
-        background_panes: Vec<SavedBackgroundPane>,
-    ) {
+    /// Takes the captured workspace by value: it carries every pane's output
+    /// tail, and this runs on a timer, so borrowing it here would copy megabytes
+    /// on each save for no reason.
+    fn update_from_live(&mut self, live: LiveWorkspace<'_>) {
+        let active = SavedTab::from_live(&live.active);
         self.version = SESSION_VERSION;
-        self.title = title.to_string();
-        self.grid = plan.grid.into();
-        self.panes = saved_panes_from_live(plan, panes);
-        self.tabs = tabs;
-        self.background_panes = background_panes;
+        self.title = active.title;
+        self.grid = active.grid;
+        self.view = active.view;
+        self.panes = active.panes;
+        self.tabs = live.tabs;
+        self.background_panes = live.background_panes;
+        self.active_tab = live.active_tab;
+        self.next_tab_number = live.next_tab_number;
     }
 
     fn summary(&self) -> String {
@@ -273,11 +347,12 @@ impl SavedSession {
 }
 
 impl SavedTab {
-    pub fn from_live(title: &str, plan: &LaunchPlan, panes: &[PtyPane]) -> Self {
+    pub fn from_live(live: &LiveGrid<'_>) -> Self {
         Self {
-            title: title.to_string(),
-            grid: plan.grid.into(),
-            panes: saved_panes_from_live(plan, panes),
+            title: live.title.to_string(),
+            grid: live.plan.grid.into(),
+            view: live.view.clone(),
+            panes: saved_panes_from_live(live),
         }
     }
 
@@ -292,23 +367,75 @@ impl SavedTab {
     pub fn pane_hosts(&self) -> Vec<Option<PtyHostRef>> {
         self.panes.iter().map(|pane| pane.host.clone()).collect()
     }
+
+    pub fn pane_names(&self) -> Vec<Option<String>> {
+        self.panes.iter().map(|pane| pane.name.clone()).collect()
+    }
+
+    pub fn sleeping_panes(&self) -> BTreeSet<usize> {
+        self.panes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, pane)| pane.sleeping.then_some(index))
+            .collect()
+    }
+
+    /// Focused pane, clamped to the panes that actually came back.
+    pub fn focus(&self) -> usize {
+        self.view.focus.min(self.panes.len().saturating_sub(1))
+    }
 }
 
+/// The live workspace a snapshot is taken from. Grouping it keeps every caller
+/// honest about the state a resumed workspace has to reproduce.
+pub struct LiveWorkspace<'a> {
+    pub active: LiveGrid<'a>,
+    pub tabs: Vec<SavedTab>,
+    pub background_panes: Vec<SavedBackgroundPane>,
+    pub active_tab: usize,
+    pub next_tab_number: usize,
+}
+
+/// One live grid: what it runs, what the user named it and its panes, and how it
+/// was arranged on screen.
+pub struct LiveGrid<'a> {
+    pub title: &'a str,
+    pub plan: &'a LaunchPlan,
+    pub panes: &'a [PtyPane],
+    pub pane_names: &'a [Option<String>],
+    pub sleeping: &'a BTreeSet<usize>,
+    pub view: SavedView,
+}
+
+/// Rebuild a grid exactly as it was saved.
+///
+/// The saved dimensions are used verbatim: a 2x3 grid comes back 2x3 even when
+/// some of its cells were empty, because a grid recomputed from its pane count
+/// silently reshapes the workspace the user arranged.
 fn launch_plan_from_saved(
     id: &str,
     saved_grid: SavedGrid,
     panes: &[SavedPane],
 ) -> Result<LaunchPlan> {
-    let grid = GridSize::new(saved_grid.rows, saved_grid.columns).ok_or_else(|| {
+    let mut grid = GridSize::new(saved_grid.rows, saved_grid.columns).ok_or_else(|| {
         anyhow!(
             "saved session {id} has invalid grid {}x{}",
             saved_grid.rows,
             saved_grid.columns
         )
     })?;
-    let panes = panes.iter().map(SavedPane::launch_spec).collect::<Vec<_>>();
+    let panes = ordered_panes(panes)
+        .into_iter()
+        .map(SavedPane::launch_spec)
+        .collect::<Vec<_>>();
     if panes.is_empty() {
         bail!("saved session {id} has no panes");
+    }
+    // A snapshot damaged into claiming more panes than cells would hide the
+    // extras behind the grid, which loses work. Growing the grid keeps every
+    // pane reachable; a consistent snapshot never reaches this.
+    if panes.len() > grid.count() {
+        grid = GridSize::from_count(panes.len());
     }
     // A grid can never hold more than `MAX_PANES`, so a file claiming more is
     // damaged. Refusing it here keeps the count from becoming per-pane
@@ -322,20 +449,30 @@ fn launch_plan_from_saved(
     Ok(LaunchPlan { panes, grid })
 }
 
-fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane> {
-    let host_processes = panes
+/// Panes in grid order, so a snapshot written out of order still restores every
+/// pane to the cell it occupied.
+fn ordered_panes(panes: &[SavedPane]) -> Vec<&SavedPane> {
+    let mut ordered = panes.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|pane| pane.index);
+    ordered
+}
+
+fn saved_panes_from_live(live: &LiveGrid<'_>) -> Vec<SavedPane> {
+    let host_processes = live
+        .panes
         .iter()
         .filter_map(PtyPane::host_process_id)
         .collect::<Vec<_>>();
     let codex_roots = roots_with_descendant_named(&host_processes, "codex").ok();
-    plan.panes
+    live.plan
+        .panes
         .iter()
         .enumerate()
         .map(|(index, spec)| {
-            let live = panes.get(index);
-            let history = live.map(SavedPaneHistory::from_pane).unwrap_or_default();
-            let host = live.map(PtyPane::host_ref);
-            let codex_running = live.is_some_and(|pane| {
+            let pane = live.panes.get(index);
+            let history = pane.map(SavedPaneHistory::from_pane).unwrap_or_default();
+            let host = pane.map(PtyPane::host_ref);
+            let codex_running = pane.is_some_and(|pane| {
                 pane.host_process_id().is_some_and(|process_id| {
                     codex_roots
                         .as_ref()
@@ -345,12 +482,27 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
             let codex_thread_id = codex_running
                 .then(|| {
                     codex_resume_id(&spec.command, &history.input_history)
-                        .or_else(|| live.and_then(|pane| pane.codex_thread_id(pane.cwd())))
+                        .or_else(|| pane.and_then(|pane| pane.codex_thread_id(pane.cwd())))
                 })
                 .flatten();
-            let mut saved = SavedPane::from_spec(index, spec, history, codex_thread_id, host);
-            if let Some(live) = live {
-                saved.cwd = live.cwd().to_path_buf();
+            let claude_session_id = claude_session_from_live(spec, pane, &history.input_history);
+            let mut saved = SavedPane::from_spec(
+                index,
+                spec,
+                history,
+                codex_thread_id,
+                claude_session_id,
+                host,
+            );
+            saved.name = live
+                .pane_names
+                .get(index)
+                .cloned()
+                .flatten()
+                .filter(|name| !name.trim().is_empty());
+            saved.sleeping = live.sleeping.contains(&index);
+            if let Some(pane) = pane {
+                saved.cwd = pane.cwd().to_path_buf();
                 saved.folder_name = folder_display_name(&saved.cwd);
             }
             saved
@@ -358,13 +510,41 @@ fn saved_panes_from_live(plan: &LaunchPlan, panes: &[PtyPane]) -> Vec<SavedPane>
         .collect()
 }
 
+/// Claude conversation a live pane is attached to.
+///
+/// A pane GridBash launched carries the id it pinned at spawn, which cannot be
+/// confused by a sibling pane in the same directory. A pane where the user
+/// started Claude themselves is read back out of what they typed.
+fn claude_session_from_live(
+    spec: &PaneLaunchSpec,
+    pane: Option<&PtyPane>,
+    input_history: &[String],
+) -> Option<String> {
+    pane.and_then(PtyPane::agent_session_id)
+        .map(str::to_string)
+        .or_else(|| claude_resume_id(&spec.command, input_history))
+}
+
 impl SavedPane {
     pub fn launch_spec(&self) -> PaneLaunchSpec {
-        let (profile_name, command) = self
-            .codex_thread_id
-            .as_deref()
-            .map(|thread_id| codex_resume_profile(&self.profile_name, &self.command, thread_id))
-            .unwrap_or_else(|| (self.profile_name.clone(), self.command.clone()));
+        let (profile_name, command) = self.resume_command();
+        self.spec_for(profile_name, command)
+    }
+
+    /// Whether this pane runs an agent, without working out which conversation
+    /// it would resume. Checking every saved pane happens on every launch, and
+    /// resolving conversations there would put a filesystem lookup per pane in
+    /// front of startup.
+    fn runs_an_agent(&self) -> bool {
+        self.codex_thread_id.is_some()
+            || self.claude_session_id.is_some()
+            || self
+                .spec_for(self.profile_name.clone(), self.command.clone())
+                .agent_label()
+                .is_some()
+    }
+
+    fn spec_for(&self, profile_name: String, command: Profile) -> PaneLaunchSpec {
         PaneLaunchSpec {
             profile_name,
             command,
@@ -378,12 +558,45 @@ impl SavedPane {
         }
     }
 
+    /// Command that puts this pane back in the conversation it left.
+    ///
+    /// A Claude transcript that is no longer on disk falls back to a plain
+    /// launch, because `claude --resume` on a missing session fails outright and
+    /// would leave the pane with no agent at all.
+    fn resume_command(&self) -> (String, Profile) {
+        if let Some(thread_id) = self.codex_thread_id.as_deref() {
+            return codex_resume_profile(&self.profile_name, &self.command, thread_id);
+        }
+        if let Some(session_id) = self.claude_session_id.as_deref()
+            && claude_session_exists(&self.cwd, session_id)
+        {
+            return claude_resume_profile(&self.profile_name, &self.command, session_id);
+        }
+
+        (
+            self.profile_name.clone(),
+            without_claude_session_pin(&self.command),
+        )
+    }
+
+    /// Conversation this pane will actually be put back into, for callers that
+    /// describe a snapshot rather than launch it. Reports nothing when the
+    /// transcript is gone, matching what a resume would really do.
+    pub fn resumable_conversation(&self) -> Option<&str> {
+        if let Some(thread_id) = self.codex_thread_id.as_deref() {
+            return Some(thread_id);
+        }
+        self.claude_session_id
+            .as_deref()
+            .filter(|session_id| claude_session_exists(&self.cwd, session_id))
+    }
+
     pub fn from_background(
         spec: &PaneLaunchSpec,
         history: SavedPaneHistory,
         host: Option<PtyHostRef>,
     ) -> Self {
-        Self::from_spec(0, spec, history, None, host)
+        Self::from_spec(0, spec, history, None, None, host)
     }
 
     fn from_spec(
@@ -391,6 +604,7 @@ impl SavedPane {
         spec: &PaneLaunchSpec,
         history: SavedPaneHistory,
         codex_thread_id: Option<String>,
+        claude_session_id: Option<String>,
         host: Option<PtyHostRef>,
     ) -> Self {
         Self {
@@ -399,11 +613,14 @@ impl SavedPane {
             command: spec.command.clone(),
             cwd: spec.cwd.clone(),
             folder_name: spec.folder_name.clone(),
+            name: None,
             worktree_name: spec.worktree_name.clone(),
             auth_name: spec.auth_name.clone(),
             auth_kind: spec.auth_kind,
+            sleeping: false,
             history,
             codex_thread_id,
+            claude_session_id,
             host,
         }
     }
@@ -500,6 +717,373 @@ fn looks_like_thread_id(value: &str) -> bool {
         })
 }
 
+/// Flags that already decide which conversation Claude opens. A pane launched
+/// with one of these is left exactly as the user wrote it.
+const CLAUDE_SESSION_FLAGS: &[&str] = &[
+    "--session-id",
+    "--resume",
+    "-r",
+    "--continue",
+    "-c",
+    "--fork-session",
+    "--from-pr",
+    "--no-session-persistence",
+];
+
+/// Pin the conversation a Claude pane is about to open.
+///
+/// Codex records its thread in a state database GridBash can read afterwards,
+/// but Claude leaves nothing that ties a transcript to a particular pane. So
+/// GridBash chooses the session id up front and passes it in: the snapshot then
+/// names the conversation exactly, even with several Claude panes in one folder.
+///
+/// Returns the conversation this pane will be talking to, if it is knowable.
+pub fn pin_claude_session(command: &mut Profile) -> Option<String> {
+    if command.agent_kind != Some(AgentKind::Claude) || !is_direct_claude_command(&command.command)
+    {
+        return None;
+    }
+    if let Some(session_id) = claude_session_id_in_args(&command.args) {
+        return Some(session_id);
+    }
+    if command
+        .args
+        .iter()
+        .any(|argument| CLAUDE_SESSION_FLAGS.contains(&argument.as_str()))
+    {
+        // The user asked for a specific conversation without naming an id, such
+        // as `--continue`. Overriding that would open the wrong one.
+        return None;
+    }
+
+    let session_id = new_session_uuid()?;
+    command.args.push("--session-id".into());
+    command.args.push(session_id.clone());
+    Some(session_id)
+}
+
+/// Conversation a command already names, without choosing a new one. Used when
+/// reattaching to a terminal that is still running: its agent is already in a
+/// conversation, so inventing an id would misname it.
+pub fn claude_session_in_command(command: &Profile) -> Option<String> {
+    claude_session_id_in_args(&command.args)
+}
+
+fn claude_resume_profile(
+    profile_name: &str,
+    command: &Profile,
+    session_id: &str,
+) -> (String, Profile) {
+    if command.agent_kind == Some(AgentKind::Claude) && is_direct_claude_command(&command.command) {
+        let mut command = command.clone();
+        command.args = claude_resume_args(&command.args, session_id);
+        return (profile_name.to_string(), command);
+    }
+    if claude_resume_id(command, &[]).as_deref() == Some(session_id) {
+        return (profile_name.to_string(), command.clone());
+    }
+
+    (
+        "claude".into(),
+        Profile {
+            command: "claude".into(),
+            args: vec!["--resume".into(), session_id.into()],
+            title: Some("Claude".into()),
+            agent_kind: Some(AgentKind::Claude),
+        },
+    )
+}
+
+/// Swap whatever conversation selection the pane carried for a resume of
+/// `session_id`. Re-passing `--session-id` would ask Claude to create a session
+/// that already exists, which it refuses.
+fn claude_resume_args(args: &[String], session_id: &str) -> Vec<String> {
+    let mut resumed = args_without_claude_session_selection(args);
+    resumed.push("--resume".into());
+    resumed.push(session_id.to_string());
+    resumed
+}
+
+fn without_claude_session_pin(command: &Profile) -> Profile {
+    if claude_session_id_in_args(&command.args).is_none() {
+        return command.clone();
+    }
+
+    let mut command = command.clone();
+    command.args = args_without_claude_session_selection(&command.args);
+    command
+}
+
+fn args_without_claude_session_selection(args: &[String]) -> Vec<String> {
+    let mut kept = Vec::with_capacity(args.len());
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].as_str();
+        if CLAUDE_SESSION_FLAGS.contains(&argument) {
+            index += 1;
+            if args
+                .get(index)
+                .is_some_and(|value| looks_like_thread_id(value))
+            {
+                index += 1;
+            }
+            continue;
+        }
+        if let Some(value) = argument.strip_prefix("--session-id=")
+            && looks_like_thread_id(value)
+        {
+            index += 1;
+            continue;
+        }
+        kept.push(args[index].clone());
+        index += 1;
+    }
+    kept
+}
+
+fn claude_resume_id(command: &Profile, input_history: &[String]) -> Option<String> {
+    claude_session_id_in_args(&command.args).or_else(|| {
+        input_history
+            .iter()
+            .rev()
+            .find_map(|input| claude_session_id_in_text(input))
+    })
+}
+
+fn claude_session_id_in_args(args: &[String]) -> Option<String> {
+    args.iter()
+        .enumerate()
+        .find_map(|(index, argument)| {
+            (CLAUDE_SESSION_FLAGS.contains(&argument.as_str()))
+                .then(|| args.get(index + 1))
+                .flatten()
+                .filter(|value| looks_like_thread_id(value))
+                .cloned()
+        })
+        .or_else(|| {
+            args.iter().find_map(|argument| {
+                argument
+                    .strip_prefix("--session-id=")
+                    .filter(|value| looks_like_thread_id(value))
+                    .map(str::to_string)
+            })
+        })
+}
+
+/// Read a Claude conversation id out of a command the user typed into a shell
+/// pane, so panes GridBash did not launch itself are still preserved.
+fn claude_session_id_in_text(value: &str) -> Option<String> {
+    let tokens = value
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|character: char| matches!(character, '"' | '\'' | ';' | ','))
+        })
+        .collect::<Vec<_>>();
+    if !tokens.iter().any(|token| {
+        Path::new(token)
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("claude"))
+    }) {
+        return None;
+    }
+
+    tokens.windows(2).find_map(|tokens| {
+        (CLAUDE_SESSION_FLAGS.contains(&tokens[0]) && looks_like_thread_id(tokens[1]))
+            .then(|| tokens[1].to_string())
+    })
+}
+
+fn is_direct_claude_command(command: &str) -> bool {
+    Path::new(command)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("claude"))
+}
+
+/// Number of Claude project folders scanned when the encoded folder name does
+/// not match. Bounded so a huge history cannot stall a resume.
+const MAX_CLAUDE_PROJECT_SCAN: usize = 4096;
+
+/// Number of transcripts examined when following a pane onto a new
+/// conversation. Bounded for the same reason.
+const MAX_CLAUDE_TRANSCRIPT_SCAN: usize = 4096;
+
+/// Conversation a pane has moved on to since it launched.
+///
+/// Clearing a conversation starts a new one inside the same terminal, so the id
+/// pinned at launch goes stale and the snapshot would resume the abandoned
+/// conversation. The pane's current one is the newest transcript in its folder
+/// that appeared after the pane started and that no other pane is following.
+///
+/// Returns nothing when the pane is still on the conversation it had.
+pub fn latest_claude_session(
+    cwd: &Path,
+    current: Option<&str>,
+    started_at_ms: Option<u64>,
+    followed: &BTreeSet<String>,
+) -> Option<String> {
+    let directory = claude_projects_dir()?.join(claude_project_folder(cwd));
+    latest_claude_session_in(&directory, current, started_at_ms, followed)
+}
+
+fn latest_claude_session_in(
+    directory: &Path,
+    current: Option<&str>,
+    started_at_ms: Option<u64>,
+    followed: &BTreeSet<String>,
+) -> Option<String> {
+    // Only a transcript newer than the one the pane already has can be a
+    // conversation it moved to.
+    let floor = current
+        .and_then(|session_id| modified_ms(&directory.join(format!("{session_id}.jsonl"))))
+        .or(started_at_ms)
+        .unwrap_or_default();
+
+    let mut newest: Option<(u64, String)> = None;
+    for entry in fs::read_dir(directory)
+        .ok()?
+        .flatten()
+        .take(MAX_CLAUDE_TRANSCRIPT_SCAN)
+    {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(session_id) = path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        // A conversation another pane is following belongs to that pane.
+        if !looks_like_thread_id(session_id)
+            || Some(session_id) == current
+            || followed.contains(session_id)
+        {
+            continue;
+        }
+        let Some(modified) = modified_ms(&path) else {
+            continue;
+        };
+        if modified <= floor || started_at_ms.is_some_and(|started| modified < started) {
+            continue;
+        }
+        if newest
+            .as_ref()
+            .is_none_or(|(newest_ms, _)| modified > *newest_ms)
+        {
+            newest = Some((modified, session_id.to_string()));
+        }
+    }
+
+    newest.map(|(_, session_id)| session_id)
+}
+
+fn modified_ms(path: &Path) -> Option<u64> {
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    modified
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|elapsed| elapsed.as_millis().min(u128::from(u64::MAX)) as u64)
+}
+
+/// Whether Claude can still open this conversation.
+///
+/// `claude --resume` on a transcript that is gone exits immediately, which would
+/// leave the pane empty instead of running an agent. Checking first lets the
+/// restore fall back to a fresh Claude in the right folder.
+fn claude_session_exists(cwd: &Path, session_id: &str) -> bool {
+    if !looks_like_thread_id(session_id) {
+        return false;
+    }
+    let Some(root) = claude_projects_dir() else {
+        return false;
+    };
+
+    let transcript = format!("{session_id}.jsonl");
+    if root
+        .join(claude_project_folder(cwd))
+        .join(&transcript)
+        .is_file()
+    {
+        return true;
+    }
+
+    // Claude derives the folder name from the working directory, and that
+    // encoding has changed shape before. Scanning keeps a resumable
+    // conversation from being dropped over a spelling difference.
+    claude_project_dirs()
+        .iter()
+        .any(|directory| directory.join(&transcript).is_file())
+}
+
+/// Folders Claude keeps transcripts in, listed once.
+///
+/// The fallback above runs for every pane whose transcript is not where it was
+/// expected, and re-reading the directory each time would put a listing per pane
+/// in front of a resume.
+fn claude_project_dirs() -> &'static [PathBuf] {
+    static DIRECTORIES: OnceLock<Vec<PathBuf>> = OnceLock::new();
+    DIRECTORIES.get_or_init(|| {
+        let Some(root) = claude_projects_dir() else {
+            return Vec::new();
+        };
+        let Ok(entries) = fs::read_dir(root) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .take(MAX_CLAUDE_PROJECT_SCAN)
+            .map(|entry| entry.path())
+            .collect()
+    })
+}
+
+fn claude_projects_dir() -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("CLAUDE_CONFIG_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        return Some(configured.join("projects"));
+    }
+
+    BaseDirs::new().map(|dirs| dirs.home_dir().join(".claude").join("projects"))
+}
+
+/// Folder Claude keeps a directory's transcripts in: the path with everything
+/// that is not a letter, digit, or dash folded to a dash.
+fn claude_project_folder(cwd: &Path) -> String {
+    cwd.to_string_lossy()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Random version 4 UUID, the form Claude requires for `--session-id`.
+fn new_session_uuid() -> Option<String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes).ok()?;
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    let hex = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Some(format!(
+        "{}-{}-{}-{}-{}",
+        &hex[..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..]
+    ))
+}
+
 impl SavedPaneHistory {
     pub fn from_pane(pane: &PtyPane) -> Self {
         Self {
@@ -544,16 +1128,8 @@ impl SessionRecorder {
         }
     }
 
-    pub fn update(
-        &mut self,
-        title: &str,
-        plan: &LaunchPlan,
-        panes: &[PtyPane],
-        tabs: Vec<SavedTab>,
-        background_panes: Vec<SavedBackgroundPane>,
-    ) {
-        self.session
-            .update_from_live(title, plan, panes, tabs, background_panes);
+    pub fn update(&mut self, live: LiveWorkspace<'_>) {
+        self.session.update_from_live(live);
     }
 
     pub fn save(&mut self) -> Result<()> {
@@ -664,56 +1240,55 @@ fn is_interrupted_agent_session(record: &SessionRecord) -> bool {
         && session.has_agent_pane()
 }
 
+/// Rebuild what the interrupted workspaces looked like.
+///
+/// Every grid is carried over as it was: its own dimensions, its name, and its
+/// panes in the cells they occupied. Earlier versions regrouped loose panes by
+/// working directory and sized the result from the pane count, which reshaped a
+/// 2x3 grid into 3x3 and replaced grid names with folder names.
 fn build_interrupted_recovery(records: &[SessionRecord]) -> Option<InterruptedRecovery> {
-    let mut groups = Vec::<(String, PathBuf, Vec<SavedPane>)>::new();
-    for record in records {
-        let session = &record.session;
-        let panes = session
-            .panes
-            .iter()
-            .chain(session.tabs.iter().flat_map(|tab| tab.panes.iter()))
-            .chain(session.background_panes.iter().map(|job| &job.pane));
-        for pane in panes {
-            let key = directory_group_key(&pane.cwd);
-            if let Some((_, _, panes)) = groups.iter_mut().find(|(group, _, _)| group == &key) {
-                panes.push(pane.clone());
-            } else {
-                groups.push((key, pane.cwd.clone(), vec![pane.clone()]));
+    let mut tabs = Vec::new();
+    let mut background_panes = Vec::new();
+    let mut used_titles = BTreeMap::<String, usize>::new();
+    let mut active_tab = 0;
+    let mut next_tab_number = 0;
+
+    for (record_index, record) in records.iter().enumerate() {
+        let (grids, active) = record.session.ordered_grids();
+        let mut recovered_active = None;
+        let first = tabs.len();
+        for (index, mut grid) in grids.into_iter().enumerate() {
+            // A grid with no panes cannot be rebuilt, so it is dropped without
+            // moving the grid the user was looking at.
+            if grid.panes.is_empty() {
+                continue;
             }
+            if recovered_active.is_none() && index >= active {
+                recovered_active = Some(tabs.len());
+            }
+            grid.title = unique_grid_title(&mut used_titles, &grid.title);
+            tabs.push(grid);
         }
+
+        // The most recently updated workspace is listed first, so opening on its
+        // active grid puts the user back where the crash happened.
+        if record_index == 0 {
+            active_tab = recovered_active.unwrap_or(first);
+        }
+        background_panes.extend(record.session.background_panes.iter().cloned());
+        next_tab_number = next_tab_number.max(record.session.next_grid_number());
     }
 
-    let pane_count = groups.iter().map(|(_, _, panes)| panes.len()).sum();
-    if pane_count == 0 {
+    let pane_count = tabs.iter().map(|tab| tab.panes.len()).sum::<usize>() + background_panes.len();
+    if tabs.is_empty() {
         return None;
     }
 
-    let mut title_counts = BTreeMap::<String, usize>::new();
-    let mut tabs = Vec::new();
-    for (_, cwd, panes) in groups {
-        let base_title = folder_display_name(&cwd);
-        for chunk in panes.chunks(MAX_RECOVERED_PANES_PER_TAB) {
-            let occurrence = title_counts.entry(base_title.clone()).or_default();
-            *occurrence += 1;
-            let title = if *occurrence == 1 {
-                base_title.clone()
-            } else {
-                format!("{base_title} ({occurrence})")
-            };
-            let mut panes = chunk.to_vec();
-            for (index, pane) in panes.iter_mut().enumerate() {
-                pane.index = index;
-            }
-            tabs.push(SavedTab {
-                title,
-                grid: GridSize::from_count(panes.len()).into(),
-                panes,
-            });
-        }
-    }
-
     Some(InterruptedRecovery {
+        active_tab: active_tab.min(tabs.len().saturating_sub(1)),
+        next_tab_number: next_tab_number.max(tabs.len() + 1),
         tabs,
+        background_panes,
         session_count: records.len(),
         pane_count,
         claim: InterruptedRecoveryClaim {
@@ -728,12 +1303,20 @@ fn build_interrupted_recovery(records: &[SessionRecord]) -> Option<InterruptedRe
     })
 }
 
-fn directory_group_key(path: &Path) -> String {
-    #[cfg(windows)]
-    return path.to_string_lossy().replace('\\', "/").to_lowercase();
-
-    #[cfg(not(windows))]
-    path.to_string_lossy().into_owned()
+/// Keep grid names when several interrupted workspaces are recovered together,
+/// numbering the duplicates rather than renaming them after a folder.
+fn unique_grid_title(used: &mut BTreeMap<String, usize>, title: &str) -> String {
+    let base = match title.trim() {
+        "" => "Grid".to_string(),
+        trimmed => trimmed.to_string(),
+    };
+    let occurrence = used.entry(base.clone()).or_default();
+    *occurrence += 1;
+    if *occurrence == 1 {
+        base
+    } else {
+        format!("{base} ({occurrence})")
+    }
 }
 
 pub fn select_resume_session(args: &ResumeArgs) -> Result<Option<SessionRecord>> {
@@ -830,13 +1413,7 @@ fn delete_saved_session_locked(record: &SessionRecord) -> Result<()> {
     ensure_session_is_closed(record)?;
 
     let mut hosts = BTreeMap::<String, PtyHostRef>::new();
-    for pane in record
-        .session
-        .panes
-        .iter()
-        .chain(record.session.tabs.iter().flat_map(|tab| tab.panes.iter()))
-        .chain(record.session.background_panes.iter().map(|job| &job.pane))
-    {
+    for pane in record.session.all_panes() {
         if let Some(host) = pane.host.as_ref() {
             hosts
                 .entry(host.endpoint.clone())
@@ -853,6 +1430,7 @@ fn delete_saved_session_locked(record: &SessionRecord) -> Result<()> {
         })?;
     }
 
+    let _ = fs::remove_file(backup_path(&record.path));
     match fs::remove_file(&record.path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -879,14 +1457,10 @@ pub fn load_recent_sessions() -> Result<Vec<SessionRecord>> {
             continue;
         }
 
-        let Ok(raw) = fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(session) = toml::from_str::<SavedSession>(&raw) else {
-            continue;
-        };
-        if session.version == SESSION_VERSION && !session.id.is_empty() {
-            sessions.push(SessionRecord { path, session });
+        // Reads the snapshot, falling back to its backup when a crash left the
+        // primary copy unreadable.
+        if let Ok(record) = load_session_record(&path) {
+            sessions.push(record);
         }
     }
 
@@ -1006,6 +1580,7 @@ fn prune_old_sessions() -> Result<()> {
             if live_owner_pid(&record).is_some() || session_has_live_host(&record.session) {
                 continue;
             }
+            let _ = fs::remove_file(backup_path(&record.path));
             match fs::remove_file(&record.path) {
                 Ok(()) => excess -= 1,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => excess -= 1,
@@ -1018,10 +1593,7 @@ fn prune_old_sessions() -> Result<()> {
 
 fn session_has_live_host(session: &SavedSession) -> bool {
     session
-        .panes
-        .iter()
-        .chain(session.tabs.iter().flat_map(|tab| tab.panes.iter()))
-        .chain(session.background_panes.iter().map(|job| &job.pane))
+        .all_panes()
         .filter_map(|pane| pane.host.as_ref())
         .any(|host| host.process_id.map(process_is_running).unwrap_or(true))
 }
@@ -1059,7 +1631,14 @@ fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
     #[cfg(unix)]
     options.mode(0o600);
     let mut file = options.open(&temporary)?;
-    if let Err(error) = file.write_all(bytes).and_then(|()| file.flush()) {
+    // Flushing only hands the bytes to the OS. A machine that loses power in
+    // that window leaves a snapshot that parses as truncated TOML, so the
+    // contents are on disk before the rename publishes them.
+    if let Err(error) = file
+        .write_all(bytes)
+        .and_then(|()| file.flush())
+        .and_then(|()| file.sync_all())
+    {
         drop(file);
         let _ = fs::remove_file(&temporary);
         return Err(error);
@@ -1067,6 +1646,12 @@ fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
     drop(file);
     #[cfg(unix)]
     fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+
+    // Keep the snapshot being replaced as a fallback, in case this write or a
+    // later one leaves the primary copy unreadable. Moving it aside rather than
+    // copying it matters: a busy workspace saves every few seconds, and its
+    // snapshot carries every pane's output.
+    let _ = fs::rename(path, backup_path(path));
     match fs::rename(&temporary, path) {
         Ok(()) => Ok(()),
         Err(error) => {
@@ -1074,6 +1659,13 @@ fn write_private_file(path: &std::path::Path, bytes: &[u8]) -> io::Result<()> {
             Err(error)
         }
     }
+}
+
+/// Companion file holding the previous good snapshot.
+fn backup_path(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".bak");
+    PathBuf::from(name)
 }
 
 /// Fingerprint a serialized session so autosave can skip unchanged writes
@@ -1101,17 +1693,41 @@ fn write_session_raw(path: &Path, raw: &[u8]) -> Result<()> {
 }
 
 fn load_session_record(path: &Path) -> Result<SessionRecord> {
+    // A snapshot damaged by a crash mid-write must not cost the workspace, so
+    // the previous good copy is tried before giving up.
+    let error = match read_session_file(path) {
+        Ok(session) => {
+            return Ok(SessionRecord {
+                path: path.to_path_buf(),
+                session,
+            });
+        }
+        Err(error) => error,
+    };
+    match read_session_file(&backup_path(path)) {
+        Ok(session) => Ok(SessionRecord {
+            path: path.to_path_buf(),
+            session,
+        }),
+        Err(_) => Err(error),
+    }
+}
+
+fn read_session_file(path: &Path) -> Result<SavedSession> {
     let raw = fs::read_to_string(path)
         .with_context(|| format!("failed to read saved session {}", path.display()))?;
     let session = toml::from_str::<SavedSession>(&raw)
         .with_context(|| format!("failed to parse saved session {}", path.display()))?;
-    if session.version != SESSION_VERSION || session.id.is_empty() {
+    if !is_supported_session(&session) {
         bail!("saved session {} has an unsupported format", path.display());
     }
-    Ok(SessionRecord {
-        path: path.to_path_buf(),
-        session,
-    })
+    Ok(session)
+}
+
+/// Snapshots from older GridBash versions still load; their newer fields simply
+/// default, and the next save writes the current format.
+fn is_supported_session(session: &SavedSession) -> bool {
+    (MIN_SESSION_VERSION..=SESSION_VERSION).contains(&session.version) && !session.id.is_empty()
 }
 
 fn session_file_path(id: &str) -> Result<PathBuf> {
@@ -1135,6 +1751,10 @@ fn now_seconds() -> u64 {
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 #[cfg(unix)]
@@ -1240,7 +1860,7 @@ mod tests {
         plan.panes[0].auth_kind = Some(AgentKind::Codex);
 
         let session = SavedSession::new("test".into(), "Grid 1", &plan);
-        let restored = session.launch_plan().expect("launch plan");
+        let restored = session.active_grid().launch_plan().expect("launch plan");
 
         assert_eq!(restored.grid, grid);
         assert_eq!(restored.panes.len(), 2);
@@ -1332,10 +1952,13 @@ mod tests {
             started_at: now_seconds(),
             updated_at: now_seconds(),
             title: "Grid 1".into(),
+            active_tab: 0,
+            next_tab_number: 2,
             grid: SavedGrid {
                 rows: 2,
                 columns: 2,
             },
+            view: SavedView::default(),
             panes: vec![
                 pane("one", "claude"),
                 pane("two", "codex"),
@@ -1372,10 +1995,13 @@ mod tests {
             started_at: now_seconds(),
             updated_at: now_seconds(),
             title: "Grid 1".into(),
+            active_tab: 0,
+            next_tab_number: 2,
             grid: SavedGrid {
                 rows: 1,
                 columns: 1,
             },
+            view: SavedView::default(),
             panes: vec![pane("active", "cmd")],
             background_panes: Vec::new(),
             tabs: vec![SavedTab {
@@ -1384,6 +2010,7 @@ mod tests {
                     rows: 1,
                     columns: 1,
                 },
+                view: SavedView::default(),
                 panes: vec![background_pane],
             }],
             running: false,
@@ -1415,10 +2042,13 @@ mod tests {
             started_at: now_seconds(),
             updated_at: now_seconds(),
             title: "Grid 1".into(),
+            active_tab: 0,
+            next_tab_number: 2,
             grid: SavedGrid {
                 rows: 1,
                 columns: 1,
             },
+            view: SavedView::default(),
             panes: vec![pane("visible", "cmd")],
             background_panes: vec![SavedBackgroundPane {
                 id: 9,
@@ -1583,67 +2213,6 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_sessions_are_grouped_into_directory_named_tabs() {
-        let alpha = PathBuf::from("workspaces").join("alpha");
-        let beta = PathBuf::from("workspaces").join("beta");
-        let mut alpha_one = pane("ignored", "codex");
-        alpha_one.cwd = alpha.clone();
-        alpha_one.history.output_tail = "first conversation".into();
-        let mut beta_one = pane("ignored", "claude");
-        beta_one.cwd = beta.clone();
-        let mut alpha_two = pane("ignored", "codex");
-        alpha_two.cwd = alpha;
-        let mut beta_two = pane("ignored", "claude");
-        beta_two.cwd = beta;
-
-        let mut first = recovery_session("first", vec![alpha_one]);
-        first.tabs.push(SavedTab {
-            title: "old title".into(),
-            grid: GridSize::from_count(1).into(),
-            panes: vec![beta_one],
-        });
-        let mut second = recovery_session("second", vec![alpha_two]);
-        second.background_panes.push(SavedBackgroundPane {
-            id: 4,
-            source_tab: "other".into(),
-            name: None,
-            pane: beta_two,
-        });
-        let records = vec![
-            SessionRecord {
-                path: PathBuf::from("first.toml"),
-                session: first,
-            },
-            SessionRecord {
-                path: PathBuf::from("second.toml"),
-                session: second,
-            },
-        ];
-
-        let recovery = build_interrupted_recovery(&records).expect("recovery");
-
-        assert_eq!(recovery.session_count, 2);
-        assert_eq!(recovery.pane_count, 4);
-        assert_eq!(
-            recovery
-                .tabs
-                .iter()
-                .map(|tab| tab.title.as_str())
-                .collect::<Vec<_>>(),
-            ["alpha", "beta"]
-        );
-        assert_eq!(recovery.tabs[0].panes.len(), 2);
-        assert_eq!(recovery.tabs[1].panes.len(), 2);
-        assert_eq!(recovery.tabs[0].panes[0].index, 0);
-        assert_eq!(recovery.tabs[0].panes[1].index, 1);
-        assert_eq!(
-            recovery.tabs[0].panes[0].history.output_tail,
-            "first conversation"
-        );
-        assert_eq!(recovery.claim.sources.len(), 2);
-    }
-
-    #[test]
     fn session_recorder_skips_unchanged_snapshots() {
         let directory = env::temp_dir().join(format!(
             "gridbash-session-dirty-test-{}-{}",
@@ -1698,7 +2267,10 @@ mod tests {
             started_at: now_seconds(),
             updated_at: now_seconds(),
             title: "Grid 1".into(),
+            active_tab: 0,
+            next_tab_number: 2,
             grid: GridSize::from_count(panes.len()).into(),
+            view: SavedView::default(),
             panes,
             background_panes: Vec::new(),
             tabs: Vec::new(),
@@ -1720,12 +2292,459 @@ mod tests {
             },
             cwd: PathBuf::from("."),
             folder_name: folder_name.into(),
+            name: None,
             worktree_name: None,
             auth_name: None,
             auth_kind: None,
+            sleeping: false,
             history: SavedPaneHistory::default(),
             codex_thread_id: None,
+            claude_session_id: None,
             host: None,
         }
+    }
+
+    fn grid(rows: usize, columns: usize) -> SavedGrid {
+        SavedGrid { rows, columns }
+    }
+
+    /// A grid keeps the size the user chose. Sizing it from the pane count is
+    /// what turned a 2x3 grid with four panes into a 2x2 one.
+    #[test]
+    fn saved_grid_dimensions_survive_a_partly_filled_grid() {
+        let panes = (0..4)
+            .map(|index| {
+                let mut pane = pane("fluent", "codex");
+                pane.index = index;
+                pane
+            })
+            .collect::<Vec<_>>();
+
+        let plan = launch_plan_from_saved("test", grid(2, 3), &panes).expect("launch plan");
+
+        assert_eq!(
+            plan.grid,
+            GridSize {
+                rows: 2,
+                columns: 3
+            }
+        );
+        assert_eq!(plan.panes.len(), 4);
+    }
+
+    /// Panes are placed by the cell they recorded, not by where they happen to
+    /// sit in the file.
+    #[test]
+    fn panes_are_restored_into_their_saved_cells() {
+        let mut third = pane("third", "codex");
+        third.index = 2;
+        let mut first = pane("first", "claude");
+        first.index = 0;
+        let mut second = pane("second", "git-bash");
+        second.index = 1;
+
+        let plan = launch_plan_from_saved("test", grid(1, 3), &[third, first, second])
+            .expect("launch plan");
+
+        assert_eq!(
+            plan.panes
+                .iter()
+                .map(|pane| pane.folder_name.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second", "third"]
+        );
+    }
+
+    /// The grid that was open goes back where it was, instead of being moved to
+    /// the front of the tab strip.
+    #[test]
+    fn tab_order_and_active_grid_round_trip() {
+        let mut session = recovery_session("order", vec![pane("middle", "codex")]);
+        session.title = "Middle".into();
+        session.active_tab = 1;
+        session.tabs = vec![
+            SavedTab {
+                title: "First".into(),
+                grid: grid(1, 1),
+                view: SavedView::default(),
+                panes: vec![pane("first", "codex")],
+            },
+            SavedTab {
+                title: "Last".into(),
+                grid: grid(1, 1),
+                view: SavedView::default(),
+                panes: vec![pane("last", "codex")],
+            },
+        ];
+
+        let (grids, active) = session.ordered_grids();
+
+        assert_eq!(
+            grids
+                .iter()
+                .map(|grid| grid.title.as_str())
+                .collect::<Vec<_>>(),
+            ["First", "Middle", "Last"]
+        );
+        assert_eq!(active, 1);
+    }
+
+    /// Pane names, sleeping panes, focus, zoom, and dragged dividers are part of
+    /// what "the same workspace" means.
+    #[test]
+    fn workspace_details_round_trip_through_toml() {
+        let mut named = pane("fluent", "codex");
+        named.name = Some("planner".into());
+        named.sleeping = true;
+        let mut session = recovery_session("details", vec![named, pane("fluent", "claude")]);
+        session.grid = grid(1, 2);
+        session.view = SavedView {
+            focus: 1,
+            zoomed: true,
+            row_weights: vec![1000],
+            column_weights: vec![1400, 600],
+        };
+
+        let raw = toml::to_string_pretty(&session).expect("serialize session");
+        let restored: SavedSession = toml::from_str(&raw).expect("parse session");
+
+        assert_eq!(restored.grid.rows, 1);
+        assert_eq!(restored.grid.columns, 2);
+        assert_eq!(restored.view, session.view);
+        assert_eq!(restored.panes[0].name.as_deref(), Some("planner"));
+        assert!(restored.panes[0].sleeping);
+        assert!(!restored.panes[1].sleeping);
+
+        let grid = restored.active_grid();
+        assert_eq!(grid.focus(), 1);
+        assert_eq!(grid.pane_names(), [Some("planner".into()), None]);
+        assert_eq!(grid.sleeping_panes(), BTreeSet::from([0]));
+    }
+
+    /// Recovery rebuilds the workspaces that were interrupted, rather than
+    /// pouring their panes into new folder-named grids.
+    #[test]
+    fn recovery_preserves_grid_sizes_names_and_positions() {
+        let mut first_pane = pane("alpha", "codex");
+        first_pane.name = Some("planner".into());
+        first_pane.history.output_tail = "first conversation".into();
+        let mut second_pane = pane("alpha", "claude");
+        second_pane.index = 1;
+
+        let mut first = recovery_session("first", vec![first_pane, second_pane]);
+        first.title = "Main".into();
+        first.grid = grid(2, 3);
+        first.active_tab = 1;
+        first.tabs = vec![SavedTab {
+            title: "Reviews".into(),
+            grid: grid(1, 2),
+            view: SavedView::default(),
+            panes: vec![pane("beta", "claude")],
+        }];
+        let mut second = recovery_session("second", vec![pane("gamma", "codex")]);
+        second.title = "Main".into();
+        second.grid = grid(1, 1);
+
+        let records = vec![
+            SessionRecord {
+                path: PathBuf::from("first.toml"),
+                session: first,
+            },
+            SessionRecord {
+                path: PathBuf::from("second.toml"),
+                session: second,
+            },
+        ];
+
+        let recovery = build_interrupted_recovery(&records).expect("recovery");
+
+        assert_eq!(recovery.session_count, 2);
+        assert_eq!(recovery.pane_count, 4);
+        // Grid names are kept, and the duplicate is numbered rather than renamed
+        // after its folder.
+        assert_eq!(
+            recovery
+                .tabs
+                .iter()
+                .map(|tab| tab.title.as_str())
+                .collect::<Vec<_>>(),
+            ["Reviews", "Main", "Main (2)"]
+        );
+        // Each grid keeps the size it had.
+        assert_eq!(recovery.tabs[0].grid.columns, 2);
+        assert_eq!(
+            (recovery.tabs[1].grid.rows, recovery.tabs[1].grid.columns),
+            (2, 3)
+        );
+        assert_eq!(recovery.tabs[2].grid.rows, 1);
+        // Recovery opens on the grid the crash interrupted.
+        assert_eq!(recovery.active_tab, 1);
+        assert_eq!(recovery.tabs[1].panes[0].name.as_deref(), Some("planner"));
+        assert_eq!(
+            recovery.tabs[1].panes[0].history.output_tail,
+            "first conversation"
+        );
+        assert_eq!(recovery.claim.sources.len(), 2);
+    }
+
+    /// Background panes were dropped entirely by recovery before.
+    #[test]
+    fn recovery_keeps_background_panes() {
+        let mut session = recovery_session("background", vec![pane("alpha", "codex")]);
+        session.background_panes.push(SavedBackgroundPane {
+            id: 7,
+            source_tab: "Main".into(),
+            name: Some("long build".into()),
+            pane: pane("alpha", "codex"),
+        });
+        let records = vec![SessionRecord {
+            path: PathBuf::from("background.toml"),
+            session,
+        }];
+
+        let recovery = build_interrupted_recovery(&records).expect("recovery");
+
+        assert_eq!(recovery.background_panes.len(), 1);
+        assert_eq!(recovery.background_panes[0].id, 7);
+        assert_eq!(recovery.pane_count, 2);
+    }
+
+    /// A Claude pane is pinned to a conversation at launch, which is what lets a
+    /// snapshot name it later.
+    #[test]
+    fn claude_panes_are_pinned_to_a_session_at_launch() {
+        let mut command = Profile {
+            command: "claude".into(),
+            args: vec!["--model".into(), "opus".into()],
+            title: Some("Claude".into()),
+            agent_kind: Some(AgentKind::Claude),
+        };
+
+        let session_id = pin_claude_session(&mut command).expect("pinned session");
+
+        assert!(looks_like_thread_id(&session_id), "{session_id}");
+        assert_eq!(
+            command.args,
+            ["--model", "opus", "--session-id", session_id.as_str()]
+        );
+        // Pinning is idempotent: relaunching the same pane keeps its conversation.
+        assert_eq!(
+            pin_claude_session(&mut command).as_deref(),
+            Some(session_id.as_str())
+        );
+        assert_eq!(command.args.len(), 4);
+    }
+
+    /// A conversation the user already chose is left alone.
+    #[test]
+    fn pinning_leaves_a_users_own_session_choice_alone() {
+        let mut continued = Profile {
+            command: "claude".into(),
+            args: vec!["--continue".into()],
+            title: None,
+            agent_kind: Some(AgentKind::Claude),
+        };
+        assert_eq!(pin_claude_session(&mut continued), None);
+        assert_eq!(continued.args, ["--continue"]);
+
+        let mut shell = Profile {
+            command: "bash".into(),
+            args: Vec::new(),
+            title: None,
+            agent_kind: None,
+        };
+        assert_eq!(pin_claude_session(&mut shell), None);
+        assert!(shell.args.is_empty());
+    }
+
+    /// Restoring a Claude pane resumes its conversation instead of asking Claude
+    /// to create a session id that already exists.
+    #[test]
+    fn saved_claude_session_relaunches_with_resume() {
+        let session_id = "019f7b81-de49-7782-8186-a3dc2c644c61";
+        let mut command = Profile {
+            command: "claude".into(),
+            args: vec!["--model".into(), "opus".into()],
+            title: Some("Claude".into()),
+            agent_kind: Some(AgentKind::Claude),
+        };
+        command
+            .args
+            .extend(["--session-id".into(), session_id.into()]);
+
+        let (profile_name, resumed) = claude_resume_profile("claude", &command, session_id);
+
+        assert_eq!(profile_name, "claude");
+        assert_eq!(resumed.args, ["--model", "opus", "--resume", session_id]);
+    }
+
+    /// A pane where the user started Claude in a shell is still preserved.
+    #[test]
+    fn extracts_claude_session_id_from_shell_history() {
+        let command = Profile {
+            command: "bash".into(),
+            args: Vec::new(),
+            title: Some("Git Bash".into()),
+            agent_kind: None,
+        };
+
+        assert_eq!(
+            claude_resume_id(
+                &command,
+                &["claude --resume 019f7b81-e2cd-71c1-84dd-9f09622cf74e".into()]
+            )
+            .as_deref(),
+            Some("019f7b81-e2cd-71c1-84dd-9f09622cf74e")
+        );
+        // An unrelated command that merely mentions a uuid is not a Claude
+        // conversation.
+        assert_eq!(
+            claude_resume_id(
+                &command,
+                &["git switch --resume 019f7b81-e2cd-71c1-84dd-9f09622cf74e".into()]
+            ),
+            None
+        );
+    }
+
+    /// A Claude conversation whose transcript is gone falls back to a plain
+    /// launch, because resuming a missing session leaves the pane with no agent.
+    #[test]
+    fn a_missing_claude_transcript_falls_back_to_a_plain_launch() {
+        let mut pane = pane("fluent", "claude");
+        pane.command.agent_kind = Some(AgentKind::Claude);
+        pane.command.command = "claude".into();
+        pane.claude_session_id = Some("019f7b81-0000-4000-8000-000000000000".into());
+
+        let launch = pane.launch_spec();
+
+        assert_eq!(launch.command.command, "claude");
+        assert!(launch.command.args.is_empty(), "{:?}", launch.command.args);
+        assert_eq!(pane.resumable_conversation(), None);
+    }
+
+    /// Snapshots written by older GridBash versions still load, with their newer
+    /// fields defaulted.
+    #[test]
+    fn version_one_snapshots_still_load() {
+        let raw = r#"
+version = 1
+id = "legacy"
+started_at = 1
+updated_at = 2
+title = "Grid 1"
+
+[grid]
+rows = 2
+columns = 3
+
+[[panes]]
+index = 0
+profile_name = "codex"
+cwd = "."
+folder_name = "fluent"
+
+[panes.command]
+command = "codex"
+"#;
+        let session: SavedSession = toml::from_str(raw).expect("parse legacy session");
+
+        assert!(is_supported_session(&session));
+        assert_eq!(session.active_tab, 0);
+        assert_eq!(session.view, SavedView::default());
+        assert!(session.panes[0].name.is_none());
+        let plan = session.active_grid().launch_plan().expect("launch plan");
+        assert_eq!(
+            plan.grid,
+            GridSize {
+                rows: 2,
+                columns: 3
+            }
+        );
+    }
+
+    /// Clearing a conversation starts a new one in the same pane, and that is
+    /// the conversation a resume has to reopen.
+    #[test]
+    fn a_pane_follows_the_conversation_it_moved_to() {
+        let directory = env::temp_dir().join(format!(
+            "gridbash-claude-follow-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let launched = "019f7b81-0000-4000-8000-00000000000a";
+        let cleared = "019f7b81-0000-4000-8000-00000000000b";
+        fs::write(directory.join(format!("{launched}.jsonl")), b"{}").expect("first transcript");
+        // File timestamps decide which conversation is current, so the second
+        // transcript has to land measurably later.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(directory.join(format!("{cleared}.jsonl")), b"{}").expect("second transcript");
+
+        let none_followed = BTreeSet::new();
+        assert_eq!(
+            latest_claude_session_in(&directory, Some(launched), None, &none_followed).as_deref(),
+            Some(cleared)
+        );
+        // A conversation another pane is already following is left to that pane.
+        let taken = BTreeSet::from([cleared.to_string()]);
+        assert_eq!(
+            latest_claude_session_in(&directory, Some(launched), None, &taken),
+            None
+        );
+        // A pane already on the newest conversation stays put.
+        assert_eq!(
+            latest_claude_session_in(&directory, Some(cleared), None, &none_followed),
+            None
+        );
+        // A transcript that predates the terminal belongs to an earlier run.
+        let after_everything = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_millis() as u64
+            + 60_000;
+        assert_eq!(
+            latest_claude_session_in(
+                &directory,
+                Some(launched),
+                Some(after_everything),
+                &none_followed
+            ),
+            None
+        );
+        let _ = fs::remove_dir_all(directory);
+    }
+
+    /// A snapshot damaged by a crash mid-write must not cost the workspace.
+    #[test]
+    fn a_damaged_snapshot_falls_back_to_its_backup() {
+        let directory = env::temp_dir().join(format!(
+            "gridbash-session-backup-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&directory).expect("create test directory");
+        let path = directory.join("session.toml");
+        let mut session = recovery_session("backup", vec![pane("alpha", "codex")]);
+        session.title = "Good".into();
+        save_session_to_path(&path, &session).expect("write first snapshot");
+
+        // A second write keeps the first as the backup.
+        session.title = "Newer".into();
+        save_session_to_path(&path, &session).expect("write second snapshot");
+        assert!(backup_path(&path).is_file());
+
+        fs::write(&path, b"version = 2\nid = \"trunc").expect("damage the snapshot");
+        let recovered = load_session_record(&path).expect("recover from backup");
+
+        assert_eq!(recovered.session.title, "Good");
+        assert_eq!(recovered.path, path);
+        let _ = fs::remove_dir_all(directory);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -246,8 +246,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         render_shell_command_center(frame, command_center_area, app, palette);
     }
 
-    let status_buttons =
-        render_status_bar(frame, status_area, &StatusBar::from_app(app), palette);
+    let status_buttons = render_status_bar(frame, status_area, &StatusBar::from_app(app), palette);
     let previous_panes_button = status_buttons.previous_panes;
     let pane_settings_button = status_buttons.pane_settings;
     let background_jobs_button = status_buttons.background_jobs;
@@ -397,11 +396,7 @@ fn tab_label(index: usize, tab: &TabLabel) -> String {
     } else {
         ""
     };
-    format!(
-        " {} {}{marker} ",
-        index + 1,
-        truncate_text(&tab.title, 18)
-    )
+    format!(" {} {}{marker} ", index + 1, truncate_text(&tab.title, 18))
 }
 
 fn tab_style(tab: &TabLabel, palette: &GridPalette) -> Style {
@@ -806,7 +801,11 @@ fn render_pane_frame(
         let leading = pane_header_leading(
             view,
             palette,
-            if fits { budget - trailing_width } else { budget },
+            if fits {
+                budget - trailing_width
+            } else {
+                budget
+            },
         );
         if fits {
             block = block.title_top(trailing.right_aligned());
@@ -1008,19 +1007,16 @@ fn render_status_bar(
         return StatusButtons::default();
     }
 
-    frame.render_widget(
-        Paragraph::new("").style(Style::default().bg(SURFACE)),
-        area,
-    );
+    frame.render_widget(Paragraph::new("").style(Style::default().bg(SURFACE)), area);
 
     let mut buttons = StatusButtons::default();
     let mut spans = vec![Span::styled(STATUS_BRAND, brand_style(palette))];
     let mut cursor = area.x.saturating_add(STATUS_BRAND.chars().count() as u16);
 
     let chip = |spans: &mut Vec<Span<'static>>,
-                    cursor: &mut u16,
-                    label: String,
-                    style: Style|
+                cursor: &mut u16,
+                label: String,
+                style: Style|
      -> Option<Rect> {
         let width = label.chars().count() as u16;
         let rect = (*cursor < area.right()).then(|| {
@@ -4732,32 +4728,61 @@ mod tests {
     }
 
     fn preview_panes() -> Vec<PreviewPane> {
-        let pane = |number: usize,
-                    label: &str,
-                    summary: &str,
-                    state: PaneState,
-                    body: &'static str| PreviewPane {
-            frame: PaneFrame {
-                number,
-                label: label.into(),
-                summary: summary.into(),
-                usage: Some("5h 80% left".into()),
-                state,
-                focused: number == 1,
-                selected: number == 4,
-                logging: number == 6,
-                compact: false,
-            },
-            body,
-        };
+        let pane =
+            |number: usize, label: &str, summary: &str, state: PaneState, body: &'static str| {
+                PreviewPane {
+                    frame: PaneFrame {
+                        number,
+                        label: label.into(),
+                        summary: summary.into(),
+                        usage: Some("5h 80% left".into()),
+                        state,
+                        focused: number == 1,
+                        selected: number == 4,
+                        logging: number == 6,
+                        compact: false,
+                    },
+                    body,
+                }
+            };
 
         vec![
-            pane(1, "api", "editing src/routes.rs", PaneState::Live, "$ cargo test"),
-            pane(2, "web", "waiting for review", PaneState::Waiting, "Continue? [y/N]"),
+            pane(
+                1,
+                "api",
+                "editing src/routes.rs",
+                PaneState::Live,
+                "$ cargo test",
+            ),
+            pane(
+                2,
+                "web",
+                "waiting for review",
+                PaneState::Waiting,
+                "Continue? [y/N]",
+            ),
             pane(3, "docs", "wrote the changelog", PaneState::Idle, "$ "),
-            pane(4, "infra", "terraform plan clean", PaneState::Live, "$ tf apply"),
-            pane(5, "tests", "3 failures remain", PaneState::Waiting, "FAILED 3"),
-            pane(6, "bench", "recording a trace", PaneState::Live, "sampling..."),
+            pane(
+                4,
+                "infra",
+                "terraform plan clean",
+                PaneState::Live,
+                "$ tf apply",
+            ),
+            pane(
+                5,
+                "tests",
+                "3 failures remain",
+                PaneState::Waiting,
+                "FAILED 3",
+            ),
+            pane(
+                6,
+                "bench",
+                "recording a trace",
+                PaneState::Live,
+                "sampling...",
+            ),
             pane(7, "spike", "paused by the user", PaneState::Sleeping, ""),
             pane(8, "old", "process exited", PaneState::Exited, "exit 130"),
             pane(9, "shell", "", PaneState::Live, "$ git status"),
@@ -4810,8 +4835,7 @@ mod tests {
                     let inner = render_pane_frame(frame, rect, &pane.frame, &palette);
                     if inner.width > 0 && inner.height > 0 {
                         frame.render_widget(
-                            Paragraph::new(pane.body)
-                                .style(Style::default().fg(TEXT).bg(APP_BG)),
+                            Paragraph::new(pane.body).style(Style::default().fg(TEXT).bg(APP_BG)),
                             inner,
                         );
                     }
@@ -5575,7 +5599,11 @@ mod tests {
                 let leading = pane_header_leading(
                     &view,
                     &GridPalette::default(),
-                    if fits { budget - trailing_width } else { budget },
+                    if fits {
+                        budget - trailing_width
+                    } else {
+                        budget
+                    },
                 );
 
                 let used = leading.width() as u16 + if fits { trailing_width } else { 0 };


### PR DESCRIPTION
Fixes #304.

Resuming a workspace rebuilt only part of it. This makes a resumed or recovered workspace match the one that closed — the terminals are new, but everything describing the workspace comes back.

## What was losing state

- **Grid dimensions were recomputed.** Crash recovery pooled panes by working directory and re-derived a size with `GridSize::from_count()`, so a 2x3 grid came back as 3x3 and grid names were replaced by folder names.
- **Claude panes recorded nothing.** Only `codex_thread_id` was saved, so Claude panes restored as bare shells showing old scrollback.
- **Tab order was lost.** The active grid was stored apart from the rest, so every resume pulled it to the front of the tab strip.
- **Never saved at all:** pane names, sleeping panes, focus, zoom, dragged divider weights. Recovery also dropped background panes.

## Changes

- **Snapshot format v2** records the missing state. Version 1 snapshots still load with the new fields defaulted.
- **Saved grid dimensions are used verbatim** — a 2x3 grid holding four panes returns 2x3 with two empty cells, and panes are placed by the cell they recorded rather than by file order.
- **Recovery carries each interrupted workspace's grids over unchanged**, keeps background panes, and opens on the grid that was interrupted. Duplicate grid names across merged workspaces are numbered rather than renamed after a folder.
- **Claude conversations are pinned at launch** with `--session-id`, so a snapshot names one exactly even with several Claude panes in one folder. Restores use `claude --resume` after checking the transcript still exists, falling back to a plain launch when it does not. Panes are re-checked periodically, so one that clears its conversation is followed onto the new one.
- **Durable snapshots:** contents are flushed to disk before the rename publishes them, the previous copy is kept as a `.bak`, and loading falls back to it when the primary is unreadable.
- **Shape changes save immediately** instead of waiting for the autosave tick, and a drop guard saves state a panic outside the event loop's firewall would otherwise take with it.
- **Resume picker** lists every grid with the size it will be rebuilt at, and `Tab` walks a positional map showing each pane in its cell with its name and a mark for conversations that resume.

## Validation

- `cargo test` (371 passed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, release build.
- New regression tests: grid-dimension preservation, cell placement, tab order and active grid, recovery fidelity, background-pane retention, Claude pinning/resume/fallback/follow-on, version 1 migration, backup fallback.
- `gridbash resume --list` read this machine's existing version 1 snapshots from both the debug and release binaries.