### PR TITLE
fix: keep a sliver pane from killing its agent on resume

### DIFF
--- a/docs/devlogs/2026-07-31-keep-a-sliver-pane-from-killing-its-agent.md
+++ b/docs/devlogs/2026-07-31-keep-a-sliver-pane-from-killing-its-agent.md
@@ -1,0 +1,51 @@
+# Keep a sliver pane from killing its agent on resume
+
+Date: 2026-07-31
+Release target: unreleased
+
+## Summary
+
+- A restored pane too narrow to hold a terminal crashed its pane host the moment
+  an agent drew a wide character, killing the agent and leaving a bare shell
+  wearing the dead agent's scrollback.
+- One Claude conversation could also be saved against two panes, which resumed
+  it twice and left the losing pane in the same state.
+
+## What Changed
+
+- Clamp every pane to at least two rows and two columns, in the view, the PTY,
+  and the pane-host wire protocol, so the three never disagree about the size a
+  parser is holding.
+- Resolve Claude conversation ownership when a workspace is saved: a pane that
+  pinned its conversation at launch owns it, a pane that only mentions one in
+  its typed history yields, and the first claimant keeps it.
+- Apply the same rule when a snapshot is loaded, because snapshots written
+  before this change already name one conversation on two panes.
+
+## Why It Matters
+
+- vt100 cannot place a double-width character in a one-row or one-column grid:
+  `col_wrap` computes `cols - width` as `1 - 2`, underflows, and then panics on
+  the cell that should hold the character's second half. Panes were clamped to
+  `1x1`, so any emoji or CJK character in replayed output took the host down.
+  Restored grids reach sliver widths far more often than live ones, which is why
+  this surfaced as a resume failure.
+- Resuming one conversation twice starts a second Claude that exits immediately,
+  so a pane that looked recovered was a plain shell showing replayed text.
+
+## Validation
+
+- `cargo test --bin gridbash -- --test-threads=1`: 388 passed, 5 ignored.
+- `cargo clippy --bin gridbash --all-targets -- -D warnings` and
+  `cargo fmt --check` are clean.
+- `tiny_panes_survive_wide_characters` was confirmed to fail with the clamp
+  lowered to one row and column, reproducing the reported panic, and to pass
+  with it restored.
+- A standalone sweep over vt100 established two rows by two columns as the
+  smallest safe grid: 22,000 mixed narrow, CJK, and emoji inputs at or above
+  that size produced no panic, and every size below it did.
+
+## Release Notes
+
+- Panes restored into a very small cell no longer take their agent down.
+- A Claude conversation is never resumed into two panes at once.

--- a/src/app.rs
+++ b/src/app.rs
@@ -51,7 +51,7 @@ use crate::{
     ports::{self, AgentPort, AgentProcessRoot},
     process_priority::PaneWorkloadClass,
     profiles::{default_profile_name, find_profile, is_terminal_profile, startup_profiles},
-    pty::{PtyEvent, PtyWriteToken},
+    pty::{PtyEvent, PtyWriteToken, clamp_pane_size},
     session::{
         InterruptedRecovery, InterruptedRecoveryClaim, LiveGrid, LiveWorkspace,
         SavedBackgroundPane, SavedPane, SavedPaneHistory, SavedTab, SavedView, SessionRecord,
@@ -10718,8 +10718,11 @@ impl App {
                 continue;
             };
 
-            let rows = rect.height.saturating_sub(2).max(1);
-            let cols = rect.width.saturating_sub(2).max(1);
+            // A restored grid can put a pane in a rect too small to hold a
+            // terminal at all. It gets the smallest usable size instead, which
+            // renders as a sliver but keeps its agent alive.
+            let (rows, cols) =
+                clamp_pane_size(rect.height.saturating_sub(2), rect.width.saturating_sub(2));
             if let Err(error) = pane.resize(rows, cols) {
                 self.status = format!("resize failed: {error:#}");
             }

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -28,7 +28,7 @@ use crate::{
     config::{PaneProcessPriority, PaneWorkloadPolicy},
     layout::PaneId,
     process_priority::PaneWorkloadClass,
-    pty::{PtyEvent, PtyPane as LocalPtyPane, PtyView, PtyWriteToken},
+    pty::{PtyEvent, PtyPane as LocalPtyPane, PtyView, PtyWriteToken, clamp_pane_size},
     session::process_is_running,
 };
 
@@ -624,6 +624,10 @@ impl PtyPane {
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
+        // Clamped before it goes over the wire so the host's parser and this
+        // one stay the same size, and so an old client cannot ask a host for a
+        // size that would panic it.
+        let (rows, cols) = clamp_pane_size(rows, cols);
         if !self.view.resize_view(rows, cols) {
             return Ok(());
         }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -38,6 +38,17 @@ const OUTPUT_TAIL_TRIM_AT_CHARS: usize = 48_000;
 const MAX_REPLAY_OUTPUT_CHARS: usize = 18_000;
 const MAX_OSC_SCAN: usize = 4096;
 const PTY_READ_BUFFER_BYTES: usize = 32 * 1024;
+
+/// Smallest grid a pane may be given.
+///
+/// A one-row or one-column terminal cannot hold a double-width character, and
+/// vt100 does not defend itself there: writing a wide character to such a grid
+/// underflows its column arithmetic and then panics on the cell that should
+/// hold the character's second half. That kills the pane host, so the agent it
+/// was running dies with it. Nothing about a two-by-two pane is useful to look
+/// at, but it keeps a sliver of a pane from taking an agent down.
+pub(crate) const MIN_PANE_ROWS: u16 = 2;
+pub(crate) const MIN_PANE_COLS: u16 = 2;
 const PTY_WRITE_QUEUE_MESSAGES: usize = 256;
 /// PTY reader/writer threads only shuttle bytes between a pipe and a channel,
 /// so the platform default stack (1 MiB on Windows, 8 MiB on glibc) is reserved
@@ -46,6 +57,11 @@ const PTY_WORKER_STACK_BYTES: usize = 128 * 1024;
 const CHILD_REAP_GRACE: Duration = Duration::from_millis(100);
 const CHILD_REAP_AFTER_FORCE: Duration = Duration::from_millis(400);
 const CHILD_REAP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Pane size that is safe to hand to a terminal parser.
+pub(crate) fn clamp_pane_size(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.max(MIN_PANE_ROWS), cols.max(MIN_PANE_COLS))
+}
 
 #[derive(Debug, Clone)]
 pub enum PtyEvent {
@@ -410,6 +426,10 @@ impl PtyView {
     }
 
     pub(crate) fn resize_view(&mut self, rows: u16, cols: u16) -> bool {
+        // Every caller is expected to have clamped already. Clamping again here
+        // keeps a parser from ever seeing a size that would panic it, whichever
+        // path the size arrived by.
+        let (rows, cols) = clamp_pane_size(rows, cols);
         if self.rows == rows && self.cols == cols {
             return false;
         }
@@ -664,6 +684,9 @@ impl PtyPane {
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) -> Result<()> {
+        // Clamped before the view so the process is told the same size the
+        // parser is holding, rather than a size the parser refused.
+        let (rows, cols) = clamp_pane_size(rows, cols);
         if !self.view.resize_view(rows, cols) {
             return Ok(());
         }
@@ -1872,6 +1895,46 @@ mod tests {
 
         assert_eq!(screen_history_lines(parser.screen_mut()), [""]);
         assert_eq!(parser.screen().scrollback(), 0);
+    }
+
+    /// A pane squeezed into a sliver of a restored grid still has to survive
+    /// the agent output replayed into it. Wide characters are the dangerous
+    /// case: at one row or one column vt100 panics on them, which used to take
+    /// the pane host and its agent down and leave a bare shell behind.
+    #[test]
+    fn tiny_panes_survive_wide_characters() {
+        for rows in 0..=3u16 {
+            for cols in 0..=3u16 {
+                let mut view = PtyView::new(PathBuf::from("."), 1_000);
+                view.resize_view(rows, cols);
+
+                let (held_rows, held_cols) = view.parser.screen().size();
+                assert!(
+                    held_rows >= MIN_PANE_ROWS,
+                    "{rows}x{cols} kept {held_rows} rows"
+                );
+                assert!(
+                    held_cols >= MIN_PANE_COLS,
+                    "{rows}x{cols} kept {held_cols} cols"
+                );
+
+                // Box drawing, CJK, and emoji all reach a pane by way of an
+                // agent's own interface.
+                view.parser.process("┌─┐\r\n日本語\r\n😀😀😀".as_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn resizing_below_the_minimum_reports_a_change_only_once() {
+        let mut view = PtyView::new(PathBuf::from("."), 1_000);
+        view.resize_view(24, 80);
+
+        assert!(view.resize_view(0, 0), "clamped size differs from 24x80");
+        assert!(
+            !view.resize_view(1, 1),
+            "1x1 clamps to the size already held"
+        );
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -424,9 +424,11 @@ fn launch_plan_from_saved(
             saved_grid.columns
         )
     })?;
-    let panes = ordered_panes(panes)
+    let ordered = ordered_panes(panes);
+    let panes = claimed_claude_sessions(&ordered)
         .into_iter()
-        .map(SavedPane::launch_spec)
+        .zip(&ordered)
+        .map(|(claude_session_id, pane)| pane.launch_spec_resuming(claude_session_id))
         .collect::<Vec<_>>();
     if panes.is_empty() {
         bail!("saved session {id} has no panes");
@@ -449,6 +451,26 @@ fn launch_plan_from_saved(
     Ok(LaunchPlan { panes, grid })
 }
 
+/// Conversation each saved pane resumes into.
+///
+/// Snapshots written before duplicates were prevented can name one Claude
+/// conversation on two panes, and one of those is on disk for every workspace
+/// that has already been resumed once. Resuming a conversation twice starts a
+/// second Claude that exits on the spot, leaving a bare shell wearing the
+/// scrollback of the agent that used to be there. The first pane in grid order
+/// keeps the conversation; the rest come back as a fresh agent in their folder.
+fn claimed_claude_sessions<'a>(panes: &[&'a SavedPane]) -> Vec<Option<&'a str>> {
+    let mut claimed = BTreeSet::new();
+    panes
+        .iter()
+        .map(|pane| {
+            pane.claude_session_id
+                .as_deref()
+                .filter(|session_id| claimed.insert(*session_id))
+        })
+        .collect()
+}
+
 /// Panes in grid order, so a snapshot written out of order still restores every
 /// pane to the cell it occupied.
 fn ordered_panes(panes: &[SavedPane]) -> Vec<&SavedPane> {
@@ -464,6 +486,7 @@ fn saved_panes_from_live(live: &LiveGrid<'_>) -> Vec<SavedPane> {
         .filter_map(PtyPane::host_process_id)
         .collect::<Vec<_>>();
     let codex_roots = roots_with_descendant_named(&host_processes, "codex").ok();
+    let claude_sessions = claude_sessions_from_live(live);
     live.plan
         .panes
         .iter()
@@ -485,7 +508,7 @@ fn saved_panes_from_live(live: &LiveGrid<'_>) -> Vec<SavedPane> {
                         .or_else(|| pane.and_then(|pane| pane.codex_thread_id(pane.cwd())))
                 })
                 .flatten();
-            let claude_session_id = claude_session_from_live(spec, pane, &history.input_history);
+            let claude_session_id = claude_sessions.get(index).cloned().flatten();
             let mut saved = SavedPane::from_spec(
                 index,
                 spec,
@@ -510,24 +533,88 @@ fn saved_panes_from_live(live: &LiveGrid<'_>) -> Vec<SavedPane> {
         .collect()
 }
 
-/// Claude conversation a live pane is attached to.
+/// Claude conversation each pane is attached to, with no conversation claimed
+/// by two panes.
 ///
-/// A pane GridBash launched carries the id it pinned at spawn, which cannot be
-/// confused by a sibling pane in the same directory. A pane where the user
-/// started Claude themselves is read back out of what they typed.
-fn claude_session_from_live(
-    spec: &PaneLaunchSpec,
-    pane: Option<&PtyPane>,
-    input_history: &[String],
-) -> Option<String> {
-    pane.and_then(PtyPane::agent_session_id)
-        .map(str::to_string)
-        .or_else(|| claude_resume_id(&spec.command, input_history))
+/// A pane GridBash launched carries the id it pinned at spawn and owns it. A
+/// pane where the user started Claude themselves is read back out of what they
+/// typed, which goes stale as soon as that conversation is picked up somewhere
+/// else — typing `claude --resume` in a second pane leaves the id in both
+/// histories.
+///
+/// Saving one conversation against two panes resumes it twice. Claude refuses
+/// the second, that pane exits immediately, and it comes back as a bare shell
+/// wearing the scrollback of the agent that used to be there. A pane that
+/// cannot prove it owns a conversation is saved without one instead, so it
+/// resumes as a fresh Claude in the right folder.
+fn claude_sessions_from_live(live: &LiveGrid<'_>) -> Vec<Option<String>> {
+    let claims = live
+        .plan
+        .panes
+        .iter()
+        .enumerate()
+        .map(|(index, spec)| {
+            let pane = live.panes.get(index);
+            ClaudeSessionClaim {
+                pinned: pane.and_then(PtyPane::agent_session_id).map(str::to_string),
+                mentioned: claude_resume_id(
+                    &spec.command,
+                    pane.map(PtyPane::input_history).unwrap_or_default(),
+                ),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    resolve_claude_sessions(&claims)
+}
+
+/// What a pane knows about the conversation it is in: the id it pinned when
+/// GridBash launched it, and any id its command or the user's typing mentions.
+#[derive(Debug, Default, Clone)]
+struct ClaudeSessionClaim {
+    pinned: Option<String>,
+    mentioned: Option<String>,
+}
+
+/// Settle which pane resumes which conversation.
+///
+/// Pinned beats mentioned, and the first claimant of a conversation keeps it.
+/// Everything else is saved without a conversation and resumes as a fresh
+/// Claude in the same folder.
+fn resolve_claude_sessions(claims: &[ClaudeSessionClaim]) -> Vec<Option<String>> {
+    let pinned = claims
+        .iter()
+        .filter_map(|claim| claim.pinned.clone())
+        .collect::<BTreeSet<_>>();
+
+    let mut claimed = BTreeSet::new();
+    claims
+        .iter()
+        .map(|claim| {
+            let session_id = match &claim.pinned {
+                Some(pinned_here) => pinned_here.clone(),
+                None => claim
+                    .mentioned
+                    .clone()
+                    // A conversation some other pane pinned belongs to that
+                    // pane, however this one came to mention it.
+                    .filter(|session_id| !pinned.contains(session_id))?,
+            };
+
+            claimed.insert(session_id.clone()).then_some(session_id)
+        })
+        .collect()
 }
 
 impl SavedPane {
     pub fn launch_spec(&self) -> PaneLaunchSpec {
-        let (profile_name, command) = self.resume_command();
+        self.launch_spec_resuming(self.claude_session_id.as_deref())
+    }
+
+    /// Launch spec for a pane put back into a named conversation, or into none
+    /// when another pane is already resuming the one it recorded.
+    fn launch_spec_resuming(&self, claude_session_id: Option<&str>) -> PaneLaunchSpec {
+        let (profile_name, command) = self.resume_command(claude_session_id);
         self.spec_for(profile_name, command)
     }
 
@@ -563,11 +650,11 @@ impl SavedPane {
     /// A Claude transcript that is no longer on disk falls back to a plain
     /// launch, because `claude --resume` on a missing session fails outright and
     /// would leave the pane with no agent at all.
-    fn resume_command(&self) -> (String, Profile) {
+    fn resume_command(&self, claude_session_id: Option<&str>) -> (String, Profile) {
         if let Some(thread_id) = self.codex_thread_id.as_deref() {
             return codex_resume_profile(&self.profile_name, &self.command, thread_id);
         }
-        if let Some(session_id) = self.claude_session_id.as_deref()
+        if let Some(session_id) = claude_session_id
             && claude_session_exists(&self.cwd, session_id)
         {
             return claude_resume_profile(&self.profile_name, &self.command, session_id);
@@ -2621,6 +2708,102 @@ mod tests {
         assert_eq!(launch.command.command, "claude");
         assert!(launch.command.args.is_empty(), "{:?}", launch.command.args);
         assert_eq!(pane.resumable_conversation(), None);
+    }
+
+    fn pinned_claim(session_id: &str) -> ClaudeSessionClaim {
+        ClaudeSessionClaim {
+            pinned: Some(session_id.into()),
+            mentioned: Some(session_id.into()),
+        }
+    }
+
+    fn mentioned_claim(session_id: &str) -> ClaudeSessionClaim {
+        ClaudeSessionClaim {
+            pinned: None,
+            mentioned: Some(session_id.into()),
+        }
+    }
+
+    /// Resuming one conversation in two panes starts a second Claude that
+    /// exits on the spot, leaving a bare shell showing the previous agent's
+    /// scrollback. The pane that pinned it keeps it.
+    #[test]
+    fn one_conversation_is_never_saved_against_two_panes() {
+        let sessions = resolve_claude_sessions(&[
+            mentioned_claim("880714ff-e26d-4159-b36a-06d258a7d484"),
+            pinned_claim("880714ff-e26d-4159-b36a-06d258a7d484"),
+            pinned_claim("eb2c3542-edc3-4f6a-8c7c-9210b58603a1"),
+        ]);
+
+        assert_eq!(
+            sessions,
+            [
+                None,
+                Some("880714ff-e26d-4159-b36a-06d258a7d484".into()),
+                Some("eb2c3542-edc3-4f6a-8c7c-9210b58603a1".into()),
+            ]
+        );
+    }
+
+    /// Two shells that both had `claude --resume` typed into them cannot both
+    /// be in that conversation. The first keeps it.
+    #[test]
+    fn duplicate_mentions_are_resolved_in_pane_order() {
+        let sessions = resolve_claude_sessions(&[
+            mentioned_claim("76686a4e-df81-488c-b4e3-25f2300d8acb"),
+            mentioned_claim("76686a4e-df81-488c-b4e3-25f2300d8acb"),
+        ]);
+
+        assert_eq!(
+            sessions,
+            [Some("76686a4e-df81-488c-b4e3-25f2300d8acb".into()), None]
+        );
+    }
+
+    /// Panes that pin their own conversations are all preserved, and a pane in
+    /// no conversation stays that way.
+    #[test]
+    fn distinct_conversations_are_all_preserved() {
+        let sessions = resolve_claude_sessions(&[
+            pinned_claim("9e3eb587-72f5-46a1-8207-82319235666b"),
+            ClaudeSessionClaim::default(),
+            mentioned_claim("1cc9882b-fa28-44b4-b756-546815bf2033"),
+        ]);
+
+        assert_eq!(
+            sessions,
+            [
+                Some("9e3eb587-72f5-46a1-8207-82319235666b".into()),
+                None,
+                Some("1cc9882b-fa28-44b4-b756-546815bf2033".into()),
+            ]
+        );
+    }
+
+    /// The snapshots already on disk carry duplicates, because they were
+    /// written before duplicates were prevented. Loading one must not resume a
+    /// conversation twice.
+    #[test]
+    fn a_snapshot_naming_one_conversation_twice_resumes_it_once() {
+        let mut first = pane("kaggle", "claude");
+        first.claude_session_id = Some("880714ff-e26d-4159-b36a-06d258a7d484".into());
+        let mut second = pane("kaggle", "git-bash");
+        second.claude_session_id = Some("880714ff-e26d-4159-b36a-06d258a7d484".into());
+        let mut third = pane("kaggle", "claude");
+        third.claude_session_id = Some("eb2c3542-edc3-4f6a-8c7c-9210b58603a1".into());
+        let plain = pane("kaggle", "git-bash");
+
+        let claimed = claimed_claude_sessions(&[&first, &second, &third, &plain]);
+
+        assert_eq!(
+            claimed,
+            [
+                Some("880714ff-e26d-4159-b36a-06d258a7d484"),
+                None,
+                Some("eb2c3542-edc3-4f6a-8c7c-9210b58603a1"),
+                None,
+            ]
+        );
     }
 
     /// Snapshots written by older GridBash versions still load, with their newer


### PR DESCRIPTION
## Problem

Resuming a workspace brought Claude panes back as plain shells showing the replayed scrollback of the agent that used to be there. A pane host crash log written during the resume:

```
kind: panic   role: pane-host
location: vt100-0.16.2/src/screen.rs:870:22
message: called `Option::unwrap()` on a `None` value
```

The pane host owns the PTY, so when it died the agent died with it, and the pane was restored as a shell.

Panes were clamped to a minimum of `1x1`. vt100 cannot place a double-width character in a one-row or one-column grid: `col_wrap` computes `cols - width` as `1 - 2`, underflows a `u16`, and then panics on the cell that should hold the character's second half. Emoji, box drawing and CJK all reach a pane through an agent's own interface, so a sliver of a pane was enough to kill one. Restored grids reach sliver widths far more often than live ones, which is why this surfaced as a resume failure.

Separately, one Claude conversation could be saved against two panes. Both resume it, the second Claude exits on the spot, and that pane ends up in the same bare-shell state. Snapshots already on disk carry these duplicates.

## Changes

- Clamp every pane to at least two rows and two columns, in `PtyView::resize_view`, `PtyPane::resize`, and `PaneHost::resize`, so the view, the PTY, and the wire cannot disagree about the size a parser is holding. `sync_pane_sizes` uses the same clamp instead of `.max(1)`.
- Settle Claude conversation ownership when a workspace is saved: a pane that pinned its conversation at launch owns it, a pane that only mentions one in typed history yields, and the first claimant keeps it.
- Apply the same rule when a snapshot is loaded, so existing snapshots stop resuming one conversation twice.

## Validation

- `cargo test --bin gridbash -- --test-threads=1`: **388 passed, 5 ignored**.
- `cargo clippy --bin gridbash --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `cargo build --release`: clean.
- `tiny_panes_survive_wide_characters` was confirmed to reproduce the reported panic with the clamp lowered to one row and column, and to pass with it restored.
- A standalone sweep over vt100 established two-by-two as the smallest safe grid: every size below it panicked, and 22,000 mixed narrow, CJK, and emoji inputs at or above it did not.

Note: the first parallel test run showed the known `pane_host` lock-poisoning flake (one real timing failure plus two poisoned-mutex cascades). All 14 `pane_host` tests pass serially.