### PR TITLE
fix: stop routine failures from evicting crash reports

### DIFF
--- a/docs/devlogs/2026-07-31-protect-crash-report-evidence.md
+++ b/docs/devlogs/2026-07-31-protect-crash-report-evidence.md
@@ -1,0 +1,46 @@
+# Stop routine failures from evicting crash reports
+
+Date: 2026-07-31
+Release target: unreleased
+
+## Summary
+
+- The crash report directory holds a fixed number of reports, and almost
+  everything in it was something other than a crash.
+
+## What Changed
+
+- `GRIDBASH_LOGS_DIR` overrides the report directory, and a test binary
+  redirects itself to a temporary one instead of writing to the real directory.
+- Each entry point reports under its own role rather than all reporting as the
+  interface.
+- One-shot control commands no longer record ordinary usage errors as error
+  exits. A panic in them is still recorded.
+- Pruning drops routine reports before panic reports.
+
+## Why It Matters
+
+- The worker recovery test records a recovered panic every time it runs, and
+  forty three of those had collected in a directory that holds fifty. A real
+  panic report was a few test runs away from being pruned, and the panic that
+  was investigated this week nearly was.
+- A control command naming a pane that no longer exists wrote an error-exit
+  report filed as a crash of a TUI that was never running. Agent panes address
+  each other by pane number, so a stale one quietly evicted real reports.
+- A panic report is the only record that survives the process. Everything else
+  in the directory can be reconstructed from somewhere, so nothing else should
+  be able to push a panic out.
+
+## Validation
+
+- `cargo test --bin gridbash -- --test-threads=1`: 392 passed, 5 ignored.
+- `cargo clippy --bin gridbash --all-targets -- -D warnings` and
+  `cargo fmt --check` are clean.
+- Confirmed against the real directory: a full test run left its file count and
+  newest timestamp unchanged, and the reports it produced landed in the
+  temporary directory instead.
+
+## Release Notes
+
+- Crash reports are no longer crowded out by recovered failures, control
+  command usage errors, or test runs.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -87,7 +87,22 @@ pub fn recovering<T>(label: &str, work: impl FnOnce() -> Result<T, String>) -> R
     }
 }
 
+/// Directory reports are written to.
+///
+/// `GRIDBASH_LOGS_DIR` overrides it. A test binary redirects itself, because a
+/// test that writes a report into the real directory does not just leave litter
+/// there: reports are pruned to a fixed count, so a test run repeated often
+/// enough evicts the user's genuine crash evidence before anyone reads it.
 pub fn logs_dir() -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("GRIDBASH_LOGS_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        return Some(configured);
+    }
+    if cfg!(test) {
+        return Some(std::env::temp_dir().join("gridbash-test-logs"));
+    }
     ProjectDirs::from("", "", "GridBash").map(|dirs| dirs.data_local_dir().join("logs"))
 }
 
@@ -209,6 +224,13 @@ fn write_report(kind: &str, role: &str, report: &str) {
     prune_reports(&directory);
 }
 
+/// Drop the oldest reports once the directory is full, taking everything else
+/// before a panic report.
+///
+/// A panic is the report that cannot be reconstructed: the process is gone and
+/// nothing else recorded why. Recovered failures and error exits are far more
+/// numerous and far less valuable, so a burst of them must not push the one
+/// panic worth reading out of the directory.
 fn prune_reports(directory: &Path) {
     let Ok(entries) = fs::read_dir(directory) else {
         return;
@@ -218,7 +240,7 @@ fn prune_reports(directory: &Path) {
         .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
         .filter_map(|entry| {
             let modified = entry.metadata().ok()?.modified().ok()?;
-            Some((modified, entry.path()))
+            Some((is_panic_report(&entry.path()), modified, entry.path()))
         })
         .collect::<Vec<_>>();
     let Some(excess) = reports
@@ -228,10 +250,16 @@ fn prune_reports(directory: &Path) {
     else {
         return;
     };
-    reports.sort_by_key(|(modified, _)| *modified);
-    for (_, path) in reports.into_iter().take(excess) {
+    reports.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)));
+    for (_, _, path) in reports.into_iter().take(excess) {
         let _ = fs::remove_file(path);
     }
+}
+
+fn is_panic_report(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("panic-"))
 }
 
 #[cfg(test)]
@@ -331,6 +359,61 @@ mod tests {
         assert!(
             !panics_are_shielded(),
             "unwinding out of the guard must lift the shield"
+        );
+    }
+
+    /// A panic report is the only evidence that a crash happened at all, so a
+    /// flood of routine reports must not be able to push one out.
+    #[test]
+    fn pruning_takes_routine_reports_before_panics() {
+        let directory = std::env::temp_dir().join(format!("gridbash-kinds-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&directory);
+        fs::create_dir_all(&directory).expect("create log directory");
+        for index in 0..5 {
+            fs::write(directory.join(format!("panic-tui-{index:04}.log")), b"x")
+                .expect("write panic report");
+        }
+        for index in 0..MAX_REPORTS + 10 {
+            fs::write(
+                directory.join(format!("recovered-tui-{index:04}.log")),
+                b"x",
+            )
+            .expect("write recovered report");
+        }
+
+        prune_reports(&directory);
+
+        let remaining = fs::read_dir(&directory)
+            .expect("read log directory")
+            .flatten()
+            .filter_map(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .map(|name| name.starts_with("panic-"))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(remaining.len(), MAX_REPORTS);
+        assert_eq!(
+            remaining.iter().filter(|is_panic| **is_panic).count(),
+            5,
+            "every panic report must survive"
+        );
+        let _ = fs::remove_dir_all(&directory);
+    }
+
+    /// A test binary that writes into the real diagnostics directory prunes the
+    /// user's genuine crash reports out of it.
+    #[test]
+    fn a_test_binary_never_writes_to_the_real_diagnostics_directory() {
+        let directory = logs_dir().expect("log directory");
+
+        let real = ProjectDirs::from("", "", "GridBash")
+            .map(|dirs| dirs.data_local_dir().join("logs"))
+            .expect("real log directory");
+        assert_ne!(
+            directory, real,
+            "tests must be redirected away from {real:?}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,14 +45,44 @@ fn main() -> Result<()> {
 
     // Installed before anything else can fail so the crash report survives the
     // terminal. App::run chains its terminal-restoring hook onto this one.
-    let role = if cli.pane_host.is_some() {
-        "pane-host"
-    } else {
-        "tui"
-    };
+    let role = diagnostics_role(&cli);
     diagnostics::install_panic_logger(role);
 
-    run(cli).inspect_err(|error| diagnostics::record_error_exit(role, error))
+    let result = run(cli);
+    if let Err(error) = &result
+        && records_error_exits(role)
+    {
+        diagnostics::record_error_exit(role, error);
+    }
+    result
+}
+
+/// What this process is, for crash reports.
+fn diagnostics_role(cli: &Cli) -> &'static str {
+    if cli.pane_host.is_some() {
+        return "pane-host";
+    }
+    if cli.mcp {
+        return "mcp";
+    }
+    match cli.command {
+        Some(Command::Agent(_)) => "agent",
+        Some(Command::Ctl(_)) => "ctl",
+        _ => "tui",
+    }
+}
+
+/// Whether a non-zero exit from this role is crash evidence.
+///
+/// A one-shot control command reports its own failure to a terminal the user is
+/// still looking at, so naming a pane that no longer exists is an ordinary
+/// usage error rather than something to record. Writing those would be actively
+/// harmful: reports are pruned to a fixed count, and agent panes address each
+/// other by pane number often enough that a stale one would keep evicting real
+/// reports. A panic in the same command is still recorded, because that is a
+/// defect wherever it happens.
+fn records_error_exits(role: &str) -> bool {
+    !matches!(role, "agent" | "ctl")
 }
 
 fn run(cli: Cli) -> Result<()> {
@@ -130,4 +160,36 @@ fn run(cli: Cli) -> Result<()> {
 
     let mut app = App::new(cli, config)?;
     app.run()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn role_for(args: &[&str]) -> &'static str {
+        diagnostics_role(&Cli::parse_from(args))
+    }
+
+    /// Reports are labelled by what the process actually was, so a control
+    /// command's failure is not filed as a crash of the interface.
+    #[test]
+    fn each_entry_point_reports_under_its_own_role() {
+        assert_eq!(role_for(&["gridbash"]), "tui");
+        assert_eq!(role_for(&["gridbash", "resume", "--latest"]), "tui");
+        assert_eq!(role_for(&["gridbash", "--mcp"]), "mcp");
+        assert_eq!(role_for(&["gridbash", "agent", "panes"]), "agent");
+        assert_eq!(role_for(&["gridbash", "ctl", "list"]), "ctl");
+    }
+
+    /// A mistyped pane number in an agent pane is an ordinary usage error. It
+    /// used to write a crash report, and reports are pruned to a fixed count,
+    /// so repeating it evicted real evidence.
+    #[test]
+    fn one_shot_control_commands_do_not_record_error_exits() {
+        assert!(!records_error_exits("agent"));
+        assert!(!records_error_exits("ctl"));
+        assert!(records_error_exits("tui"));
+        assert!(records_error_exits("pane-host"));
+        assert!(records_error_exits("mcp"));
+    }
 }


### PR DESCRIPTION
## Problem

Crash reports are the only evidence that survives GridBash exiting, and the directory keeps a fixed 50. Almost everything in the real directory was something other than a crash:

```
43  recovered | worker exploded                     <- written by the test suite
 2  recovered | Insufficient system resources ...
 2  error-exit | pane-14 is not available in this session
 1  panic     | called `Option::unwrap()` on a `None` value
```

Two sources were filling it:

1. **Test runs wrote into the real directory.** `a_panicking_worker_reports_an_error_instead_of_going_silent` calls `diagnostics::recovering`, which records a recovered panic on every run and never cleans up. 43 had accumulated in a directory that holds 50, so a genuine panic report was a few test runs from being pruned. The panic investigated in #307 nearly was.

2. **Every entry point reported as `tui`.** A one-shot `gridbash agent` / `gridbash ctl` command naming a pane that no longer exists wrote an error-exit report, filed as a crash of an interface that was never running. Agent panes address each other by pane number, so a stale number quietly evicted real reports.

## Changes

- `logs_dir()` honours `GRIDBASH_LOGS_DIR`, and a test binary redirects itself to a temporary directory.
- `diagnostics_role()` labels each entry point (`tui`, `pane-host`, `mcp`, `agent`, `ctl`).
- One-shot control commands no longer record error exits. A panic in them is still recorded, because that is a defect wherever it happens.
- `prune_reports` takes routine reports before panic reports, so a burst of recovered failures cannot push out the one report that cannot be reconstructed from anything else.

## Validation

- `cargo test --bin gridbash -- --test-threads=1`: **392 passed, 5 ignored**.
- `cargo clippy --bin gridbash --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Verified against the real directory: a full test run left its file count (49) and newest timestamp unchanged, and the two reports it produced landed in the temporary directory instead.