### PR TITLE
feat: reach every shortcut on macOS, recover workspaces on request, and adopt outside terminals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ whisper-rs = "0.16"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ agents and shells.
 | `Alt+h` or `F1` | Open the full in-app shortcut guide |
 | `Alt+q` | Show the quit confirmation and exact resume command |
 
+On macOS, Option is a character composer rather than Alt in Apple Terminal,
+iTerm2, and Ghostty, so GridBash adds a leader key: press `Ctrl+G`, release it,
+then press the shortcut key without Alt — `Ctrl+G` then `c` for the command
+center, `Ctrl+G` then an arrow to move focus. Turning on the terminal's Option
+as Meta setting makes the Alt shortcuts work directly instead.
+
 See the [full controls reference](docs/REFERENCE.md#controls) for resizing,
 renaming, sleeping, restarting, scrolling, settings, and recovery actions.
 
@@ -130,12 +136,12 @@ to close GridBash, or any other key to cancel. The same command is printed after
 GridBash returns to the launching shell. Quit confirmation is enabled by default
 and can be disabled in Settings.
 
-If the terminal or GridBash process closes unexpectedly, the next plain
-`gridbash` launch automatically recovers unfinished agent sessions. Saved panes
-are grouped into tabs by working directory, each tab is named after that
-directory, and `Alt+t` moves to the next tab. Explicit launch arguments still
-start the workspace you requested, and older snapshots remain available through
-`gridbash resume`.
+A plain `gridbash` always gives you a new, empty workspace. If the terminal or
+GridBash process closes unexpectedly, run `gridbash --recover` to reopen the
+unfinished agent sessions it left behind — each interrupted workspace comes back
+with its grids intact, and `Alt+t` moves between tabs. A plain launch says in the
+status bar when there is something to recover, and older snapshots remain
+available through `gridbash resume`.
 
 ## Profiles and configuration
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -27,6 +27,9 @@ exited = "red"
 [keys]
 zoom-pane = "alt+f"
 settings = "alt+o"
+# Press the leader, then the shortcut key without Alt, for terminals that do not
+# send Alt at all. On by default on macOS; "off" disables it.
+leader = "ctrl+g"
 
 [manager]
 activity_summaries = false # opt in: sends bounded active-tab output to this API

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -7,21 +7,28 @@ README](../README.md) for installation and a shorter introduction.
 ## Create a grid
 
 Run `gridbash` with no arguments, or press `Alt+n` inside a running workspace,
-to open the new-grid screen. It asks for four things and decides the rest:
+to open the new-grid screen. It asks three questions, one at a time, and decides
+the rest:
 
-| Field | Meaning |
-| --- | --- |
-| Rows | 1-10 rows of panes. |
-| Columns | 1-10 columns of panes. |
-| Name | Tab title for this grid. Blank falls back to `Grid N`. |
-| Project | Folder the panes start in, with Tab completion. |
+| Step | Question | Keys |
+| --- | --- | --- |
+| 01 | How big? 1-10 rows by 1-10 columns. | `↑↓` rows, `←→` columns, `1`-`9` for a square (`0` for the maximum) |
+| 02 | Call it what? Tab title for this grid; blank falls back to `Grid N`. | typing, `←→` to move the cursor |
+| 03 | Where? Folder the panes start in. | typing, `Tab` completes folders and cycles matches |
+
+`Enter` answers the current question and moves to the next; on the last step it
+launches. `Shift+Tab` goes back a step, `Esc` cancels, and a rail under the panel
+shows which steps are done. Nothing moves between steps on its own, so the arrow
+keys belong to whichever question is being asked — on the size step they point at
+the axis they change rather than at another field.
 
 Everything else is assumed so there is nothing else to answer:
 
 - **Worktrees are on** whenever the project is a git repository with a commit
   and no tracked modifications. The screen names the exact branches it will
   create and falls back to the shared project folder — saying why — when the
-  repository cannot host them. `Alt+w` overrides the choice.
+  repository cannot host them. `Alt+w`, or `F2` where the terminal will not send
+  Alt, overrides the choice.
 - **Panes run the platform shell**: Git Bash on Windows, otherwise the first
   available of zsh, bash, fish, sh, or PowerShell. `GRIDBASH_PROFILE`, a
   non-agent `--set-default` profile, and `--profile` still win. Pick agents per
@@ -82,7 +89,7 @@ gridbash --set-default codex
 | Tab | Complete the project path, or move to the next field. |
 | Tab again | Cycle the remaining folder matches. |
 | Ctrl+w / Ctrl+u | Delete the previous path segment / clear the field. |
-| Alt+w | Override managed worktrees for this grid. |
+| Alt+w or F2 | Override managed worktrees for this grid. |
 | Enter | Launch, from any field. |
 | Esc / Ctrl+c | Cancel. |
 
@@ -150,10 +157,14 @@ hosts; a session owned by a live GridBash process cannot be deleted. The
 `--delete` form provides the same behavior for scripts and requires a full
 session ID or unique prefix.
 
-Automatic recovery only applies to a plain launch. Grid, profile, count, cwd,
-worktree, layout, and agent-API launch options take precedence, while every
-saved snapshot remains available through the explicit `gridbash resume`
-commands above.
+A plain `gridbash` always starts an empty workspace. When a GridBash process
+dies without cleaning up, its sessions are left marked as running; pass
+`gridbash --recover` to adopt those workspaces instead of starting a new one, and
+a plain launch reports in the status bar how many are waiting. Recovery only
+applies to an otherwise plain launch: grid, profile, count, cwd, worktree,
+layout, and agent-API options describe a specific workspace and suppress it.
+Every saved snapshot also remains available through the explicit `gridbash
+resume` commands above.
 
 ## Managed git worktrees
 
@@ -296,6 +307,7 @@ GridBash is modeless: ordinary terminal input continues to the active target, wh
 | Alt+l | Resize the current grid. |
 | Alt+x | Swap two selected grids when any grids are selected; otherwise swap the two selected panes. |
 | Alt+n | Open the new-grid screen and launch another tab. |
+| Ctrl+Alt+t | Re-root the focused pane at an outside Git Bash window's folder. |
 | Alt+t | Switch to the next tab. |
 | Alt+w | Open the current-grid close confirmation. |
 | Alt+s | Toggle selection of the focused pane. |
@@ -372,6 +384,31 @@ Alt+Ctrl+B opens Background Agents. Rows show whether each job is working, quiet
 
 When an agent launched by GridBash exits normally, including through `/exit`, GridBash replaces it with the preferred interactive terminal in the pane's current directory. If another focused pane exits, Enter, `r`, or `t` restarts it, while `z` sleeps it. Alt+Shift+T performs the same restart directly for exited target panes.
 
+### The leader key
+
+Terminals differ on whether they send Alt at all. Apple Terminal, iTerm2, and
+Ghostty map Option to character composition by default, so Option+C produces
+`ç` and none of the Alt shortcuts ever reach GridBash. The leader key replaces
+the modifier with a first keystroke: press it, release it, then press the
+shortcut key on its own.
+
+`Ctrl+G` then `c` opens the command center, `Ctrl+G` then an arrow moves focus,
+`Ctrl+G` then `Shift+C` captures output, and `Ctrl+G` then `Ctrl+P` opens Ports.
+`Ctrl+G` then `q` quits. Esc backs out, and pressing the leader twice sends it
+to the focused pane, so no pane loses the key. The status bar names the leader
+while it is waiting.
+
+GridBash enables the leader on macOS and leaves it off elsewhere, where Alt
+arrives intact. Set it explicitly, or turn it off, in the `[keys]` table:
+
+```toml
+[keys]
+leader = "ctrl+g"   # "off" disables it
+```
+
+Enabling the terminal's own Option-as-Meta setting is the alternative and makes
+the Alt shortcuts work directly; the two can be used together.
+
 ### Configurable shortcuts
 
 Override application controls in the top-level `[keys]` table. Action names
@@ -389,7 +426,8 @@ Supported actions are `quit`, `help`, `focus-left`, `focus-right`, `focus-up`,
 `next-tab`, `new-tab`, `close-grid`, `resize-grid`, `swap-panes`, `zoom-pane`, `command-line`,
 `command-palette`, `bashbot`, `voice-input`, `edit-goal`, `stop-goal`, `settings`, `previous-panes`, `ports`,
 `pane-activity`, `copy-mode`, `auth-profiles`, `capture-output`,
-`toggle-output-logging`, `rename-tab`, and `rename-pane`. Unlisted actions retain their
+`toggle-output-logging`, `rename-tab`, `rename-pane`, and `adopt-terminal`, plus
+`leader` for the [leader key](#the-leader-key). Unlisted actions retain their
 defaults. Duplicate chords and unmodified terminal keys are rejected. F1 and
 `Alt+q` remain reserved help and quit recovery paths; in-app help displays the
 effective bindings.
@@ -403,9 +441,17 @@ The resize picker starts from the current dimensions and shows each existing pan
 
 A pane's top border carries its number and name on the left and its state on the right. Opt-in AI activity summaries add a concise work headline after the name once output settles; GridBash never uses raw typing or terminal UI fragments as the displayed summary. A configured manager goal replaces pane summaries across the grid until removed. Saving a blank pane name restores its default number.
 
+## Adopting an outside terminal
+
+`Ctrl+Alt+T` lists the Git Bash windows running outside GridBash and re-roots the focused pane at the folder one of them is sitting in. Pick a row, then confirm; the pane's current shell is closed and replaced by one starting in that folder, and its managed worktree name is recomputed for the new location.
+
+The outside window is never touched. It keeps its process and stays open, because Windows binds a process to the console it was created with and offers no way to hand a live process to another pseudoconsole — so what moves is the location, not the session. A window whose title does not reveal a folder is still listed, greyed out and unselectable, rather than being silently dropped.
+
+Folders are read from the window title, which is where MSYS shells publish them: `MINGW64:/c/Users/you/project`, `MSYS:~`, and Cygwin's `/cygdrive/c/...` all resolve, and a title a running program has overwritten resolves to nothing rather than to a guess. This is Windows-only; elsewhere the picker reports that nothing was found.
+
 The tab strip draws each grid as a separate capped shape rather than one continuous highlight: the current grid is filled with the accent colour, a grid whose agent is waiting on you is filled amber and marked `•`, an exited grid is marked `!`, and grids selected by hand are underlined. When the grids outrun the terminal width the strip scrolls to keep the current one visible and marks the hidden ends with `‹` and `›`. Remaining width goes to the keyboard hints, which drop from the end as it runs out.
 
-The status bar centres the focused pane's number, name, and AI activity summary. When summaries are off or unconfigured, that line says so instead of guessing from the shape of the output; a transient status message takes the centre for as long as it lasts, and a narrow terminal drops the pane name before the summary. Left of centre are the clickable Panes, Summary, and background-jobs chips, plus the input mode and scope only when they are not the ordinary ones; the ports chip stays anchored to the right edge.
+The status bar centres the focused pane's number, name, and AI activity summary, followed by how long that summary stays cached and a `⟳` control that refreshes it now. The countdown reads `due` once the cache is stale and `···` while a request is in flight, and the whole clock is the click target. It is shown only for panes that can actually be summarized — never for a sleeping or exited pane, one with summaries switched off, or while a manager goal has suspended them. When summaries are off or unconfigured, the centre says so instead of guessing from the shape of the output; a transient status message takes the centre for as long as it lasts, and a narrow terminal drops the pane name before the summary. Left of centre are the clickable Panes, Summary, and background-jobs chips, plus the input mode and scope only when they are not the ordinary ones; the ports chip stays anchored to the right edge.
 
 The state on the right is whichever one matters most: `exited`, `asleep`, `needs you`, or `idle`. `needs you` marks an agent pane that has stopped producing output for roughly three seconds, which is how an agent asks for input — it indicates output followed by inactivity, not completion or process exit. A non-agent pane that goes quiet reads `idle` instead. As a pane narrows, its header drops its usage figure first, then its activity summary; the number, name, and state are kept. Focused and selected panes are marked by a filled number chip and a coloured border, which outrank a pane's own state.
 
@@ -431,7 +477,7 @@ Set `GRIDBASH_VOICE_MODEL` to use another local Whisper model or `GRIDBASH_SPEEC
 
 GridBash targets modern UTF-8, ANSI/xterm-compatible terminals, including Windows Terminal, Apple Terminal, iTerm2, GNOME Terminal, Konsole, Kitty, WezTerm, and Alacritty.
 
-SSH and tmux work when the remote session advertises a color-capable `TERM`. `TERM=dumb` and Linux kernel consoles are unsupported. In Apple Terminal and iTerm2, configure Option as Meta/Alt so GridBash receives its shortcuts.
+SSH and tmux work when the remote session advertises a color-capable `TERM`. `TERM=dumb` and Linux kernel consoles are unsupported. On macOS the shortcuts are reachable out of the box through the [leader key](#the-leader-key); configuring Option as Meta/Alt in Apple Terminal, iTerm2, or Ghostty makes the Alt chords work directly as well.
 
 ## Launch profiles
 
@@ -540,7 +586,7 @@ Settings persist compact titles, activity badges, quit confirmation, background-
 
 The BashBot Director and AI activity summaries use the OpenAI-compatible chat-completions endpoint, model, and API key under `[manager]`. These values can also be edited in Settings > Manager. The UI masks the API key, but the key is stored in the local TOML file.
 
-AI activity summaries are disabled by default. Enable them separately in Settings > Manager only when you want bounded recent output from eligible panes in the active tab sent to the configured endpoint. GridBash batches panes after roughly three seconds of quiet output, rate-limits automatic refreshes, pauses them while a manager goal is present, and preserves the last successful headline across temporary API failures. The Pane Activity refresh control requests an immediate update; pending input is never used as a displayed summary.
+AI activity summaries are disabled by default. Enable them separately in Settings > Manager only when you want bounded recent output from eligible panes in the active tab sent to the configured endpoint. GridBash batches panes after roughly three seconds of quiet output, pauses them while a manager goal is present, and preserves the last successful headline across temporary API failures. Each pane then caches its summary for three minutes before another request may be spent on it, so a nine-pane grid costs at most twenty batched calls an hour; failures back off separately, doubling from thirty seconds up to five minutes. The status bar's `⟳` control and the Pane Activity refresh control both skip the cache and request an immediate update for one pane; pending input is never used as a displayed summary.
 
 `/goal` in Alt+C Chat creates a goal for the current grid. Each review sends pane role and folder metadata plus bounded recent output from that grid to the configured API. Sleeping and exited panes are never command targets. Reviews label output by pane, report changed statuses in the transcript, and keep validated follow-ups bound to their intended PTYs if panes are reordered. Goals keep running when another grid is active; `/stop` ends only the current grid's goal.
 

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -11,7 +11,9 @@
 //! and the original window is left alone, running, for the user to close when
 //! they are ready.
 
-use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::path::Path;
+use std::path::PathBuf;
 
 /// A terminal window running outside this GridBash.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,6 +43,12 @@ impl ExternalTerminal {
 }
 
 /// Window titles that mark a shell we know how to read a path out of.
+///
+/// Everything from here down reads MSYS window titles, which only exist on
+/// Windows. Off it there is nothing to enumerate and nothing to parse, so the
+/// module narrows to the type the interface still has to name and a `discover`
+/// that finds nothing.
+#[cfg(windows)]
 const SHELL_TITLE_PREFIXES: [&str; 5] = ["MINGW64:", "MINGW32:", "MSYS:", "MSYS2:", "CYGWIN:"];
 
 /// The working directory a shell window's title is reporting.
@@ -50,6 +58,7 @@ const SHELL_TITLE_PREFIXES: [&str; 5] = ["MINGW64:", "MINGW32:", "MSYS:", "MSYS2
 /// letter has to be put back. Titles that carry no path at all — a shell that
 /// has been retitled by a running program, say — resolve to nothing rather than
 /// to a guess.
+#[cfg(windows)]
 pub fn cwd_from_title(title: &str, home: Option<&Path>) -> Option<PathBuf> {
     let trimmed = title.trim();
     let body = SHELL_TITLE_PREFIXES
@@ -76,6 +85,7 @@ pub fn cwd_from_title(title: &str, home: Option<&Path>) -> Option<PathBuf> {
 }
 
 /// Turns the shell's idea of a path into one the OS can open.
+#[cfg(windows)]
 fn posix_to_windows(value: &str, home: Option<&Path>) -> Option<PathBuf> {
     // Already a Windows path, from a shell that reports them that way.
     if value.len() >= 2 && value.as_bytes()[1] == b':' {
@@ -118,11 +128,13 @@ fn posix_to_windows(value: &str, home: Option<&Path>) -> Option<PathBuf> {
 
 /// Keeps only windows whose folder still exists, so the picker never offers a
 /// path that would fail the moment it was chosen.
+#[cfg(windows)]
 fn resolve(pid: u32, title: String) -> ExternalTerminal {
     let cwd = cwd_from_title(&title, home_dir().as_deref()).filter(|path| path.is_dir());
     ExternalTerminal { pid, title, cwd }
 }
 
+#[cfg(windows)]
 fn home_dir() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
 }
@@ -203,6 +215,7 @@ pub fn discover() -> Vec<ExternalTerminal> {
 /// Deliberately narrow. Listing every console window on the desktop would put
 /// the user's editor and chat client in a picker that promises to open a shell
 /// where they are.
+#[cfg(windows)]
 fn looks_like_a_shell(title: &str) -> bool {
     let trimmed = title.trim();
     // `get` rather than a slice: window titles are arbitrary user text, and
@@ -219,6 +232,7 @@ fn looks_like_a_shell(title: &str) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
     #[test]
     fn reads_the_folder_out_of_a_git_bash_title() {
         let home = PathBuf::from("C:\\Users\\Jason");
@@ -251,6 +265,7 @@ mod tests {
 
     /// A window retitled by whatever is running in it must resolve to nothing
     /// rather than to a plausible-looking wrong folder.
+    #[cfg(windows)]
     #[test]
     fn a_title_without_a_path_resolves_to_nothing() {
         let home = PathBuf::from("C:\\Users\\Jason");
@@ -266,6 +281,7 @@ mod tests {
         assert_eq!(cwd("MINGW64:/usr/local"), None);
     }
 
+    #[cfg(windows)]
     #[test]
     fn only_shell_windows_are_offered() {
         assert!(looks_like_a_shell("MINGW64:/c/src"));
@@ -307,6 +323,14 @@ mod tests {
     #[test]
     fn discovery_never_panics() {
         let _ = discover();
+    }
+
+    /// Off Windows there is no window list to read, and the picker has to be
+    /// told that rather than shown an empty list it cannot explain.
+    #[cfg(not(windows))]
+    #[test]
+    fn discovery_finds_nothing_off_windows() {
+        assert!(discover().is_empty());
     }
 
     /// Prints what is actually on this desktop. Run with:

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -1,0 +1,327 @@
+//! Adopting a terminal the user already has open into a pane.
+//!
+//! A running console cannot be moved into GridBash. Windows binds a process to
+//! the console it was created with, and there is no supported way to hand a live
+//! process to a different pseudoconsole — so the window on screen keeps its
+//! process no matter what we do here.
+//!
+//! What can be carried across is *where* it was: a shell's window title says its
+//! working directory, and that is the part people actually mean when they say
+//! they want a window "in" the grid. So a pane is re-rooted at the same folder
+//! and the original window is left alone, running, for the user to close when
+//! they are ready.
+
+use std::path::{Path, PathBuf};
+
+/// A terminal window running outside this GridBash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalTerminal {
+    pub pid: u32,
+    /// The window title, as shown in the taskbar.
+    pub title: String,
+    /// The folder the title reports, when it reports one that still exists.
+    pub cwd: Option<PathBuf>,
+}
+
+impl ExternalTerminal {
+    /// What the picker shows: the folder if we could read one, else the raw
+    /// title, so a window we only half-understand is still listed rather than
+    /// silently dropped.
+    pub fn label(&self) -> String {
+        match self.cwd.as_deref() {
+            Some(cwd) => cwd.display().to_string(),
+            None => self.title.clone(),
+        }
+    }
+
+    /// Only a window whose folder we resolved can re-root a pane.
+    pub fn is_adoptable(&self) -> bool {
+        self.cwd.is_some()
+    }
+}
+
+/// Window titles that mark a shell we know how to read a path out of.
+const SHELL_TITLE_PREFIXES: [&str; 5] = ["MINGW64:", "MINGW32:", "MSYS:", "MSYS2:", "CYGWIN:"];
+
+/// The working directory a shell window's title is reporting.
+///
+/// Git Bash titles its window `MINGW64:/c/Users/you/project`, which is a POSIX
+/// path from an MSYS root rather than anything Windows can open, so the drive
+/// letter has to be put back. Titles that carry no path at all — a shell that
+/// has been retitled by a running program, say — resolve to nothing rather than
+/// to a guess.
+pub fn cwd_from_title(title: &str, home: Option<&Path>) -> Option<PathBuf> {
+    let trimmed = title.trim();
+    let body = SHELL_TITLE_PREFIXES
+        .iter()
+        .find_map(|prefix| {
+            trimmed
+                .len()
+                .checked_sub(prefix.len())
+                .and_then(|_| trimmed.get(..prefix.len()))
+                .filter(|head| head.eq_ignore_ascii_case(prefix))
+                .and_then(|_| trimmed.get(prefix.len()..))
+        })
+        .unwrap_or(trimmed)
+        .trim();
+
+    // A retitled window reads like "npm run dev" or "vim - src/main.rs". The
+    // path, when there is one, is the first thing on the line.
+    let candidate = body.split_whitespace().next()?;
+    if candidate.is_empty() {
+        return None;
+    }
+
+    posix_to_windows(candidate, home)
+}
+
+/// Turns the shell's idea of a path into one the OS can open.
+fn posix_to_windows(value: &str, home: Option<&Path>) -> Option<PathBuf> {
+    // Already a Windows path, from a shell that reports them that way.
+    if value.len() >= 2 && value.as_bytes()[1] == b':' {
+        return Some(PathBuf::from(value.replace('/', "\\")));
+    }
+
+    if let Some(rest) = value.strip_prefix('~') {
+        let home = home?;
+        let rest = rest.trim_start_matches(['/', '\\']);
+        return Some(if rest.is_empty() {
+            home.to_path_buf()
+        } else {
+            home.join(rest.replace('/', "\\"))
+        });
+    }
+
+    // Cygwin spells the same thing with a prefix of its own.
+    let value = value.strip_prefix("/cygdrive").unwrap_or(value);
+
+    // `/c/Users/you` — a drive letter standing in for its root.
+    let rest = value.strip_prefix('/')?;
+    let mut parts = rest.splitn(2, '/');
+    let drive = parts.next()?;
+    let mut letter = drive.chars();
+    let letter = letter.next()?;
+    if !letter.is_ascii_alphabetic() || drive.chars().count() != 1 {
+        return None;
+    }
+
+    // Built as text rather than with `PathBuf::push`, which appends a separator
+    // of the *host's* kind: a non-Windows host would turn `C:\` plus `src` into
+    // `C:\/src`. These are Windows paths whatever machine parses them, and the
+    // tests below run on every platform GridBash ships to.
+    let mut path = format!("{}:\\", letter.to_ascii_uppercase());
+    if let Some(tail) = parts.next().filter(|tail| !tail.is_empty()) {
+        path.push_str(&tail.replace('/', "\\"));
+    }
+    Some(PathBuf::from(path))
+}
+
+/// Keeps only windows whose folder still exists, so the picker never offers a
+/// path that would fail the moment it was chosen.
+fn resolve(pid: u32, title: String) -> ExternalTerminal {
+    let cwd = cwd_from_title(&title, home_dir().as_deref()).filter(|path| path.is_dir());
+    ExternalTerminal { pid, title, cwd }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
+}
+
+/// Every shell window on this desktop that does not belong to us.
+///
+/// Returns nothing off Windows: the title convention this reads is an MSYS one,
+/// and elsewhere a terminal multiplexer is the right tool for the job anyway.
+#[cfg(windows)]
+pub fn discover() -> Vec<ExternalTerminal> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::{
+        Win32::{
+            Foundation::{HWND, LPARAM, TRUE},
+            UI::WindowsAndMessaging::{
+                EnumWindows, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+                IsWindowVisible,
+            },
+        },
+        core::BOOL,
+    };
+
+    unsafe extern "system" fn collect(window: HWND, lparam: LPARAM) -> BOOL {
+        // SAFETY: the pointer is the one handed to `EnumWindows` below, which
+        // outlives the enumeration it drives.
+        let found = unsafe { &mut *(lparam as *mut Vec<(u32, String)>) };
+        if unsafe { IsWindowVisible(window) } == 0 {
+            return TRUE;
+        }
+
+        let length = unsafe { GetWindowTextLengthW(window) };
+        if length <= 0 {
+            return TRUE;
+        }
+        let mut buffer = vec![0u16; length as usize + 1];
+        let written = unsafe { GetWindowTextW(window, buffer.as_mut_ptr(), buffer.len() as i32) };
+        if written <= 0 {
+            return TRUE;
+        }
+        let title = std::ffi::OsString::from_wide(&buffer[..written as usize])
+            .to_string_lossy()
+            .into_owned();
+
+        let mut pid = 0u32;
+        unsafe { GetWindowThreadProcessId(window, &mut pid) };
+        if pid != 0 {
+            found.push((pid, title));
+        }
+        TRUE
+    }
+
+    let mut found: Vec<(u32, String)> = Vec::new();
+    // SAFETY: `collect` only writes through the pointer we pass, and the vector
+    // it points at is alive for the whole call.
+    unsafe {
+        EnumWindows(Some(collect), &mut found as *mut _ as LPARAM);
+    }
+
+    let own = std::process::id();
+    let mut terminals = found
+        .into_iter()
+        .filter(|(pid, _)| *pid != own)
+        .filter(|(_, title)| looks_like_a_shell(title))
+        .map(|(pid, title)| resolve(pid, title))
+        .collect::<Vec<_>>();
+    terminals.sort_by_key(ExternalTerminal::label);
+    terminals.dedup_by(|left, right| left.pid == right.pid);
+    terminals
+}
+
+#[cfg(not(windows))]
+pub fn discover() -> Vec<ExternalTerminal> {
+    Vec::new()
+}
+
+/// Whether a window title is one of the shells this can read a folder out of.
+///
+/// Deliberately narrow. Listing every console window on the desktop would put
+/// the user's editor and chat client in a picker that promises to open a shell
+/// where they are.
+fn looks_like_a_shell(title: &str) -> bool {
+    let trimmed = title.trim();
+    // `get` rather than a slice: window titles are arbitrary user text, and
+    // slicing one whose first character is multi-byte panics — which on this
+    // path would take the whole interface down mid-frame.
+    SHELL_TITLE_PREFIXES.iter().any(|prefix| {
+        trimmed
+            .get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_the_folder_out_of_a_git_bash_title() {
+        let home = PathBuf::from("C:\\Users\\Jason");
+        let cwd = |title: &str| cwd_from_title(title, Some(&home));
+
+        assert_eq!(
+            cwd("MINGW64:/c/Users/Jason/Documents/GitHub"),
+            Some(PathBuf::from("C:\\Users\\Jason\\Documents\\GitHub"))
+        );
+        // The prefix is optional, and the case of it is not ours to rely on.
+        assert_eq!(cwd("/d/work"), Some(PathBuf::from("D:\\work")));
+        assert_eq!(cwd("mingw32:/e/"), Some(PathBuf::from("E:\\")));
+        assert_eq!(cwd("MSYS:/c/tmp"), Some(PathBuf::from("C:\\tmp")));
+        assert_eq!(
+            cwd("CYGWIN:/cygdrive/f/data"),
+            Some(PathBuf::from("F:\\data"))
+        );
+
+        // Home-relative titles.
+        assert_eq!(cwd("MINGW64:~"), Some(home.clone()));
+        assert_eq!(cwd("~/projects"), Some(home.join("projects")));
+        assert_eq!(cwd_from_title("~", None), None, "no home means no answer");
+
+        // A shell that already speaks Windows.
+        assert_eq!(
+            cwd("C:/Users/Jason/src"),
+            Some(PathBuf::from("C:\\Users\\Jason\\src"))
+        );
+    }
+
+    /// A window retitled by whatever is running in it must resolve to nothing
+    /// rather than to a plausible-looking wrong folder.
+    #[test]
+    fn a_title_without_a_path_resolves_to_nothing() {
+        let home = PathBuf::from("C:\\Users\\Jason");
+        let cwd = |title: &str| cwd_from_title(title, Some(&home));
+
+        assert_eq!(cwd(""), None);
+        assert_eq!(cwd("   "), None);
+        assert_eq!(cwd("MINGW64:"), None);
+        assert_eq!(cwd("npm run dev"), None);
+        assert_eq!(cwd("Inbox - Outlook"), None);
+        // A drive letter is one character; "/usr/bin" is not a Windows path.
+        assert_eq!(cwd("/usr/bin"), None);
+        assert_eq!(cwd("MINGW64:/usr/local"), None);
+    }
+
+    #[test]
+    fn only_shell_windows_are_offered() {
+        assert!(looks_like_a_shell("MINGW64:/c/src"));
+        assert!(looks_like_a_shell("  mingw64:/c/src"));
+        assert!(looks_like_a_shell("CYGWIN:~"));
+        assert!(!looks_like_a_shell("Slack | general"));
+        assert!(!looks_like_a_shell("Command Prompt"));
+        assert!(!looks_like_a_shell(""));
+
+        // Window titles are arbitrary user text. Slicing one whose first
+        // character is multi-byte used to panic here, and this runs over every
+        // window on the desktop.
+        for hostile in ["·", "日本語のタイトル", "→", "M·NGW64:/c/x", "🙂 build"] {
+            assert!(!looks_like_a_shell(hostile), "{hostile}");
+        }
+    }
+
+    #[test]
+    fn a_window_without_a_readable_folder_still_names_itself() {
+        let unreadable = ExternalTerminal {
+            pid: 42,
+            title: "MINGW64:~ - npm run dev".into(),
+            cwd: None,
+        };
+        assert_eq!(unreadable.label(), "MINGW64:~ - npm run dev");
+        assert!(!unreadable.is_adoptable());
+
+        let readable = ExternalTerminal {
+            pid: 43,
+            title: "MINGW64:/c/src".into(),
+            cwd: Some(PathBuf::from("C:\\src")),
+        };
+        assert_eq!(readable.label(), "C:\\src");
+        assert!(readable.is_adoptable());
+    }
+
+    /// Discovery must be safe to call anywhere, including in a test process with
+    /// no desktop to enumerate.
+    #[test]
+    fn discovery_never_panics() {
+        let _ = discover();
+    }
+
+    /// Prints what is actually on this desktop. Run with:
+    /// `cargo test -- --ignored --nocapture lists_the_shell_windows`
+    #[test]
+    #[ignore = "inspects the live desktop"]
+    fn lists_the_shell_windows_on_this_desktop() {
+        for terminal in discover() {
+            eprintln!(
+                "pid {:>6}  adoptable={}  {}  <- {:?}",
+                terminal.pid,
+                terminal.is_adoptable(),
+                terminal.label(),
+                terminal.title
+            );
+        }
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,7 @@ use vt100::{MouseProtocolEncoding, MouseProtocolMode, Screen};
 
 use crate::{
     actions::{fuzzy_match_score, palette_actions, palette_label},
+    adopt::{self, ExternalTerminal},
     auth::{self, AgentKind, AuthProfile},
     cli::{Cli, GridMode},
     composer::{Composer, GridPicker, GridPickerAction},
@@ -46,7 +47,7 @@ use crate::{
     copy_mode::{CopyMode, CopyModeView},
     diagnostics,
     image_preview::{self, ImagePreview},
-    keybindings::{Action, KeyBindings, is_help_recovery, is_quit_recovery},
+    keybindings::{Action, KeyBindings, is_help_recovery, is_quit_recovery, with_leader_alt},
     layout::{GridLayout, GridSize, PaneId, pane_at},
     manager::{self, ActivitySummary, AssistantReply, ManagerCommand, ManagerDecision, PaneUpdate},
     output_capture::{self, OutputLogs, PaneLogKey},
@@ -61,7 +62,7 @@ use crate::{
         SessionRecorder, claude_session_in_command, complete_interrupted_recovery,
         latest_claude_session, pin_claude_session,
     },
-    setup::{LaunchPlan, PaneLaunchSpec, folder_display_name},
+    setup::{LaunchPlan, PaneLaunchSpec, folder_display_name, git_worktree_name},
     ui,
     usage::{self, UsageEvent, UsageTarget},
     voice::{VoiceInput, VoiceOutcome, VoiceStart},
@@ -99,7 +100,19 @@ const PANE_GOAL_RETRY_DELAY: Duration = Duration::from_secs(30);
 const PANE_GOAL_MAX_FAILURES: u8 = 5;
 const ACTIVITY_SUMMARY_OUTPUT_MAX_BYTES: usize = 12_000;
 const ACTIVITY_SUMMARY_QUIET_AFTER: Duration = Duration::from_secs(3);
-const ACTIVITY_SUMMARY_COOLDOWN: Duration = Duration::from_secs(30);
+/// How long a pane keeps its cached summary before the summariser is allowed to
+/// spend another request on it.
+///
+/// Every pane in the active grid batches into one call, so this is very nearly
+/// the whole cost of the feature: at three minutes a nine-pane grid asks the API
+/// twenty times an hour. The refresh control exists for the moments that is too
+/// slow, which is what lets the automatic interval be this relaxed.
+const ACTIVITY_SUMMARY_COOLDOWN: Duration = Duration::from_secs(3 * 60);
+/// Backoff after a failed request, doubling per consecutive failure.
+///
+/// Kept separate from the cooldown so that slowing the automatic interval does
+/// not also blunt the backoff into a single flat step at the ceiling.
+const ACTIVITY_SUMMARY_RETRY_BASE: Duration = Duration::from_secs(30);
 const ACTIVITY_SUMMARY_MAX_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
 const ASSISTANT_CONTEXT_MAX_BYTES: usize = 24_000;
 const ASSISTANT_HISTORY_MAX_BYTES: usize = 8_000;
@@ -183,12 +196,15 @@ pub struct App {
     image_overlay: Option<ImagePreview>,
     grid_resizer: Option<GridPicker>,
     help_open: bool,
+    /// The leader key was pressed and the next key is a shortcut, not input.
+    leader_pending: bool,
     quit_confirmation_pending: bool,
     close_grid_confirmation_pending: bool,
     settings: SettingsState,
     rename: RenamePaneState,
     tab_rename: RenameTabState,
     previous_panes: PreviousPanesState,
+    adopt_picker: AdoptPickerState,
     background_jobs: Vec<BackgroundJob>,
     background_picker: BackgroundPickerState,
     port_inspector: PortInspectorState,
@@ -209,6 +225,7 @@ pub struct App {
     tab_rects: Vec<(usize, Rect)>,
     previous_panes_button: Option<Rect>,
     previous_pane_rows: Vec<(usize, Rect)>,
+    summary_refresh_button: Option<Rect>,
     pane_settings_button: Option<Rect>,
     pane_settings_rename_button: Option<Rect>,
     pane_settings_reload_button: Option<Rect>,
@@ -451,12 +468,69 @@ pub struct TabLabel {
     pub exited: bool,
 }
 
-/// What the status bar prints in the middle: the focused pane, and the
-/// summariser's one-line account of what it is doing.
+/// The picker that re-roots a pane at an outside terminal's folder.
+///
+/// The target pane is captured when the picker opens rather than read at the
+/// moment of confirmation: the list is the thing with the keyboard, and a pane
+/// should never be replaced because focus drifted while the user was reading.
+#[derive(Debug, Clone, Default)]
+struct AdoptPickerState {
+    open: bool,
+    cursor: usize,
+    target: usize,
+    terminals: Vec<ExternalTerminal>,
+    /// The second half of "ask first": the row is chosen, and the picker is
+    /// waiting for the user to agree to close what is in the pane now.
+    confirming: bool,
+}
+
+impl AdoptPickerState {
+    fn selected(&self) -> Option<&ExternalTerminal> {
+        self.terminals.get(self.cursor)
+    }
+
+    fn close(&mut self) {
+        self.open = false;
+        self.confirming = false;
+        self.terminals.clear();
+    }
+}
+
+/// One outside terminal, as the picker draws it.
+#[derive(Debug, Clone)]
+pub struct AdoptTerminalRow {
+    /// The folder, or the raw window title when its folder could not be read.
+    pub label: String,
+    pub pid: u32,
+    pub adoptable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdoptTerminalView {
+    pub cursor: usize,
+    pub target_label: String,
+    pub rows: Vec<AdoptTerminalRow>,
+    pub confirming: bool,
+}
+
+/// What the status bar prints in the middle: the focused pane, the summariser's
+/// one-line account of what it is doing, and how long that account is cached
+/// for.
+///
+/// The countdown is carried as a `Duration` rather than a formatted string so
+/// the bar can decide how much of it fits, and as a plain value rather than an
+/// `Instant` so the bar stays renderable without a live `App`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FocusedPaneSummary {
     pub title: String,
     pub detail: String,
+    /// Time left on the cached summary. `None` once it is due for a refresh.
+    pub refresh_in: Option<Duration>,
+    /// A request for this pane is in flight right now.
+    pub refreshing: bool,
+    /// Whether refreshing is possible at all — false when summaries are off,
+    /// unconfigured, or suspended by a running goal.
+    pub refreshable: bool,
 }
 
 impl FocusedPaneSummary {
@@ -471,6 +545,15 @@ enum KeyOutcome {
     Render,
     AuthLogin(AuthProfile),
     Quit,
+}
+
+/// What reading the leader key left for the rest of key handling to do.
+enum LeaderOutcome {
+    /// The leader consumed the press; nothing else looks at it.
+    Handled(KeyOutcome),
+    /// The key to carry on with, which is the shortcut the leader resolved to
+    /// when one was pending.
+    Key(KeyEvent),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2942,12 +3025,14 @@ impl App {
             image_overlay: None,
             grid_resizer: None,
             help_open: false,
+            leader_pending: false,
             quit_confirmation_pending: false,
             close_grid_confirmation_pending: false,
             settings: init.settings,
             rename: RenamePaneState::default(),
             tab_rename: RenameTabState::default(),
             previous_panes: PreviousPanesState::default(),
+            adopt_picker: AdoptPickerState::default(),
             background_jobs,
             background_picker: BackgroundPickerState::default(),
             port_inspector: PortInspectorState::default(),
@@ -2968,6 +3053,7 @@ impl App {
             tab_rects: Vec::new(),
             previous_panes_button: None,
             previous_pane_rows: Vec::new(),
+            summary_refresh_button: None,
             pane_settings_button: None,
             pane_settings_rename_button: None,
             pane_settings_reload_button: None,
@@ -3718,6 +3804,7 @@ impl App {
                 self.tab_rects = draw_state.tab_rects;
                 self.previous_panes_button = draw_state.previous_panes_button;
                 self.previous_pane_rows = draw_state.previous_pane_rows;
+                self.summary_refresh_button = draw_state.summary_refresh_button;
                 self.pane_settings_button = draw_state.pane_settings_button;
                 self.pane_settings_rename_button = draw_state.pane_settings_rename_button;
                 self.pane_settings_reload_button = draw_state.pane_settings_reload_button;
@@ -6086,7 +6173,65 @@ impl App {
         changed
     }
 
+    /// Reads the leader key, which stands in for Alt.
+    ///
+    /// A terminal that will not send Alt — every default macOS one, where
+    /// Option composes characters instead — leaves the whole shortcut table
+    /// unreachable. Pressing the leader first and the shortcut key second gets
+    /// there without holding a modifier the terminal refuses to pass on.
+    fn resolve_leader(&mut self, key: KeyEvent) -> LeaderOutcome {
+        if !self.leader_pending {
+            if !self.keybindings.is_leader(&key) {
+                return LeaderOutcome::Key(key);
+            }
+            self.leader_pending = true;
+            if let Some(leader) = self.keybindings.leader_label() {
+                self.status = format!("{leader} pressed — now press a shortcut key, or Esc");
+            }
+            return LeaderOutcome::Handled(KeyOutcome::Render);
+        }
+
+        self.leader_pending = false;
+        // Pressing it twice sends it on, so the leader never permanently costs
+        // the panes a key they might need.
+        if self.keybindings.is_leader(&key) {
+            self.status.clear();
+            return LeaderOutcome::Key(key);
+        }
+        if key.code == KeyCode::Esc {
+            self.status.clear();
+            return LeaderOutcome::Handled(KeyOutcome::Render);
+        }
+
+        let shortcut = with_leader_alt(&key);
+        if self.keybindings.action_for(&shortcut).is_some() || is_quit_recovery(&shortcut) {
+            self.status.clear();
+            return LeaderOutcome::Key(shortcut);
+        }
+
+        // Passing an unrecognized key through would type it into the pane a beat
+        // after the user meant it as a shortcut.
+        self.status = "that key is not a shortcut — F1 lists them".into();
+        LeaderOutcome::Handled(KeyOutcome::Render)
+    }
+
+    /// What to tell a first-time user whose terminal will not send Alt.
+    pub fn leader_hint(&self) -> Option<String> {
+        cfg!(target_os = "macos")
+            .then(|| self.keybindings.leader_label())
+            .flatten()
+            .map(|leader| {
+                format!(
+                    "macOS terminals send Option as a character, not Alt: press {leader} then the shortcut key, or turn on Option as Meta"
+                )
+            })
+    }
+
     fn handle_key(&mut self, terminal: &mut Tui, key: KeyEvent) -> Result<KeyOutcome> {
+        let key = match self.resolve_leader(key) {
+            LeaderOutcome::Handled(outcome) => return Ok(outcome),
+            LeaderOutcome::Key(key) => key,
+        };
         let action = self.keybindings.action_for(&key);
         if self.close_grid_confirmation_pending {
             return self.handle_close_grid_confirmation_key(key);
@@ -6180,6 +6325,11 @@ impl App {
 
         if self.background_picker.open {
             let outcome = self.handle_background_jobs_key(key)?;
+            return Ok(render_if_selection_cleared(outcome, selection_cleared));
+        }
+
+        if self.adopt_picker.open {
+            let outcome = self.handle_adopt_terminal_key(key)?;
             return Ok(render_if_selection_cleared(outcome, selection_cleared));
         }
 
@@ -6798,6 +6948,9 @@ impl App {
             Action::RenamePane => {
                 self.begin_rename();
             }
+            Action::AdoptTerminal => {
+                self.open_adopt_terminal();
+            }
         }
         Ok(())
     }
@@ -7142,6 +7295,171 @@ impl App {
                 self.status = "tab name cannot be empty".into();
             }
         }
+    }
+
+    /// Offers the outside shell windows this desktop has open.
+    ///
+    /// The window itself stays where it is — a running console cannot be moved
+    /// into a pane — so what this adopts is the folder it is sitting in.
+    fn open_adopt_terminal(&mut self) {
+        let Some(target) = self.focused_pane() else {
+            self.status = "focus a pane to adopt a terminal into".into();
+            return;
+        };
+
+        let terminals = adopt::discover();
+        if terminals.is_empty() {
+            // Off Windows there is nothing to enumerate rather than nothing
+            // open, and a user hunting for a window they can see deserves to be
+            // told which of the two it is.
+            self.status = if cfg!(windows) {
+                "no outside Git Bash windows found".into()
+            } else {
+                "adopting an outside terminal is Windows-only".to_string()
+            };
+            return;
+        }
+
+        self.pane_settings.close();
+        self.previous_panes.close();
+        self.adopt_picker = AdoptPickerState {
+            open: true,
+            cursor: terminals
+                .iter()
+                .position(ExternalTerminal::is_adoptable)
+                .unwrap_or(0),
+            target,
+            terminals,
+            confirming: false,
+        };
+        self.status = format!("adopt a terminal into pane {}", target + 1);
+    }
+
+    fn close_adopt_terminal(&mut self) {
+        self.adopt_picker.close();
+        self.status = "adopt cancelled".into();
+    }
+
+    fn handle_adopt_terminal_key(&mut self, key: KeyEvent) -> Result<KeyOutcome> {
+        if key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Char('q')) {
+            return Ok(KeyOutcome::Quit);
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                // Backing out of the confirmation returns to the list rather
+                // than throwing away the whole choice.
+                if self.adopt_picker.confirming {
+                    self.adopt_picker.confirming = false;
+                } else {
+                    self.close_adopt_terminal();
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') if !self.adopt_picker.confirming => {
+                self.adopt_picker.cursor = self.adopt_picker.cursor.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') if !self.adopt_picker.confirming => {
+                let last = self.adopt_picker.terminals.len().saturating_sub(1);
+                self.adopt_picker.cursor = (self.adopt_picker.cursor + 1).min(last);
+            }
+            KeyCode::Enter => {
+                let Some(selected) = self.adopt_picker.selected().cloned() else {
+                    return Ok(KeyOutcome::Render);
+                };
+                if !selected.is_adoptable() {
+                    self.status = "that window's title does not say where it is".into();
+                    return Ok(KeyOutcome::Render);
+                }
+                if !self.adopt_picker.confirming {
+                    self.adopt_picker.confirming = true;
+                    return Ok(KeyOutcome::Render);
+                }
+
+                let target = self.adopt_picker.target;
+                let cwd = selected.cwd.clone().unwrap_or_default();
+                self.adopt_picker.close();
+                if let Err(error) = self.adopt_terminal_into_pane(target, cwd) {
+                    self.status = format!("adopt failed: {error:#}");
+                }
+            }
+            _ => return Ok(KeyOutcome::Continue),
+        }
+        Ok(KeyOutcome::Render)
+    }
+
+    /// Replaces a pane with a shell rooted where the chosen window is.
+    ///
+    /// The outside window keeps its process and is left running; nothing is done
+    /// to it. Only the pane changes.
+    fn adopt_terminal_into_pane(&mut self, pane_index: usize, cwd: PathBuf) -> Result<()> {
+        if pane_index >= self.panes.len() {
+            return Err(anyhow!("pane {} is no longer available", pane_index + 1));
+        }
+        if !cwd.is_dir() {
+            return Err(anyhow!("{} is not a folder any more", cwd.display()));
+        }
+
+        let mut spec = self
+            .launch_plan
+            .as_ref()
+            .and_then(|plan| plan.panes.get(pane_index))
+            .cloned()
+            .ok_or_else(|| anyhow!("pane {} has no launch settings", pane_index + 1))?;
+        // The pane moves house, so everything that described the old address
+        // moves with it — including the managed worktree, which belonged to the
+        // folder being left behind.
+        spec.folder_name = folder_display_name(&cwd);
+        spec.worktree_name = git_worktree_name(&cwd);
+        spec.cwd = cwd.clone();
+
+        let mut pane = self.spawn_pane_instance(&spec, pane_index)?;
+        if let Err(error) = retire_pane(&mut self.panes[pane_index]) {
+            let cleanup_error = retire_pane(&mut pane).err();
+            return Err(match cleanup_error {
+                Some(cleanup_error) => error.context(format!(
+                    "replacement pane cleanup also failed: {cleanup_error:#}"
+                )),
+                None => error,
+            });
+        }
+
+        self.panes[pane_index] = pane;
+        if let Some(plan) = &mut self.launch_plan {
+            plan.panes[pane_index] = spec;
+        }
+        if let Some(idle) = self.pane_idle.get_mut(pane_index) {
+            *idle = PaneIdleState::new(Instant::now());
+        }
+        self.sleeping.remove(&pane_index);
+        self.start_usage_for_active_tab();
+        self.save_session_snapshot()?;
+        self.status = format!("pane {} now sits in {}", pane_index + 1, cwd.display());
+        Ok(())
+    }
+
+    pub fn adopt_terminal_view(&self) -> Option<AdoptTerminalView> {
+        self.adopt_picker.open.then(|| AdoptTerminalView {
+            cursor: self
+                .adopt_picker
+                .cursor
+                .min(self.adopt_picker.terminals.len().saturating_sub(1)),
+            target_label: format!(
+                "{} {}",
+                self.adopt_picker.target + 1,
+                self.pane_label(self.adopt_picker.target)
+            ),
+            rows: self
+                .adopt_picker
+                .terminals
+                .iter()
+                .map(|terminal| AdoptTerminalRow {
+                    label: terminal.label(),
+                    pid: terminal.pid,
+                    adoptable: terminal.is_adoptable(),
+                })
+                .collect(),
+            confirming: self.adopt_picker.confirming,
+        })
     }
 
     fn open_previous_panes(&mut self) {
@@ -8060,6 +8378,27 @@ impl App {
             self.status = format!("pane {} is no longer available", index + 1);
             return;
         }
+        self.refresh_activity_summary(index);
+    }
+
+    /// Forces the focused pane's summary to refresh now, skipping the cache.
+    ///
+    /// The automatic interval is deliberately slow, so the one thing the user
+    /// must always be able to do is ask for an answer about the pane in front of
+    /// them without waiting for it.
+    pub fn refresh_focused_pane_summary(&mut self) {
+        let Some(index) = self.focused_pane() else {
+            self.status = "focus a pane to refresh its AI summary".into();
+            return;
+        };
+        self.refresh_activity_summary(index);
+    }
+
+    fn refresh_activity_summary(&mut self, index: usize) {
+        if index >= self.panes.len() {
+            self.status = format!("pane {} is no longer available", index + 1);
+            return;
+        }
         if !self.config.manager.activity_summaries {
             self.status = "enable AI activity summaries in Settings > Manager".into();
             return;
@@ -8095,8 +8434,13 @@ impl App {
         state.force_refresh = true;
         state.dirty = true;
         state.dirty_since = Some(Instant::now());
-        let history_summary = self.pane_history_summary(index);
-        self.pane_settings.refresh_history(history_summary);
+        // The overlay only wants the new history when it is the thing on screen
+        // showing that pane; the status bar's refresh control reaches this same
+        // path with the overlay closed.
+        if self.pane_settings.open && self.pane_settings.pane_index == index {
+            let history_summary = self.pane_history_summary(index);
+            self.pane_settings.refresh_history(history_summary);
+        }
         self.status = if pending_input {
             format!(
                 "queued AI summary for pane {}; waiting for pending input",
@@ -8651,6 +8995,14 @@ impl App {
 
         if self.mouse_enabled
             && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && self.summary_refresh_button_at(mouse.column, mouse.row)
+        {
+            self.refresh_focused_pane_summary();
+            return Ok(true);
+        }
+
+        if self.mouse_enabled
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
             && self.previous_panes_button_at(mouse.column, mouse.row)
         {
             if self.previous_panes.open {
@@ -8907,6 +9259,11 @@ impl App {
 
     fn previous_panes_button_at(&self, x: u16, y: u16) -> bool {
         self.previous_panes_button
+            .is_some_and(|rect| rect_contains(rect, x, y))
+    }
+
+    fn summary_refresh_button_at(&self, x: u16, y: u16) -> bool {
+        self.summary_refresh_button
             .is_some_and(|rect| rect_contains(rect, x, y))
     }
 
@@ -10236,6 +10593,12 @@ impl App {
         &self.status
     }
 
+    /// Seeds the status bar before the first frame, for things the launcher
+    /// knows and the app does not.
+    pub fn set_status(&mut self, status: impl Into<String>) {
+        self.status = status.into();
+    }
+
     pub fn quit_confirmation_view(&self) -> Option<QuitConfirmationView> {
         self.quit_confirmation_pending.then_some(())?;
         Some(QuitConfirmationView {
@@ -10789,6 +11152,7 @@ impl App {
             .get(&pane.id())
             .filter(|state| state.generation == pane.generation());
 
+        let suspended = self.manager_goal.is_some();
         let detail = if let Some(goal) = self.manager_goal.as_ref() {
             // A running goal owns the summariser, and its objective is the better
             // answer to "what is this pane doing" anyway.
@@ -10809,9 +11173,22 @@ impl App {
             "summarizing…".into()
         };
 
+        let refreshable = !suspended
+            && self.config.manager.activity_summaries
+            && self.config.manager.is_configured()
+            && !pane.exited
+            && !self.sleeping.contains(&index);
+
         FocusedPaneSummary {
             title: format!("{} {}", index + 1, self.pane_label(index)),
             detail,
+            // The countdown only means anything while the cache it belongs to is
+            // the thing on screen.
+            refresh_in: refreshable
+                .then(|| activity_summary_refresh_in(state, Instant::now()))
+                .flatten(),
+            refreshing: state.is_some_and(|state| state.in_flight),
+            refreshable,
         }
     }
 
@@ -12037,11 +12414,21 @@ fn format_activity_summary_context(panes: &[ActivitySummaryContextPane]) -> Stri
 
 fn activity_summary_retry_delay(failure_count: u8) -> Duration {
     let exponent = failure_count.saturating_sub(1).min(8) as u32;
-    let seconds = ACTIVITY_SUMMARY_COOLDOWN
+    let seconds = ACTIVITY_SUMMARY_RETRY_BASE
         .as_secs()
         .saturating_mul(1_u64 << exponent)
         .min(ACTIVITY_SUMMARY_MAX_RETRY_DELAY.as_secs());
     Duration::from_secs(seconds)
+}
+
+/// How long the pane's cached summary has left before the summariser may spend
+/// another request on it. `None` means the cache is already stale.
+fn activity_summary_refresh_in(
+    state: Option<&ActivitySummaryState>,
+    now: Instant,
+) -> Option<Duration> {
+    let last_request = state?.last_request_at?;
+    ACTIVITY_SUMMARY_COOLDOWN.checked_sub(now.saturating_duration_since(last_request))
 }
 
 fn activity_summary_request_eligible(
@@ -13845,6 +14232,62 @@ mod tests {
         assert_eq!(app.active_grid_id, 42);
         assert!(app.assistant.open);
         assert_eq!(app.command_line.cwd, PathBuf::from("C:\\grid-one"));
+    }
+
+    /// On a terminal that never sends Alt — every stock macOS one — the leader
+    /// is the only way in to the shortcut table.
+    #[test]
+    fn the_leader_key_reaches_shortcuts_without_alt() {
+        let cli = Cli::parse_from(["gridbash"]);
+        let mut app = App::new(cli, Config::default()).expect("app");
+        app.keybindings = KeyBindings::from_overrides(&BTreeMap::from([(
+            "leader".to_string(),
+            "ctrl+g".to_string(),
+        )]))
+        .expect("leader");
+
+        let leader = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+        let press =
+            |app: &mut App, key| matches!(app.resolve_leader(key), LeaderOutcome::Handled(_));
+
+        // The leader itself is swallowed, and arms the key after it.
+        assert!(press(&mut app, leader));
+        assert!(app.leader_pending);
+
+        // That key then resolves as though Alt had been held.
+        let resolved =
+            match app.resolve_leader(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)) {
+                LeaderOutcome::Key(key) => key,
+                LeaderOutcome::Handled(_) => panic!("the leader swallowed a bound shortcut"),
+            };
+        assert_eq!(
+            app.keybindings.action_for(&resolved),
+            Some(Action::CommandLine)
+        );
+        assert!(!app.leader_pending);
+
+        // Pressed twice it goes to the pane, so the leader costs it nothing.
+        assert!(press(&mut app, leader));
+        assert!(matches!(
+            app.resolve_leader(leader),
+            LeaderOutcome::Key(key) if key == leader
+        ));
+
+        // Esc backs out.
+        assert!(press(&mut app, leader));
+        assert!(press(
+            &mut app,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+        ));
+        assert!(!app.leader_pending);
+
+        // An unbound key is reported, never typed into the pane a beat late.
+        assert!(press(&mut app, leader));
+        assert!(press(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('9'), KeyModifiers::NONE)
+        ));
+        assert!(app.status.contains("not a shortcut"), "{}", app.status);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,11 @@ pub struct Cli {
     /// Initial layout strategy.
     #[arg(long, value_enum, default_value_t = GridMode::Grid)]
     pub layout: GridMode,
+
+    /// Reopen the workspaces an interrupted GridBash left behind instead of
+    /// starting an empty one.
+    #[arg(long)]
+    pub recover: bool,
 }
 
 impl Cli {
@@ -83,7 +88,23 @@ impl Cli {
         !self.no_agent_api
     }
 
-    pub fn allows_automatic_recovery(&self) -> bool {
+    /// Whether this launch should adopt the workspaces of a GridBash that died
+    /// without cleaning up after itself.
+    ///
+    /// This used to happen on every bare `gridbash`, which meant one crash made
+    /// every later launch reopen the same workspace — the command for "give me a
+    /// fresh grid" quietly stopped meaning that. Recovery is worth keeping, but
+    /// it has to be asked for; the crashed sessions are still listed by
+    /// `gridbash resume` either way, and a plain launch says so when there are
+    /// any.
+    pub fn wants_interrupted_recovery(&self) -> bool {
+        self.recover && self.is_plain_launch()
+    }
+
+    /// A launch that named nothing: no grid, no profile, no directory, no mode.
+    /// Anything else is a deliberate description of the workspace to build, and
+    /// must not be answered with somebody else's.
+    pub fn is_plain_launch(&self) -> bool {
         self.command.is_none()
             && self.grid.is_none()
             && self.count.is_none()
@@ -327,24 +348,36 @@ mod tests {
         assert!(cli.command.is_none());
         assert_eq!(cli.grid.as_deref(), Some("2x3"));
         assert_eq!(cli.profile.as_deref(), Some("git-bash"));
-        assert!(!cli.allows_automatic_recovery());
+        assert!(!cli.is_plain_launch());
     }
 
+    /// A bare `gridbash` means "give me a new workspace". It stopped meaning
+    /// that once a single crash left a session behind, because every launch
+    /// afterwards silently reopened it.
     #[test]
-    fn automatic_recovery_only_applies_to_plain_launches() {
+    fn a_plain_launch_starts_fresh_unless_recovery_is_asked_for() {
         let plain = Cli::parse_from(["gridbash"]);
         assert!(plain.agent_control_enabled());
-        assert!(plain.allows_automatic_recovery());
+        assert!(plain.is_plain_launch());
+        assert!(!plain.wants_interrupted_recovery());
+
+        let recover = Cli::parse_from(["gridbash", "--recover"]);
+        assert!(recover.wants_interrupted_recovery());
+
+        // Recovery answers "reopen what was there", so it cannot be combined
+        // with a launch that describes a different workspace.
+        let described = Cli::parse_from(["gridbash", "--recover", "--worktrees"]);
+        assert!(!described.wants_interrupted_recovery());
 
         let worktrees = Cli::parse_from(["gridbash", "--worktrees"]);
-        assert!(!worktrees.allows_automatic_recovery());
+        assert!(!worktrees.is_plain_launch());
 
         let agent_api = Cli::parse_from(["gridbash", "--agent-api"]);
-        assert!(!agent_api.allows_automatic_recovery());
+        assert!(!agent_api.is_plain_launch());
 
         let no_agent_api = Cli::parse_from(["gridbash", "--no-agent-api"]);
         assert!(!no_agent_api.agent_control_enabled());
-        assert!(!no_agent_api.allows_automatic_recovery());
+        assert!(!no_agent_api.is_plain_launch());
 
         assert!(
             Cli::try_parse_from(["gridbash", "--no-agent-api", "--agent-api-port", "4321"])

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -96,7 +96,7 @@ pub struct Composer {
     default_name: String,
     rows: usize,
     columns: usize,
-    active: Field,
+    step: Step,
     suggestions: Suggestions,
     profile_name: String,
     profile_title: String,
@@ -112,20 +112,52 @@ pub struct Composer {
     shape_changed: Instant,
 }
 
+/// One question at a time.
+///
+/// The four inputs used to sit on screen together, reached by walking a cursor
+/// up and down through them. That asks the user to read the whole form before
+/// answering any of it, and it spends the arrow keys — the obvious way to size a
+/// grid — on moving between fields instead. Each step now owns the arrows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Field {
-    Rows,
-    Columns,
+pub enum Step {
+    Shape,
     Name,
     Project,
 }
 
-impl Field {
-    pub const ALL: [Self; 4] = [Self::Rows, Self::Columns, Self::Name, Self::Project];
+impl Step {
+    pub const ALL: [Self; 3] = [Self::Shape, Self::Name, Self::Project];
 
-    fn is_text(self) -> bool {
-        matches!(self, Self::Name | Self::Project)
+    fn index(self) -> usize {
+        Self::ALL
+            .iter()
+            .position(|step| *step == self)
+            .unwrap_or_default()
     }
+
+    fn offset(self, delta: isize) -> Option<Self> {
+        let next = self.index() as isize + delta;
+        (next >= 0).then(|| Self::ALL.get(next as usize).copied())?
+    }
+
+    fn is_last(self) -> bool {
+        self.index() + 1 == Self::ALL.len()
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Shape => "SHAPE",
+            Self::Name => "NAME",
+            Self::Project => "PROJECT",
+        }
+    }
+}
+
+/// Which side of the grid a key is sizing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Axis {
+    Rows,
+    Columns,
 }
 
 #[derive(Debug, Clone)]
@@ -203,7 +235,7 @@ impl Composer {
             base_dir,
             rows: DEFAULT_ROWS,
             columns: DEFAULT_COLUMNS,
-            active: Field::Rows,
+            step: Step::Shape,
             suggestions: Suggestions::default(),
             profile_title: profile.display_name(&profile_name),
             profile_name,
@@ -256,8 +288,23 @@ impl Composer {
 
     // ----------------------------------------------------------------- input
 
+    fn toggle_worktrees(&mut self) -> ComposerEvent {
+        self.worktrees_enabled = !self.worktrees_enabled;
+        self.notice = None;
+        ComposerEvent::Continue
+    }
+
     fn handle_key(&mut self, key: KeyEvent, config: &Config) -> ComposerEvent {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+        // Enter answers the question in front of the user: it moves on, and only
+        // launches once there is nothing left to ask.
         if is_enter_key(key) {
+            if !self.step.is_last() {
+                self.move_step(1);
+                return ComposerEvent::Continue;
+            }
             return match self.build_outcome(config) {
                 Ok(outcome) => ComposerEvent::Launch(Box::new(outcome)),
                 Err(error) => {
@@ -270,50 +317,62 @@ impl Composer {
             };
         }
 
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let alt = key.modifiers.contains(KeyModifiers::ALT);
-
         match key.code {
             KeyCode::Esc => return ComposerEvent::Quit,
             KeyCode::Char('c') if ctrl => return ComposerEvent::Quit,
-            KeyCode::Char('w') if alt => {
-                self.worktrees_enabled = !self.worktrees_enabled;
-                self.notice = None;
-                return ComposerEvent::Continue;
-            }
-            KeyCode::Tab if self.active == Field::Project => {
+            KeyCode::Char('w') if alt => return self.toggle_worktrees(),
+            // The wizard runs before the grid does, so it has no leader key to
+            // fall back on. A stock macOS terminal never sends Alt, and F2 is
+            // the one key that reaches this toggle on every platform.
+            KeyCode::F(2) => return self.toggle_worktrees(),
+            // Tab still completes a folder, because that is what it does in every
+            // shell. It only walks the wizard where there is nothing to complete.
+            KeyCode::Tab if self.step == Step::Project => {
                 self.complete_project();
                 return ComposerEvent::Continue;
             }
-            KeyCode::Tab | KeyCode::Down => {
-                self.move_field(1);
+            KeyCode::Tab => {
+                self.move_step(1);
                 return ComposerEvent::Continue;
             }
-            KeyCode::BackTab | KeyCode::Up => {
-                self.move_field(-1);
+            KeyCode::BackTab => {
+                self.move_step(-1);
                 return ComposerEvent::Continue;
             }
             _ => {}
         }
 
-        match self.active {
-            Field::Rows | Field::Columns => self.handle_shape_key(key),
-            Field::Name => self.handle_text_key(key, ctrl, TextTarget::Name),
-            Field::Project => self.handle_text_key(key, ctrl, TextTarget::Project),
+        match self.step {
+            Step::Shape => self.handle_shape_key(key),
+            Step::Name => self.handle_text_key(key, ctrl, TextTarget::Name),
+            Step::Project => self.handle_text_key(key, ctrl, TextTarget::Project),
         }
         ComposerEvent::Continue
     }
 
+    /// The shape step owns all four arrows, mapped to the thing they point at:
+    /// up and down make the grid taller and shorter, left and right make it
+    /// wider and narrower. Nothing has to be selected first.
     fn handle_shape_key(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Left | KeyCode::Char('-') | KeyCode::Char('_') => self.adjust_shape(-1),
-            KeyCode::Right | KeyCode::Char('+') | KeyCode::Char('=') => self.adjust_shape(1),
-            KeyCode::Home => self.set_shape(1),
-            KeyCode::End => self.set_shape(MAX_DIMENSION),
+            KeyCode::Up => self.adjust_shape(Axis::Rows, 1),
+            KeyCode::Down => self.adjust_shape(Axis::Rows, -1),
+            KeyCode::Right => self.adjust_shape(Axis::Columns, 1),
+            KeyCode::Left => self.adjust_shape(Axis::Columns, -1),
+            KeyCode::Char('+') | KeyCode::Char('=') => {
+                self.adjust_shape(Axis::Rows, 1);
+                self.adjust_shape(Axis::Columns, 1);
+            }
+            KeyCode::Char('-') | KeyCode::Char('_') => {
+                self.adjust_shape(Axis::Rows, -1);
+                self.adjust_shape(Axis::Columns, -1);
+            }
+            KeyCode::Home => self.set_square(1),
+            KeyCode::End => self.set_square(MAX_DIMENSION),
             KeyCode::Char(ch) if ch.is_ascii_digit() => {
                 let digit = ch.to_digit(10).unwrap_or(1) as usize;
                 // 0 reads as "all the way up", the way the resize picker works.
-                self.set_shape(if digit == 0 { MAX_DIMENSION } else { digit });
+                self.set_square(if digit == 0 { MAX_DIMENSION } else { digit });
             }
             _ => {}
         }
@@ -380,46 +439,58 @@ impl Composer {
             return;
         }
 
-        match self.active {
-            Field::Name => {
+        match self.step {
+            Step::Name => {
                 self.name.insert_str(&clean);
             }
-            Field::Project => {
+            Step::Project => {
                 self.project.insert_str(&clean);
                 self.project_touched = true;
                 self.refresh_suggestions();
                 self.refresh_project();
             }
-            Field::Rows | Field::Columns => return,
+            Step::Shape => return,
         }
         self.notice = None;
     }
 
-    fn move_field(&mut self, delta: isize) {
-        let current = Field::ALL
-            .iter()
-            .position(|field| *field == self.active)
-            .unwrap_or(0);
-        let next = (current as isize + delta).rem_euclid(Field::ALL.len() as isize) as usize;
-        self.active = Field::ALL[next];
-        if self.active == Field::Project {
+    /// Walks the wizard. Unlike the old field cursor this does not wrap: the
+    /// first step has nothing before it and the last is answered with Enter, so
+    /// wrapping would only ever be a way to lose your place.
+    fn move_step(&mut self, delta: isize) {
+        let Some(next) = self.step.offset(delta) else {
+            return;
+        };
+        self.step = next;
+        self.notice = None;
+        if next == Step::Project {
             self.refresh_suggestions();
         }
     }
 
-    fn adjust_shape(&mut self, delta: isize) {
-        let value = match self.active {
-            Field::Columns => self.columns,
-            _ => self.rows,
+    fn adjust_shape(&mut self, axis: Axis, delta: isize) {
+        let value = match axis {
+            Axis::Rows => self.rows,
+            Axis::Columns => self.columns,
         };
-        self.set_shape((value as isize + delta).clamp(1, MAX_DIMENSION as isize) as usize);
+        self.set_shape(
+            axis,
+            (value as isize + delta).clamp(1, MAX_DIMENSION as isize) as usize,
+        );
     }
 
-    fn set_shape(&mut self, value: usize) {
+    /// Typing a digit asks for the square grid most people mean by "three".
+    /// The arrows are there to take it out of square afterwards.
+    fn set_square(&mut self, value: usize) {
+        self.set_shape(Axis::Rows, value);
+        self.set_shape(Axis::Columns, value);
+    }
+
+    fn set_shape(&mut self, axis: Axis, value: usize) {
         let value = value.clamp(1, MAX_DIMENSION);
-        let slot = match self.active {
-            Field::Columns => &mut self.columns,
-            _ => &mut self.rows,
+        let slot = match axis {
+            Axis::Rows => &mut self.rows,
+            Axis::Columns => &mut self.columns,
         };
         if *slot == value {
             return;
@@ -792,24 +863,77 @@ impl Composer {
             return;
         }
 
+        // One step at a time, sized to what it actually asks. The two short
+        // steps keep their box tight and let the rail sit under them instead of
+        // floating at the bottom of a mostly empty panel; the project step wants
+        // everything left over for its folder browser.
+        let rail = 2u16.min(area.height.saturating_sub(4));
+        let body = area.height.saturating_sub(rail);
+        let step_height = match self.step {
+            Step::Shape => 5.min(body),
+            Step::Name => 4.min(body),
+            Step::Project => body,
+        };
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(4), Constraint::Min(4)])
+            .constraints([
+                Constraint::Length(step_height),
+                Constraint::Length(rail),
+                Constraint::Min(0),
+            ])
             .split(area);
 
-        self.draw_shape(frame, chunks[0], tick);
-        self.draw_identity(frame, chunks[1], tick);
+        match self.step {
+            Step::Shape => self.draw_shape(frame, chunks[0], tick),
+            Step::Name => self.draw_name(frame, chunks[0], tick),
+            Step::Project => self.draw_project(frame, chunks[0], tick),
+        }
+        if rail > 0 {
+            self.draw_step_rail(frame, chunks[1]);
+        }
+    }
+
+    /// The step numbers, so the wizard says how far along it is without the user
+    /// having to remember how many questions there were.
+    fn draw_step_rail(&self, frame: &mut Frame<'_>, area: Rect) {
+        let current = self.step;
+        let mut spans = Vec::new();
+        for (index, step) in Step::ALL.iter().enumerate() {
+            if index > 0 {
+                spans.push(Span::styled("  ", Style::default().fg(MUTED)));
+            }
+            let done = index < current.index();
+            let style = if *step == current {
+                Style::default()
+                    .fg(TERMINAL_GREEN)
+                    .add_modifier(Modifier::BOLD)
+            } else if done {
+                Style::default().fg(DIM_GREEN)
+            } else {
+                Style::default().fg(MUTED)
+            };
+            spans.push(Span::styled(
+                format!(
+                    "{}{} {}",
+                    if done { "✓" } else { " " },
+                    index + 1,
+                    step.label()
+                ),
+                style,
+            ));
+        }
+
+        frame.render_widget(
+            Paragraph::new(Line::from(spans)).style(Style::default().bg(RAISED_BG)),
+            area,
+        );
     }
 
     fn draw_shape(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
         if area.height < 4 {
             return;
         }
-        let block = section_block(
-            "01",
-            "SHAPE",
-            self.active_in(&[Field::Rows, Field::Columns]),
-        );
+        let block = section_block("01", "HOW BIG?", true);
         let inner = inset(block.inner(area), 1, 0);
         frame.render_widget(block, area);
         if inner.width == 0 || inner.height == 0 {
@@ -817,31 +941,28 @@ impl Composer {
         }
 
         let width = inner.width as usize;
-        let lines = vec![
-            shape_row("ROWS", self.rows, self.active == Field::Rows, tick, width),
-            shape_row(
-                "COLUMNS",
-                self.columns,
-                self.active == Field::Columns,
-                tick,
-                width,
-            ),
+        // Both numbers are live at once now, so neither is drawn as the one the
+        // cursor happens to be parked on.
+        let mut lines = vec![
+            shape_row("ROWS", self.rows, true, tick, width),
+            shape_row("COLUMNS", self.columns, true, tick, width),
+            hint_row(Span::styled(
+                truncate("↑↓ rows · ←→ columns · 1-9 for a square", width),
+                Style::default().fg(MUTED),
+            )),
         ];
+        lines.truncate(inner.height as usize);
         frame.render_widget(
             Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
             inner,
         );
     }
 
-    fn draw_identity(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+    fn draw_name(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
         if area.height < 4 {
             return;
         }
-        let block = section_block(
-            "02",
-            "IDENTITY",
-            self.active_in(&[Field::Name, Field::Project]),
-        );
+        let block = section_block("02", "CALL IT WHAT?", true);
         let inner = inset(block.inner(area), 1, 0);
         frame.render_widget(block, area);
         if inner.width == 0 || inner.height == 0 {
@@ -851,15 +972,7 @@ impl Composer {
         let value_width = (inner.width as usize).saturating_sub(13).max(6);
         let hint_width = (inner.width as usize).saturating_sub(11).max(6);
         let mut lines = vec![
-            text_row(
-                "NAME",
-                &self.name,
-                self.active == Field::Name,
-                tick,
-                value_width,
-                None,
-                DIM_GREEN,
-            ),
+            text_row("NAME", &self.name, true, tick, value_width, None, DIM_GREEN),
             hint_row(Span::styled(
                 truncate(
                     &if self.name.value.trim().is_empty() {
@@ -871,10 +984,32 @@ impl Composer {
                 ),
                 Style::default().fg(MUTED),
             )),
+        ];
+        lines.truncate(inner.height as usize);
+        frame.render_widget(
+            Paragraph::new(lines).style(Style::default().bg(RAISED_BG)),
+            inner,
+        );
+    }
+
+    fn draw_project(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
+        if area.height < 4 {
+            return;
+        }
+        let block = section_block("03", "WHERE?", true);
+        let inner = inset(block.inner(area), 1, 0);
+        frame.render_widget(block, area);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+
+        let value_width = (inner.width as usize).saturating_sub(13).max(6);
+        let hint_width = (inner.width as usize).saturating_sub(11).max(6);
+        let mut lines = vec![
             text_row(
                 "PROJECT",
                 &self.project,
-                self.active == Field::Project,
+                true,
                 tick,
                 value_width,
                 self.project_ghost().as_deref(),
@@ -893,6 +1028,8 @@ impl Composer {
             },
         );
 
+        // The folder browser gets everything the step does not need, which on
+        // its own step is most of the panel.
         let remaining = inner.height.saturating_sub(used);
         if remaining >= 2 {
             self.draw_suggestions(
@@ -910,7 +1047,7 @@ impl Composer {
     /// the field is not focused, so the panel always shows where else the grid
     /// could land instead of a block of dead space.
     fn draw_suggestions(&self, frame: &mut Frame<'_>, area: Rect) {
-        let focused = self.active == Field::Project;
+        let focused = self.step == Step::Project;
         let folders = &self.suggestions.siblings;
         let matches = &self.suggestions.matches;
         let selected = self
@@ -998,7 +1135,7 @@ impl Composer {
 
     /// Dim text after the cursor showing what Tab would fill in.
     fn project_ghost(&self) -> Option<String> {
-        if self.active != Field::Project || self.project.cursor != self.project.len() {
+        if self.step != Step::Project || self.project.cursor != self.project.len() {
             return None;
         }
         if self.suggestions.index.is_some() {
@@ -1029,17 +1166,15 @@ impl Composer {
         }
     }
 
-    fn active_in(&self, fields: &[Field]) -> bool {
-        fields.contains(&self.active)
-    }
-
     // --------------------------------------------------------------- preview
 
     fn draw_preview(&self, frame: &mut Frame<'_>, area: Rect, tick: u64) {
         if area.width < 20 || area.height < 6 {
             return;
         }
-        let block = section_block("03", "LIVE GRID", false);
+        // No step number: the preview is not a question, it is the answer to
+        // the one being asked.
+        let block = section_block("◆", "LIVE GRID", false);
         let inner = inset(block.inner(area), 1, 0);
         frame.render_widget(block, area);
         if inner.width == 0 || inner.height == 0 {
@@ -1203,10 +1338,10 @@ impl Composer {
     }
 
     fn hint_notice(&self) -> Notice {
-        let text = match self.active {
-            Field::Rows | Field::Columns => "type a digit, or ←/→ to resize the grid",
-            Field::Name => "name this grid so its tab is easy to find",
-            Field::Project => "Tab completes folders · Tab again cycles matches",
+        let text = match self.step {
+            Step::Shape => "how many panes? arrows size the grid, Enter moves on",
+            Step::Name => "name this grid so its tab is easy to find, or leave it",
+            Step::Project => "Tab completes folders · Enter launches",
         };
         Notice {
             text: text.into(),
@@ -1215,22 +1350,27 @@ impl Composer {
     }
 
     fn controls_line(&self, width: u16) -> Line<'static> {
-        let mut spans = vec![
-            keycap("↑↓"),
-            label("FIELD"),
-            keycap("←→"),
-            label(if self.active.is_text() {
-                "CURSOR"
-            } else {
-                "SIZE"
-            }),
-            keycap("TAB"),
-            label(if self.active == Field::Project {
-                "COMPLETE"
-            } else {
-                "NEXT"
-            }),
-        ];
+        // Each step advertises only the keys that do something on it. The old
+        // line promised UP/DOWN FIELD everywhere, which was the whole habit this
+        // screen is trying to drop.
+        let mut spans = match self.step {
+            Step::Shape => vec![keycap("↑↓←→"), label("SIZE")],
+            Step::Name | Step::Project => vec![keycap("←→"), label("CURSOR")],
+        };
+        if self.step == Step::Project {
+            spans.push(keycap("TAB"));
+            spans.push(label("COMPLETE"));
+        }
+        spans.push(keycap("ENTER"));
+        spans.push(label(if self.step.is_last() {
+            "LAUNCH"
+        } else {
+            "NEXT"
+        }));
+        if self.step != Step::Shape {
+            spans.push(keycap("SHIFT+TAB"));
+            spans.push(label("BACK"));
+        }
         if width >= 78 {
             spans.push(keycap("ALT+W"));
             spans.push(label("WORKTREES"));
@@ -2686,69 +2826,93 @@ mod tests {
         assert_eq!(name, TEST_PROFILE);
     }
 
+    /// The screen asks one question at a time, and Enter answers it. Launching
+    /// is what happens when there is nothing left to ask, not something Enter
+    /// could do from anywhere.
     #[test]
-    fn only_four_fields_are_reachable_and_enter_launches_from_each() {
+    fn the_wizard_walks_one_step_at_a_time() {
         let config = shell_config();
         let mut composer = composer();
 
-        assert_eq!(
-            Field::ALL,
-            [Field::Rows, Field::Columns, Field::Name, Field::Project]
-        );
-        for field in Field::ALL {
-            composer.active = field;
+        assert_eq!(Step::ALL, [Step::Shape, Step::Name, Step::Project]);
+        assert_eq!(composer.step, Step::Shape);
+
+        for expected in [Step::Name, Step::Project] {
             let event =
                 composer.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &config);
             assert!(
-                matches!(event, ComposerEvent::Launch(_)),
-                "Enter did not launch from {field:?}"
+                matches!(event, ComposerEvent::Continue),
+                "Enter launched before the last step"
             );
+            assert_eq!(composer.step, expected);
+        }
+        assert!(matches!(
+            composer.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), &config),
+            ComposerEvent::Launch(_)
+        ));
+
+        // Shift+Tab walks back, and stops rather than wrapping round the end.
+        for expected in [Step::Name, Step::Shape, Step::Shape] {
+            press(&mut composer, KeyCode::BackTab, &config);
+            assert_eq!(composer.step, expected);
         }
 
-        // Down wraps through exactly the four fields.
-        composer.active = Field::Rows;
-        for expected in [Field::Columns, Field::Name, Field::Project, Field::Rows] {
-            press(&mut composer, KeyCode::Down, &config);
-            assert_eq!(composer.active, expected);
+        // The arrows belong to the step now, so they no longer move between
+        // steps — which is the whole point of splitting the form up.
+        for code in [KeyCode::Down, KeyCode::Up] {
+            press(&mut composer, code, &config);
+            assert_eq!(composer.step, Step::Shape);
         }
 
         // Tab advances everywhere except Project, where it completes instead.
-        for expected in [Field::Columns, Field::Name, Field::Project] {
+        for expected in [Step::Name, Step::Project] {
             press(&mut composer, KeyCode::Tab, &config);
-            assert_eq!(composer.active, expected);
+            assert_eq!(composer.step, expected);
         }
         press(&mut composer, KeyCode::Tab, &config);
-        assert_eq!(composer.active, Field::Project);
+        assert_eq!(composer.step, Step::Project);
         press(&mut composer, KeyCode::BackTab, &config);
-        assert_eq!(composer.active, Field::Name);
+        assert_eq!(composer.step, Step::Name);
     }
 
+    /// On the shape step the arrows point at what they change: down and up size
+    /// the grid vertically, left and right size it horizontally. Nothing has to
+    /// be selected first, because there is nothing else on the step.
     #[test]
-    fn digits_and_arrows_shape_the_grid() {
+    fn arrows_size_the_grid_along_the_axis_they_point_at() {
         let config = shell_config();
         let mut composer = composer();
+        assert_eq!(composer.step, Step::Shape);
 
-        composer.active = Field::Rows;
-        press(&mut composer, KeyCode::Char('4'), &config);
-        composer.active = Field::Columns;
+        // A digit asks for the square most people mean by that number.
+        press(&mut composer, KeyCode::Char('3'), &config);
+        assert_eq!(composer.grid().rows, 3);
+        assert_eq!(composer.grid().columns, 3);
+
+        press(&mut composer, KeyCode::Up, &config);
+        assert_eq!(composer.grid().rows, 4);
+        assert_eq!(composer.grid().columns, 3, "up must not touch columns");
+        press(&mut composer, KeyCode::Right, &config);
+        assert_eq!(composer.grid().columns, 4);
+        assert_eq!(composer.grid().rows, 4, "right must not touch rows");
+
+        // 0 still reads as "all the way up", and both axes clamp at 1.
         press(&mut composer, KeyCode::Char('0'), &config);
-        assert_eq!(composer.grid().rows, 4);
+        assert_eq!(composer.grid().rows, MAX_DIMENSION);
         assert_eq!(composer.grid().columns, MAX_DIMENSION);
-
-        press(&mut composer, KeyCode::Left, &config);
-        assert_eq!(composer.grid().columns, MAX_DIMENSION - 1);
-        for _ in 0..20 {
+        for _ in 0..MAX_DIMENSION + 5 {
             press(&mut composer, KeyCode::Left, &config);
+            press(&mut composer, KeyCode::Down, &config);
         }
+        assert_eq!(composer.grid().rows, 1);
         assert_eq!(composer.grid().columns, 1);
-        assert_eq!(composer.grid().rows, 4);
     }
 
     #[test]
     fn typing_a_name_titles_the_grid_and_empty_names_fall_back() {
         let config = shell_config();
         let mut composer = composer();
-        composer.active = Field::Name;
+        composer.step = Step::Name;
         for _ in 0..MAX_NAME_CHARS {
             press(&mut composer, KeyCode::Backspace, &config);
         }
@@ -2770,7 +2934,7 @@ mod tests {
         fs::create_dir_all(root.join("alpha-one").join("nested")).expect("nested dir");
 
         let mut composer = composer_in(root.clone());
-        composer.active = Field::Project;
+        composer.step = Step::Project;
 
         let base = display_path(&root.canonicalize().expect("canonical root"));
         composer
@@ -2810,7 +2974,7 @@ mod tests {
     fn unresolvable_projects_block_launch_with_a_visible_reason() {
         let config = shell_config();
         let mut composer = composer();
-        composer.active = Field::Project;
+        composer.step = Step::Project;
         composer
             .project
             .set("definitely-not-a-gridbash-project".into());
@@ -2853,6 +3017,10 @@ mod tests {
             &config,
         );
         assert!(!composer.worktrees_active());
+
+        // F2 is the same toggle for a terminal that will not send Alt.
+        composer.handle_key(KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE), &config);
+        assert!(composer.worktrees_active());
     }
 
     #[test]
@@ -2863,18 +3031,38 @@ mod tests {
 
         assert!(text.contains("NEW GRID"));
         assert!(text.contains(WORDMARK[1]), "wordmark row missing");
-        assert!(text.contains("SHAPE"));
-        assert!(text.contains("IDENTITY"));
+        assert!(text.contains("HOW BIG?"));
         assert!(text.contains("LIVE GRID"));
         assert!(text.contains("ROWS"));
         assert!(text.contains("COLUMNS"));
-        assert!(text.contains("NAME"));
-        assert!(text.contains("PROJECT"));
-        assert!(text.contains("LAUNCH"));
         assert!(text.contains("PANES"));
+        // The step rail names every question, including the ones not being
+        // asked yet, so the wizard says how long it is up front.
+        for step in Step::ALL {
+            assert!(
+                text.contains(step.label()),
+                "{} missing from the rail",
+                step.label()
+            );
+        }
+        // Only the current step's input is on screen; the later ones are just
+        // names on the rail.
+        assert!(
+            !text.contains("WHERE?"),
+            "a later step leaked onto the shape step"
+        );
         // The knobs this revamp removed must not come back.
         assert!(!text.contains("Auth"));
         assert!(!text.contains("START WORKSPACE"));
+
+        // Walking to the last step swaps the panel over and offers the launch.
+        let mut composer = composer;
+        composer.step = Step::Project;
+        let text = rendered(140, 40, &composer, &config);
+        assert!(text.contains("WHERE?"));
+        assert!(text.contains("PROJECT"));
+        assert!(text.contains("LAUNCH"));
+        assert!(!text.contains("HOW BIG?"));
     }
 
     #[test]
@@ -2972,8 +3160,11 @@ mod tests {
         let composer = composer();
         let text = rendered(72, 18, &composer, &config);
 
-        assert!(text.contains("SHAPE"));
-        assert!(text.contains("IDENTITY"));
+        assert!(text.contains("HOW BIG?"));
+        assert!(
+            text.contains("SHAPE"),
+            "the step rail survives a small screen"
+        );
         assert!(text.contains("LAUNCH"));
         assert!(text.contains("ENTER"));
     }
@@ -2982,7 +3173,7 @@ mod tests {
     fn draws_at_every_size_without_panicking() {
         let config = shell_config();
         let mut composer = composer();
-        composer.active = Field::Project;
+        composer.step = Step::Project;
         composer.refresh_suggestions();
 
         for width in [8u16, 20, 40, 72, 96, 140, 200] {
@@ -3025,12 +3216,12 @@ mod tests {
         // Let the reveal animation finish so the dump shows the settled screen.
         composer.shape_changed = Instant::now() - Duration::from_secs(2);
         for (width, height, field) in [
-            (140u16, 40u16, Field::Rows),
-            (140, 40, Field::Project),
-            (96, 30, Field::Name),
-            (80, 24, Field::Rows),
+            (140u16, 40u16, Step::Shape),
+            (140, 40, Step::Project),
+            (96, 30, Step::Name),
+            (80, 24, Step::Shape),
         ] {
-            composer.active = field;
+            composer.step = field;
             composer.refresh_suggestions();
             let mut terminal =
                 Terminal::new(TestBackend::new(width, height)).expect("test terminal");

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -37,6 +37,7 @@ pub enum Action {
     AuthProfiles,
     RenameTab,
     RenamePane,
+    AdoptTerminal,
 }
 
 const ACTIONS: &[Action] = &[
@@ -65,6 +66,7 @@ const ACTIONS: &[Action] = &[
     Action::ZoomPane,
     Action::ResizeGrid,
     Action::RenamePane,
+    Action::AdoptTerminal,
     Action::RestartPanes,
     Action::SwapPanes,
     Action::SleepPanes,
@@ -113,6 +115,7 @@ impl Action {
             Self::AuthProfiles => "auth-profiles",
             Self::RenameTab => "rename-tab",
             Self::RenamePane => "rename-pane",
+            Self::AdoptTerminal => "adopt-terminal",
         }
     }
 
@@ -150,6 +153,7 @@ impl Action {
             Self::AuthProfiles => "manage and assign auth profiles",
             Self::RenameTab => "rename current tab",
             Self::RenamePane => "rename focused pane",
+            Self::AdoptTerminal => "open a pane where an outside Git Bash window is",
         }
     }
 
@@ -191,6 +195,7 @@ impl Action {
             Self::AuthProfiles => "alt+shift+a",
             Self::RenameTab => "alt+shift+r",
             Self::RenamePane => "alt+r",
+            Self::AdoptTerminal => "ctrl+alt+t",
         }
     }
 }
@@ -327,9 +332,29 @@ fn parse_key(value: &str) -> Result<ShortcutKey> {
     }
 }
 
+/// The name the `[keys]` table uses for the leader key.
+const LEADER_KEY: &str = "leader";
+
+/// The leader shortcut a platform starts with.
+///
+/// macOS terminals spend the Option key on character composition — Option+C is
+/// `ç`, not Alt+C — so out of the box a Mac cannot press a single GridBash
+/// shortcut. A leader key gives every one of them back without asking the user
+/// to reconfigure their terminal before the app is usable. Everywhere else Alt
+/// arrives intact, and taking a Ctrl key away from the panes would cost more
+/// than it returns, so there is no leader unless one is configured.
+#[cfg(target_os = "macos")]
+const DEFAULT_LEADER: Option<&str> = Some("ctrl+g");
+#[cfg(not(target_os = "macos"))]
+const DEFAULT_LEADER: Option<&str> = None;
+
+/// Values that turn the leader off in config.
+const LEADER_DISABLED: [&str; 4] = ["", "off", "none", "false"];
+
 #[derive(Debug, Clone)]
 pub struct KeyBindings {
     bindings: BTreeMap<Action, Shortcut>,
+    leader: Option<Shortcut>,
 }
 
 impl KeyBindings {
@@ -341,6 +366,7 @@ impl KeyBindings {
                 Shortcut::parse(action.default_chord()).map(|shortcut| (action, shortcut))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
+        let mut leader = DEFAULT_LEADER.map(Shortcut::parse).transpose()?;
 
         for (name, chord) in overrides {
             let normalized = name.trim().to_ascii_lowercase();
@@ -349,9 +375,20 @@ impl KeyBindings {
                     "[keys] action '{name}' was removed; use 'command-line' and the Alt+C BashBot Director command center"
                 );
             }
+            if normalized == LEADER_KEY {
+                let requested = chord.trim().to_ascii_lowercase();
+                leader = if LEADER_DISABLED.contains(&requested.as_str()) {
+                    None
+                } else {
+                    Some(Shortcut::parse(chord).map_err(|error| {
+                        anyhow!("invalid [keys].leader shortcut '{chord}': {error}")
+                    })?)
+                };
+                continue;
+            }
             let action = Action::from_name(&normalized).ok_or_else(|| {
                 anyhow!(
-                    "unknown [keys] action '{name}'; supported actions: {}",
+                    "unknown [keys] action '{name}'; supported actions: {LEADER_KEY}, {}",
                     ACTIONS
                         .iter()
                         .map(|action| action.name())
@@ -379,7 +416,29 @@ impl KeyBindings {
             }
         }
 
-        Ok(Self { bindings })
+        // A leader that is also a shortcut would swallow that shortcut, since
+        // the leader is read before anything else.
+        if let Some(leader) = leader
+            && let Some(action) = seen.get(&leader)
+        {
+            bail!(
+                "shortcut {} is the leader key and is also assigned to '{}'",
+                leader.label(),
+                action.name()
+            );
+        }
+
+        Ok(Self { bindings, leader })
+    }
+
+    /// Whether this event is the leader key itself.
+    pub fn is_leader(&self, event: &KeyEvent) -> bool {
+        self.leader.is_some_and(|shortcut| shortcut.matches(event))
+    }
+
+    /// How the leader key is written for the user, when there is one.
+    pub fn leader_label(&self) -> Option<String> {
+        self.leader.map(Shortcut::label)
     }
 
     pub fn action_for(&self, event: &KeyEvent) -> Option<Action> {
@@ -391,10 +450,10 @@ impl KeyBindings {
     }
 
     pub fn help_entries(&self) -> Vec<(String, &'static str)> {
-        ACTIONS
-            .iter()
-            .copied()
-            .map(|action| {
+        self.leader_label()
+            .map(|label| (label, "leader: press it, then a shortcut key without Alt"))
+            .into_iter()
+            .chain(ACTIONS.iter().copied().map(|action| {
                 // `from_overrides` seeds every action, but indexing a map that
                 // is one action short would panic instead of degrading.
                 let label = match self.shortcut_for(action) {
@@ -408,7 +467,7 @@ impl KeyBindings {
                     },
                 };
                 (label, action.description())
-            })
+            }))
             .collect()
     }
 
@@ -440,6 +499,22 @@ fn fallback_quit_shortcut() -> Shortcut {
         shift: false,
         key: ShortcutKey::Char('q'),
     }
+}
+
+/// The same key press with Alt held.
+///
+/// The leader stands in for Alt, so the key after it is matched as though Alt
+/// had been held: leader then `C` runs Alt+C, and leader then `Ctrl+P` runs
+/// Ctrl+Alt+P.
+pub fn with_leader_alt(event: &KeyEvent) -> KeyEvent {
+    let mut event = *event;
+    event.modifiers |= KeyModifiers::ALT;
+    // A terminal that reports a capital letter without also reporting Shift
+    // would otherwise reach none of the Alt+Shift bindings through the leader.
+    if matches!(event.code, KeyCode::Char(ch) if ch.is_ascii_uppercase()) {
+        event.modifiers |= KeyModifiers::SHIFT;
+    }
+    event
 }
 
 fn fallback_help_shortcut() -> Shortcut {
@@ -477,7 +552,8 @@ mod tests {
                 .label(),
             "a missing binding falls back to the action's default chord"
         );
-        assert_eq!(bindings.help_entries().len(), ACTIONS.len());
+        let leader_rows = usize::from(bindings.leader_label().is_some());
+        assert_eq!(bindings.help_entries().len(), ACTIONS.len() + leader_rows);
         assert!(
             bindings
                 .action_for(&KeyEvent::new(KeyCode::Char('q'), KeyModifiers::ALT))
@@ -548,6 +624,106 @@ mod tests {
             KeyBindings::from_overrides(&overrides(&[("quit", "ctrl+q"), ("zoom-pane", "alt+q")]))
                 .expect_err("quit recovery key");
         assert!(alt_q.to_string().contains("Alt+Q is reserved"));
+    }
+
+    /// The whole point of the leader: a Mac that never sends Alt can still
+    /// reach every shortcut.
+    #[test]
+    fn the_leader_stands_in_for_alt() {
+        let bindings =
+            KeyBindings::from_overrides(&overrides(&[("leader", "ctrl+g")])).expect("leader");
+
+        assert!(bindings.is_leader(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL)));
+        assert_eq!(bindings.leader_label().as_deref(), Some("Ctrl+G"));
+
+        // Plain letters reach the Alt bindings.
+        assert_eq!(
+            bindings.action_for(&with_leader_alt(&KeyEvent::new(
+                KeyCode::Char('c'),
+                KeyModifiers::NONE
+            ))),
+            Some(Action::CommandLine)
+        );
+        // Arrows too, which are the shortcuts most likely to be reached for.
+        assert_eq!(
+            bindings.action_for(&with_leader_alt(&KeyEvent::new(
+                KeyCode::Left,
+                KeyModifiers::NONE
+            ))),
+            Some(Action::FocusLeft)
+        );
+        // Ctrl+Alt chords need only their Ctrl half after the leader.
+        assert_eq!(
+            bindings.action_for(&with_leader_alt(&KeyEvent::new(
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL
+            ))),
+            Some(Action::Ports)
+        );
+        // An unbound key resolves to nothing rather than to a near miss.
+        assert_eq!(
+            bindings.action_for(&with_leader_alt(&KeyEvent::new(
+                KeyCode::Char('9'),
+                KeyModifiers::NONE
+            ))),
+            None
+        );
+    }
+
+    /// Alt+Shift bindings are reachable through the leader whether or not the
+    /// terminal reports Shift alongside the capital letter.
+    #[test]
+    fn the_leader_reaches_shifted_shortcuts_either_way() {
+        let bindings =
+            KeyBindings::from_overrides(&overrides(&[("leader", "ctrl+g")])).expect("leader");
+
+        for modifiers in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+            assert_eq!(
+                bindings.action_for(&with_leader_alt(&KeyEvent::new(
+                    KeyCode::Char('C'),
+                    modifiers
+                ))),
+                Some(Action::CaptureOutput),
+                "{modifiers:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_leader_can_be_turned_off_and_cannot_shadow_a_shortcut() {
+        for value in ["off", "none", "false", ""] {
+            let bindings = KeyBindings::from_overrides(&overrides(&[("leader", value)]))
+                .expect("leader override");
+            assert_eq!(bindings.leader_label(), None, "{value}");
+            assert!(!bindings.is_leader(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL)));
+        }
+
+        let clash = KeyBindings::from_overrides(&overrides(&[
+            ("leader", "ctrl+g"),
+            ("zoom-pane", "ctrl+g"),
+        ]))
+        .expect_err("leader that shadows a shortcut");
+        assert!(clash.to_string().contains("leader key"));
+
+        let invalid = KeyBindings::from_overrides(&overrides(&[("leader", "ctrl+shift+nope")]))
+            .expect_err("invalid leader");
+        assert!(invalid.to_string().contains("[keys].leader"));
+    }
+
+    /// Whatever the platform default is, it must parse and must not collide
+    /// with a shipped binding.
+    #[test]
+    fn the_platform_default_leader_is_usable() {
+        let bindings = KeyBindings::from_overrides(&BTreeMap::new()).expect("default bindings");
+        assert_eq!(
+            bindings.leader_label(),
+            DEFAULT_LEADER.map(|chord| {
+                Shortcut::parse(chord)
+                    .expect("default leader parses")
+                    .label()
+            })
+        );
+        assert_eq!(bindings.leader_label().is_some(), cfg!(target_os = "macos"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod adopt;
 mod app;
 mod auth;
 mod cli;
@@ -37,7 +38,7 @@ use crate::{
     cli::{Cli, Command},
     config::Config,
     profiles::{find_profile, profile_diagnostics},
-    session::{claim_interrupted_recovery, select_resume_session},
+    session::{claim_interrupted_recovery, interrupted_session_count, select_resume_session},
 };
 
 fn main() -> Result<()> {
@@ -145,7 +146,7 @@ fn run(cli: Cli) -> Result<()> {
         return app.run();
     }
 
-    if cli.allows_automatic_recovery()
+    if cli.wants_interrupted_recovery()
         && let Some(recovery) = claim_interrupted_recovery()?
     {
         let mut app = App::recover_interrupted(
@@ -158,7 +159,27 @@ fn run(cli: Cli) -> Result<()> {
         return app.run();
     }
 
+    // A fresh grid that silently strands a crashed workspace is worse than
+    // either outcome on its own, so the new session says what is still there and
+    // how to get it back. Failing to read the session directory is not a reason
+    // to refuse to start.
+    let notice = cli
+        .is_plain_launch()
+        .then(|| interrupted_session_count().unwrap_or(0))
+        .filter(|count| *count > 0)
+        .map(|count| {
+            format!(
+                "{count} interrupted workspace{} can be reopened with `gridbash --recover`",
+                if count == 1 { "" } else { "s" }
+            )
+        });
+
     let mut app = App::new(cli, config)?;
+    // Nothing else in the interface would explain why every shortcut appears to
+    // do nothing, so the leader is said out loud on the platforms that need it.
+    if let Some(notice) = notice.or_else(|| app.leader_hint()) {
+        app.set_status(notice);
+    }
     app.run()
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1325,6 +1325,31 @@ pub fn claim_interrupted_recovery() -> Result<Option<InterruptedRecovery>> {
     with_session_state_lock(claim_interrupted_recovery_locked)
 }
 
+/// How long an interrupted session stays worth mentioning on a plain launch.
+///
+/// Nothing clears these records any more now that a plain launch leaves them
+/// alone, so without a window the notice would only ever count upwards — one
+/// crash a month ago would still be reported today, next to a fresh one.
+const RECOVERY_NOTICE_WINDOW_SECS: u64 = 24 * 60 * 60;
+
+/// How many saved sessions were recently left running by a GridBash that is
+/// gone.
+///
+/// Unlike `claim_interrupted_recovery` this takes nothing: it exists so a plain
+/// launch can mention that the workspaces are still there without adopting them.
+/// Older ones are still reachable through `gridbash resume`.
+pub fn interrupted_session_count() -> Result<usize> {
+    with_session_state_lock(|| {
+        let cutoff = now_seconds().saturating_sub(RECOVERY_NOTICE_WINDOW_SECS);
+        Ok(load_recent_sessions()?
+            .iter()
+            .filter(|record| {
+                is_interrupted_agent_session(record) && record.session.updated_at >= cutoff
+            })
+            .count())
+    })
+}
+
 pub fn complete_interrupted_recovery(claim: &InterruptedRecoveryClaim) -> Result<()> {
     with_session_state_lock(|| {
         for source in &claim.sources {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,12 +11,12 @@ use vt100::Cell;
 
 use crate::{
     app::{
-        App, AssistantMessageRole, BackgroundJobState, BackgroundJobView, BackgroundJobsView,
-        CloseGridConfirmationView, CommandPaletteView, ExitedPaneRecoveryView, FocusedPaneSummary,
-        FollowUpDialog, GridPalette, PaneSelection, PaneSettingsTarget, PaneSettingsView,
-        PortInspectorView, PreviousPaneView, PreviousPanesView, QuitConfirmationView,
-        RenamePaneView, RenameTabView, SettingsGroup, SettingsRow, SettingsTab, SettingsValueKind,
-        TabLabel, WorkspaceAssistantView,
+        AdoptTerminalView, App, AssistantMessageRole, BackgroundJobState, BackgroundJobView,
+        BackgroundJobsView, CloseGridConfirmationView, CommandPaletteView, ExitedPaneRecoveryView,
+        FocusedPaneSummary, FollowUpDialog, GridPalette, PaneSelection, PaneSettingsTarget,
+        PaneSettingsView, PortInspectorView, PreviousPaneView, PreviousPanesView,
+        QuitConfirmationView, RenamePaneView, RenameTabView, SettingsGroup, SettingsRow,
+        SettingsTab, SettingsValueKind, TabLabel, WorkspaceAssistantView,
     },
     auth::{AgentKind, AuthProfile},
     copy_mode::{CopyCellKind, CopyModeView, TextPoint},
@@ -80,6 +80,7 @@ pub struct DrawState {
     pub tab_rects: Vec<(usize, Rect)>,
     pub previous_panes_button: Option<Rect>,
     pub previous_pane_rows: Vec<(usize, Rect)>,
+    pub summary_refresh_button: Option<Rect>,
     pub pane_settings_button: Option<Rect>,
     pub pane_settings_rename_button: Option<Rect>,
     pub pane_settings_reload_button: Option<Rect>,
@@ -141,6 +142,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     let grid_resizer = app.grid_resizer();
     let image_overlay = app.image_overlay_view();
     let assistant_view = app.workspace_assistant_view();
+    let adopt_terminal_view = app.adopt_terminal_view();
     let quit_confirmation = app.quit_confirmation_view();
     let close_grid_confirmation = app.close_grid_confirmation_view();
     let help_open = app.help_open();
@@ -248,6 +250,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
 
     let status_buttons = render_status_bar(frame, status_area, &StatusBar::from_app(app), palette);
     let previous_panes_button = status_buttons.previous_panes;
+    let summary_refresh_button = status_buttons.summary_refresh;
     let pane_settings_button = status_buttons.pane_settings;
     let background_jobs_button = status_buttons.background_jobs;
     let ports_button = status_buttons.ports;
@@ -286,6 +289,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
     if let Some(rename) = tab_rename_view.as_ref() {
         render_rename_tab(frame, area, rename);
     }
+    if let Some(adopt) = adopt_terminal_view.as_ref() {
+        render_adopt_terminal(frame, area, adopt, palette);
+    }
     if let Some(image) = image_overlay {
         render_image_overlay(frame, area, image);
     }
@@ -314,6 +320,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) -> DrawState {
         tab_rects,
         previous_panes_button,
         previous_pane_rows,
+        summary_refresh_button,
         pane_settings_button,
         pane_settings_rename_button,
         pane_settings_reload_button,
@@ -1067,6 +1074,7 @@ struct StatusButtons {
     pane_settings: Option<Rect>,
     background_jobs: Option<Rect>,
     ports: Option<Rect>,
+    summary_refresh: Option<Rect>,
 }
 
 /// Everything the status bar draws, with nothing left to look up.
@@ -1284,25 +1292,51 @@ fn render_status_bar(
         area.x.saturating_add(left_width),
         buttons.ports.map_or(area.right(), |chip| chip.x),
     ) {
-        let line = if !view.status.is_empty() {
+        // The refresh control is only offered alongside the summary it refreshes,
+        // never over a status message that is about to disappear.
+        let clock = if view.status.is_empty() && view.pane.refreshable {
+            summary_clock_spans(&view.pane)
+        } else {
+            Vec::new()
+        };
+        let clock_width = u16::try_from(clock.iter().map(Span::width).sum::<usize>())
+            .unwrap_or(u16::MAX)
+            .min(room);
+        let text_room = room.saturating_sub(clock_width) as usize;
+
+        let mut spans = if !view.status.is_empty() {
             // Status messages are sentences and routinely outrun the bar.
             // Trimming ends them in an ellipsis rather than mid-word, so a cut
             // message reads as cut rather than as a typo.
-            Line::from(Span::styled(
-                truncate_text(&view.status, room as usize),
+            vec![Span::styled(
+                truncate_text(&view.status, text_room),
                 Style::default().fg(TEXT),
-            ))
+            )]
         } else {
-            pane_summary_line(&view.pane, room as usize)
+            pane_summary_line(&view.pane, text_room).spans
         };
-        let width = u16::try_from(line.width()).unwrap_or(u16::MAX).min(room);
+        let text_width = u16::try_from(spans.iter().map(Span::width).sum::<usize>())
+            .unwrap_or(u16::MAX)
+            .min(room);
+        // A clock with nothing in front of it is a countdown to nothing.
+        let clock_width = if text_width > 0 { clock_width } else { 0 };
+        if clock_width > 0 {
+            spans.extend(clock);
+        }
+
+        let width = text_width.saturating_add(clock_width).min(room);
         if width > 0 {
             let centred = area.x + area.width.saturating_sub(width) / 2;
             let x = centred.clamp(start, start + room - width);
             frame.render_widget(
-                Paragraph::new(line).style(Style::default().bg(SURFACE)),
+                Paragraph::new(Line::from(spans)).style(Style::default().bg(SURFACE)),
                 Rect::new(x, area.y, width, 1),
             );
+            // The whole clock is the click target, not just the glyph on the end
+            // of it: one cell is a hard thing to hit, and a font that renders the
+            // glyph badly would otherwise leave nothing to aim at.
+            buttons.summary_refresh =
+                (clock_width > 0).then(|| Rect::new(x + text_width, area.y, clock_width, 1));
         }
     }
 
@@ -1328,6 +1362,9 @@ const STATUS_CENTRE_MARGIN: u16 = 2;
 /// better off leaving the space blank.
 const STATUS_CENTRE_MIN: u16 = 16;
 const SUMMARY_SEPARATOR: &str = " · ";
+/// The refresh control on the end of the countdown. Padded so it reads as a
+/// button rather than as punctuation.
+const SUMMARY_REFRESH_GLYPH: &str = " ⟳ ";
 
 /// The span of the bar the centre line may use: `(x, width)`, or nothing when
 /// the chips have eaten the middle.
@@ -1338,6 +1375,43 @@ fn status_centre_gap(area: Rect, left_end: u16, right_start: u16) -> Option<(u16
         .min(area.right());
     let room = end.checked_sub(start)?;
     (room >= STATUS_CENTRE_MIN).then_some((start, room))
+}
+
+/// The countdown on the focused pane's cached summary, and the control that
+/// skips it.
+///
+/// Summaries are cached for minutes at a time to keep the API bill down, which
+/// makes "how old is this" a fair question — so the bar answers it, and puts the
+/// way to get a fresh one right next to the answer.
+fn summary_clock_spans(pane: &FocusedPaneSummary) -> Vec<Span<'static>> {
+    let clock = if pane.refreshing {
+        "···".to_string()
+    } else {
+        match pane.refresh_in {
+            Some(left) => {
+                let seconds = left.as_secs();
+                format!("{}:{:02}", seconds / 60, seconds % 60)
+            }
+            None => "due".to_string(),
+        }
+    };
+
+    vec![
+        Span::styled(
+            format!("{SUMMARY_SEPARATOR}{clock}"),
+            Style::default().fg(TEXT_FAINT),
+        ),
+        Span::styled(
+            SUMMARY_REFRESH_GLYPH,
+            Style::default()
+                .fg(if pane.refreshing {
+                    TEXT_FAINT
+                } else {
+                    TEXT_DIM
+                })
+                .bg(SURFACE_HI),
+        ),
+    ]
 }
 
 /// `2 Fluent · running the failing test alone`, trimmed to fit.
@@ -2781,6 +2855,141 @@ fn background_jobs_command_bar(width: u16) -> Line<'static> {
         command_key("Esc"),
         Span::styled(" close", Style::default().fg(Color::Gray)),
     ])
+}
+
+/// The picker that re-roots a pane at an outside terminal's folder.
+///
+/// It is careful to promise only what it does. "Adopting" a window moves the
+/// pane to that window's folder; the window itself keeps its process and is left
+/// running, because a live console cannot be handed to another pseudoconsole.
+fn render_adopt_terminal(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    view: &AdoptTerminalView,
+    palette: &GridPalette,
+) {
+    let modal = previous_panes_modal_rect(area, view.rows.len().saturating_add(2));
+    let shadow = settings_shadow_rect(area, modal);
+    if shadow != modal {
+        frame.render_widget(Clear, shadow);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(SETTINGS_SHADOW)),
+            shadow,
+        );
+    }
+    frame.render_widget(Clear, modal);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(
+            Style::default()
+                .fg(palette.focus())
+                .add_modifier(Modifier::BOLD),
+        )
+        .style(settings_panel_style())
+        .title(" Adopt A Terminal ");
+    let inner = block.inner(modal);
+    frame.render_widget(block, modal);
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let budget = inner.width.saturating_sub(4) as usize;
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!("into pane {}", view.target_label),
+                    Style::default()
+                        .fg(palette.focus())
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    truncate_text(
+                        "opens a shell where the window is; the window keeps running",
+                        budget,
+                    ),
+                    Style::default().fg(SETTINGS_MUTED),
+                ),
+            ]),
+        ])
+        .style(settings_panel_style()),
+        chunks[0],
+    );
+
+    let rows = chunks[1];
+    let visible = rows.height as usize;
+    let first = view.cursor.saturating_sub(visible.saturating_sub(1));
+    let lines = view
+        .rows
+        .iter()
+        .enumerate()
+        .skip(first)
+        .take(visible)
+        .map(|(index, row)| {
+            let selected = index == view.cursor;
+            // A window whose title hides its folder is still listed, so the user
+            // is not left wondering why it is missing — it just cannot be picked.
+            let style = if !row.adoptable {
+                Style::default().fg(TEXT_FAINT)
+            } else if selected {
+                Style::default()
+                    .fg(INK)
+                    .bg(palette.focus())
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(SETTINGS_TEXT)
+            };
+            Line::from(vec![
+                Span::styled(if selected { " ▸ " } else { "   " }, style),
+                Span::styled(truncate_text(&row.label, budget.saturating_sub(10)), style),
+                Span::styled(
+                    format!("  pid {}", row.pid),
+                    if selected {
+                        style
+                    } else {
+                        Style::default().fg(SETTINGS_MUTED)
+                    },
+                ),
+            ])
+        })
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines).style(settings_panel_style()), rows);
+
+    let footer = if view.confirming {
+        Line::from(vec![
+            Span::styled(
+                "  replace this pane? ",
+                Style::default().fg(WAITING).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "its shell closes · Enter confirms · Esc goes back",
+                Style::default().fg(SETTINGS_MUTED),
+            ),
+        ])
+    } else {
+        Line::from(Span::styled(
+            "  ↑↓ choose · Enter adopts · Esc cancels",
+            Style::default().fg(SETTINGS_MUTED),
+        ))
+    };
+    frame.render_widget(
+        Paragraph::new(footer).style(settings_panel_style()),
+        chunks[2],
+    );
 }
 
 fn previous_panes_modal_rect(area: Rect, pane_count: usize) -> Rect {
@@ -4947,6 +5156,7 @@ fn set_terminal_cursor(frame: &mut Frame<'_>, area: Rect, screen: &vt100::Screen
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::AdoptTerminalRow;
     use crate::{
         cli::Cli,
         config::Config,
@@ -4954,6 +5164,7 @@ mod tests {
     };
     use clap::Parser;
     use ratatui::{Terminal, backend::TestBackend};
+    use std::time::Duration;
 
     /// One pane in a rendered preview of the shell.
     struct PreviewPane {
@@ -5086,6 +5297,9 @@ mod tests {
                         pane: FocusedPaneSummary {
                             title: "1 Frontend".into(),
                             detail: "wiring the checkout form to the new API".into(),
+                            refresh_in: Some(Duration::from_secs(134)),
+                            refreshable: true,
+                            ..FocusedPaneSummary::default()
                         },
                         ..StatusBar::default()
                     },
@@ -5372,6 +5586,9 @@ mod tests {
             pane: FocusedPaneSummary {
                 title: "2 Fluent".into(),
                 detail: "running the failing test alone".into(),
+                refresh_in: Some(Duration::from_secs(134)),
+                refreshable: true,
+                ..FocusedPaneSummary::default()
             },
             ..StatusBar::default()
         };
@@ -5383,11 +5600,13 @@ mod tests {
             .expect("render status bar");
 
         let rendered = buffer_text(&terminal);
-        let expected = "2 Fluent · running the failing test alone";
+        let expected = "2 Fluent · running the failing test alone · 2:14 ⟳";
         let start = rendered
             .find(expected)
             .map(|byte| rendered[..byte].chars().count())
             .unwrap_or_else(|| panic!("summary missing from the bar: {rendered}"));
+        // The clock is part of the centred block, so the whole run is what has
+        // to sit in the middle — not the sentence with the clock hanging off it.
         let middle = start + expected.chars().count() / 2;
         assert!(
             middle.abs_diff(60) <= 1,
@@ -5398,6 +5617,112 @@ mod tests {
         // every frame of every session.
         assert!(!rendered.contains("LIVE"), "bar: {rendered}");
         assert!(!rendered.contains("focused pane"), "bar: {rendered}");
+    }
+
+    /// The countdown says how stale the cached summary is, and the control next
+    /// to it is what skips the wait. Both have to be hittable with a mouse.
+    #[test]
+    fn the_refresh_control_is_clickable_and_reports_the_cache_age() {
+        let backend = TestBackend::new(120, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let view = StatusBar {
+            pane: FocusedPaneSummary {
+                title: "2 Fluent".into(),
+                detail: "running the failing test alone".into(),
+                refresh_in: Some(Duration::from_secs(134)),
+                refreshable: true,
+                ..FocusedPaneSummary::default()
+            },
+            ..StatusBar::default()
+        };
+
+        let mut buttons = StatusButtons::default();
+        terminal
+            .draw(|frame| {
+                buttons = render_status_bar(frame, frame.area(), &view, &GridPalette::default());
+            })
+            .expect("render status bar");
+
+        let buffer = terminal.backend().buffer().clone();
+        let button = buttons.summary_refresh.expect("refresh control");
+        let hit = (button.x..button.right())
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect::<String>();
+        assert_eq!(
+            hit, " · 2:14 ⟳ ",
+            "the whole clock must be the click target"
+        );
+
+        // Clock formats, including the two states that are not a countdown.
+        let spans = |pane: &FocusedPaneSummary| {
+            summary_clock_spans(pane)
+                .iter()
+                .map(|span| span.content.to_string())
+                .collect::<String>()
+        };
+        let base = FocusedPaneSummary {
+            refreshable: true,
+            ..FocusedPaneSummary::default()
+        };
+        assert_eq!(
+            spans(&FocusedPaneSummary {
+                refresh_in: Some(Duration::from_secs(7)),
+                ..base.clone()
+            }),
+            " · 0:07 ⟳ "
+        );
+        assert_eq!(spans(&base), " · due ⟳ ");
+        assert_eq!(
+            spans(&FocusedPaneSummary {
+                refreshing: true,
+                ..base.clone()
+            }),
+            " · ··· ⟳ "
+        );
+    }
+
+    /// Nothing to refresh, nothing to offer: a pane that cannot be summarized
+    /// must not grow a control that would only report an error when pressed.
+    #[test]
+    fn an_unrefreshable_pane_gets_no_clock() {
+        let backend = TestBackend::new(120, 1);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let off = StatusBar {
+            pane: FocusedPaneSummary {
+                title: "2 Fluent".into(),
+                detail: "turn on AI activity summaries in Settings > Manager".into(),
+                ..FocusedPaneSummary::default()
+            },
+            ..StatusBar::default()
+        };
+
+        let mut buttons = StatusButtons::default();
+        terminal
+            .draw(|frame| {
+                buttons = render_status_bar(frame, frame.area(), &off, &GridPalette::default());
+            })
+            .expect("render status bar");
+        assert_eq!(buttons.summary_refresh, None);
+        assert!(!buffer_text(&terminal).contains('⟳'));
+
+        // Nor while a status message has taken the centre away from it.
+        let busy = StatusBar {
+            status: "copied 3 lines".into(),
+            pane: FocusedPaneSummary {
+                title: "2 Fluent".into(),
+                detail: "running the failing test alone".into(),
+                refresh_in: Some(Duration::from_secs(134)),
+                refreshable: true,
+                ..FocusedPaneSummary::default()
+            },
+            ..StatusBar::default()
+        };
+        terminal
+            .draw(|frame| {
+                buttons = render_status_bar(frame, frame.area(), &busy, &GridPalette::default());
+            })
+            .expect("render status bar");
+        assert_eq!(buttons.summary_refresh, None);
     }
 
     /// A status message is the answer to something the user just did, so it
@@ -5411,6 +5736,9 @@ mod tests {
             pane: FocusedPaneSummary {
                 title: "2 Fluent".into(),
                 detail: "running the failing test alone".into(),
+                refresh_in: Some(Duration::from_secs(134)),
+                refreshable: true,
+                ..FocusedPaneSummary::default()
             },
             ..StatusBar::default()
         };
@@ -5433,6 +5761,7 @@ mod tests {
         let pane = FocusedPaneSummary {
             title: "2 Fluent".into(),
             detail: "running the failing test alone".into(),
+            ..FocusedPaneSummary::default()
         };
 
         let wide = pane_summary_line(&pane, 60);
@@ -5461,6 +5790,58 @@ mod tests {
         let (start, room) = status_centre_gap(Rect::new(0, 0, 120, 1), 34, 110).expect("gap");
         assert_eq!(start, 36);
         assert_eq!(start + room, 108);
+    }
+
+    /// The picker must say what it actually does. Adopting a window moves the
+    /// pane to that window's folder; the window keeps its process, because a
+    /// live console cannot be handed to another pseudoconsole.
+    #[test]
+    fn the_adopt_picker_names_the_target_and_asks_before_replacing() {
+        let view = AdoptTerminalView {
+            cursor: 1,
+            target_label: "2 Fluent".into(),
+            rows: vec![
+                AdoptTerminalRow {
+                    label: "MINGW64:~ - npm run dev".into(),
+                    pid: 41,
+                    adoptable: false,
+                },
+                AdoptTerminalRow {
+                    label: "C:\\repos\\api".into(),
+                    pid: 42,
+                    adoptable: true,
+                },
+            ],
+            confirming: false,
+        };
+
+        let render = |view: &AdoptTerminalView| {
+            let mut terminal = Terminal::new(TestBackend::new(90, 20)).expect("test terminal");
+            terminal
+                .draw(|frame| {
+                    render_adopt_terminal(frame, frame.area(), view, &GridPalette::default());
+                })
+                .expect("render adopt picker");
+            buffer_text(&terminal)
+        };
+
+        let listing = render(&view);
+        assert!(listing.contains("into pane 2 Fluent"), "{listing}");
+        assert!(listing.contains("C:\\repos\\api"), "{listing}");
+        assert!(listing.contains("pid 42"), "{listing}");
+        // A window whose folder could not be read is still listed rather than
+        // silently dropped, so its absence is never a mystery.
+        assert!(listing.contains("npm run dev"), "{listing}");
+        assert!(listing.contains("the window keeps running"), "{listing}");
+        assert!(!listing.contains("its shell closes"), "{listing}");
+
+        // Confirming is the second half of "ask first": it says what is lost.
+        let confirming = render(&AdoptTerminalView {
+            confirming: true,
+            ..view
+        });
+        assert!(confirming.contains("replace this pane?"), "{confirming}");
+        assert!(confirming.contains("its shell closes"), "{confirming}");
     }
 
     /// The hints exist to be discoverable, not to be load-bearing. A terminal


### PR DESCRIPTION
## Why

A friend on a Mac reported that none of the Alt shortcuts work. They can't: Apple Terminal, iTerm2, and Ghostty all map Option to character composition by default, so `Option+C` produces `ç` and crossterm never sees `ALT`. Every one of GridBash's shortcuts was unreachable on a stock macOS terminal, and the only fix on offer was a docs line telling users to turn on Option-as-Meta first.

## What

**A leader key.** Press it, release it, then press the shortcut key without Alt. `Ctrl+G` `c` opens the command center, `Ctrl+G` `←` moves focus, `Ctrl+G` `Shift+C` captures output, `Ctrl+G` `Ctrl+P` opens Ports, `Ctrl+G` `q` quits. Esc backs out; pressing the leader twice sends it to the focused pane, so no pane loses the key.

- Default `ctrl+g` on macOS, **off everywhere else** — Windows and Linux behavior is unchanged.
- Configurable: `[keys] leader = "ctrl+g"`, or `"off"`.
- Rejected at startup if it would shadow a bound shortcut.
- The status bar names the leader on launch on macOS, since nothing else would explain why the shortcuts appear dead.
- The launch wizard runs before the leader exists, so its one Alt binding (`Alt+W`, worktree override) also answers to `F2`.

**Recovery moved behind `--recover`.** A bare `gridbash` used to adopt the workspaces of a GridBash that died, so one crash made every later launch reopen the same session. A plain launch now starts fresh and counts what is still recoverable, within a 24h window, so the notice doesn't only ever count upwards.

**Summary freshness.** Summaries are cached for minutes at a time to keep the API bill down, so the focused pane's summary carries a countdown and the control that refreshes it.

**Adopt an outside terminal.** `Ctrl+Alt+T` lists the shell windows already open on the desktop and re-roots a pane at the folder one is sitting in. The window keeps its process — a live console cannot be handed to another pseudoconsole — and is left running. Windows-only; says so on other platforms rather than reporting an empty list.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and 434 tests pass on Windows, plus the npm launcher and version suites. macOS and Linux are proven by this PR's CI — I have no darwin toolchain locally.

One bug this fixes on the way: `adopt.rs` built its Windows paths with `PathBuf::push`, which appends the *host's* separator (`C:\` + `src` → `C:\/src` on Unix). Its tests would have failed `cargo test` on the macOS and Linux runners, which blocks the release job.