### PR TITLE
security: compare the pane host token the same way as the control token

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -399,14 +399,14 @@ fn authorize_request(
     }
 }
 
-/// Compare a presented token against the session's without letting how long the
-/// comparison took say how much of it was right.
+/// Compare a presented token against an expected one without letting how long
+/// the comparison took say how much of it was right.
 ///
 /// Guessing a two hundred and fifty six bit token a byte at a time is not a
 /// practical attack even against `==`, so this is depth rather than a fix for
 /// something reachable. It costs one pass over thirty two bytes on a path that
 /// runs once per control command.
-fn tokens_match(presented: &str, expected: &str) -> bool {
+pub(crate) fn tokens_match(presented: &str, expected: &str) -> bool {
     let presented = presented.as_bytes();
     let expected = expected.as_bytes();
     // Lengths are public: a token of the wrong length is rejected without

--- a/src/pane_host.rs
+++ b/src/pane_host.rs
@@ -1186,7 +1186,9 @@ fn accept_client(
         );
         return Ok(None);
     }
-    if token != expected_token {
+    // Compared the same way the control API compares its own tokens, so the
+    // two authentication paths do not disagree about what a secret is.
+    if !crate::control::tokens_match(&token, expected_token) {
         let _ = send_json(
             &mut stream,
             &HostEvent::Error {


### PR DESCRIPTION
Found by reading `src/pane_host.rs` end to end.

`accept_client` authenticated with `if token != expected_token`, while the control API — same kind of loopback socket, same job — was made constant-time in #310. Both now use `tokens_match`.

Neither is practically attackable at these token lengths (192-bit for the pane host, 256-bit for the control API). Two authentication paths in one codebase disagreeing about what a secret is, is the part worth fixing.

## Validation

- `cargo test --bin gridbash -- --test-threads=1`: **401 passed, 5 ignored**.
- `cargo clippy --bin gridbash --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.