### PR TITLE
fix: guard the resize preview against a zero-column grid

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -2420,10 +2420,14 @@ impl GridPicker {
     }
 
     fn preview_summary(&self, index: usize) -> Option<&str> {
-        let row = index / self.columns;
-        let column = index % self.columns;
+        // `GridSize` is a plain struct, and the loop that calls this already
+        // guards its own division the same way. Dividing by a zero column count
+        // here would panic mid-frame.
+        let columns = self.columns.max(1);
+        let row = index / columns;
+        let column = index % columns;
         let old_index = (row < self.initial.rows && column < self.initial.columns)
-            .then_some(row * self.initial.columns + column)?;
+            .then_some(row * self.initial.columns.max(1) + column)?;
 
         self.pane_summaries
             .get(old_index)
@@ -2486,6 +2490,25 @@ mod tests {
     use crate::auth::AgentKind;
 
     use super::*;
+
+    /// `GridSize` is a plain struct, so a zero dimension can reach the picker.
+    /// The preview loop already guarded its own division; the summary lookup it
+    /// calls did not, and dividing by zero there would panic mid-frame.
+    #[test]
+    fn the_resize_preview_survives_a_zero_dimension() {
+        let picker = GridPicker::new(GridSize {
+            rows: 0,
+            columns: 0,
+        })
+        .with_pane_summaries(vec![Some("busy".into())]);
+
+        assert_eq!(picker.preview_summary(0), None);
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).expect("build a test terminal");
+        terminal
+            .draw(|frame| picker.draw(frame, None))
+            .expect("drawing a zero-sized grid must not panic");
+    }
 
     const TEST_PROFILE: &str = "test-shell";
 


### PR DESCRIPTION
Found by reading `src/composer.rs` end to end.

`GridPicker::draw_preview` guards its own division:

```rust
let row = index / self.columns.max(1);
let column = index % self.columns.max(1);
```

`GridPicker::preview_summary`, called from inside that same loop for every cell, did not:

```rust
let row = index / self.columns;   // panics when columns == 0
```

`GridSize` is a plain struct rather than a validated one, and the neighbouring `.max(1)` shows the case was already considered reachable. A panic here lands inside `terminal.draw`, which is the one place it costs the whole frame and has to be caught by the event loop's recovery path.

Verified: with the guard removed the new test fails with `attempt to divide by zero` at `composer.rs:2427`.

## Validation

- `cargo test --bin gridbash -- --test-threads=1`: **398 passed, 5 ignored** (1 new).
- `cargo clippy --bin gridbash --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.